### PR TITLE
Build firmware with gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build ESPHome firmware
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-firmware:
+    name: Build Firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - name: Build Firmware
+        uses: esphome/build-action@v3.2.0
+        id: esphome-build
+        with:
+          yaml_file: voice-kit.yaml
+          version: latest
+          cache: true
+      - name: Move generated files to output
+        run: |
+          mkdir -p output
+          mv ${{ steps.esphome-build.outputs.name }}/*.bin output/
+          jq --arg version "${{ steps.esphome-build.outputs.project-version }}" \
+            '{"name": "ESPHome Voice Kit", "version": $version, "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":[.]}' \
+            ${{ steps.esphome-build.outputs.name }}/manifest.json > output/manifest.json
+
+      - name: Upload firmware
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          path: output
+          name: voice-kit
+
+  build-pages:
+    name: Build pages
+    runs-on: ubuntu-latest
+    needs:
+      - build-firmware
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: voice-kit
+          path: output
+      - run: cp -R static/* output/
+      - uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: output
+          retention-days: 1
+
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-pages
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5.0.0
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           mkdir -p output
           mv ${{ steps.esphome-build.outputs.name }} output/
           jq --arg version "${{ steps.esphome-build.outputs.project-version }}" \
-            '{"name": "ESPHome Voice Kit", "version": $version, "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":[.]}' \
+            '{"name": "ESPHome Voice Kit", "version": $version, "home_assistant_domain": "esphome", "new_install_prompt_erase": false, "builds":[.]}' \
             output/${{ steps.esphome-build.outputs.name }}/manifest.json > output/manifest.json
 
       - name: Upload firmware

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build ESPHome firmware
 on:
   push:
     branches:
-      - main
+      - dev
   pull_request:
   workflow_dispatch:
 
@@ -52,7 +52,8 @@ jobs:
           retention-days: 1
 
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    # TODO: Change this to `release` later.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: build-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Move generated files to output
         run: |
           mkdir -p output
-          mv ${{ steps.esphome-build.outputs.name }}/*.bin output/
+          mv ${{ steps.esphome-build.outputs.name }} output/
           jq --arg version "${{ steps.esphome-build.outputs.project-version }}" \
             '{"name": "ESPHome Voice Kit", "version": $version, "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":[.]}' \
-            ${{ steps.esphome-build.outputs.name }}/manifest.json > output/manifest.json
+            output/${{ steps.esphome-build.outputs.name }}/manifest.json > output/manifest.json
 
       - name: Upload firmware
         uses: actions/upload-artifact@v4.3.4

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,12 @@
+<html>
+
+<head>
+  <title>ESPHome Voice Kit</title>
+</head>
+
+<body>
+  <esp-web-install-button manifest="./manifest.json"></esp-web-install-button>
+</body>
+<script type="module" src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"></script>
+
+</html>


### PR DESCRIPTION
This will deploy the firmware to https://esphome.github.io/voice-kit where there is a minimal esp-web-tools button to install.

If the firmware is set up with OTA then the files will also be ready to use.

```yaml

http_request:

ota:
  - platform: esphome
    id: ota_esphome
  - platform: http_request
    id: ota_http_request

update:
  - platform: http_request
    id: update_http_request
    name: Firmware
    source: https://esphome.github.io/voice-kit/manifest.json
```