### PR TITLE
Potential Volume Fixes and on_pause condition

### DIFF
--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -77,6 +77,7 @@ AnnoucementTrigger = media_player_ns.class_(
     "AnnouncementTrigger", automation.Trigger.template()
 )
 IsIdleCondition = media_player_ns.class_("IsIdleCondition", automation.Condition)
+IsPausedCondition = media_player_ns.class_("IsPausedCondition", automation.Condition)
 IsPlayingCondition = media_player_ns.class_("IsPlayingCondition", automation.Condition)
 
 
@@ -192,6 +193,9 @@ async def media_player_play_media_action(config, action_id, template_arg, args):
 )
 @automation.register_condition(
     "media_player.is_idle", IsIdleCondition, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_condition(
+    "media_player.is_paused", IsPausedCondition, MEDIA_PLAYER_ACTION_SCHEMA
 )
 @automation.register_condition(
     "media_player.is_playing", IsPlayingCondition, MEDIA_PLAYER_ACTION_SCHEMA

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -69,5 +69,10 @@ template<typename... Ts> class IsPlayingCondition : public Condition<Ts...>, pub
   bool check(Ts... x) override { return this->parent_->state == MediaPlayerState::MEDIA_PLAYER_STATE_PLAYING; }
 };
 
+template<typename... Ts> class IsPausedCondition : public Condition<Ts...>, public Parented<MediaPlayer> {
+ public:
+  bool check(Ts... x) override { return this->parent_->state == MediaPlayerState::MEDIA_PLAYER_STATE_PAUSED; }
+};
+
 }  // namespace media_player
 }  // namespace esphome

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -37,6 +37,10 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
       return "UNMUTE";
     case MEDIA_PLAYER_COMMAND_TOGGLE:
       return "TOGGLE";
+    case MEDIA_PLAYER_COMMAND_VOLUME_UP:
+      return "VOLUME_UP";
+    case MEDIA_PLAYER_COMMAND_VOLUME_DOWN:
+      return "VOLUME_DOWN";
     default:
       return "UNKNOWN";
   }

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -717,13 +717,17 @@ void NabuMediaPlayer::control(const media_player::MediaPlayerCall &call) {
 
   if (call.get_volume().has_value()) {
     media_command.volume = call.get_volume().value();
-    xQueueSend(this->media_control_command_queue_, &media_command, portMAX_DELAY);
+    xQueueSend(this->media_control_command_queue_, &media_command, 0);    // Wait 0 ticks for queue to be free, volume sets aren't that important!
     return;
   }
 
   if (call.get_command().has_value()) {
     media_command.command = call.get_command().value();
-    xQueueSend(this->media_control_command_queue_, &media_command, portMAX_DELAY);
+    TickType_t ticks_to_wait = portMAX_DELAY;
+    if ((call.get_command().value() == media_player::MEDIA_PLAYER_COMMAND_VOLUME_UP) || (call.get_command().value() == media_player::MEDIA_PLAYER_COMMAND_VOLUME_DOWN)) {
+      ticks_to_wait = 0;  // Wait 0 ticks for queue to be free, volume sets aren't that important!
+    }
+    xQueueSend(this->media_control_command_queue_, &media_command, ticks_to_wait);
     return;
   }
 }


### PR DESCRIPTION
Adds an ``is_paused`` condition for media players.
Properly logs volume change commands instead of saying unknown command.
Don't wait for space in the media player command queue for volume change commands to hopefully eliminate crashes when the wheel is spun fast.