### PR TITLE
Use new shared workflow to publish firmware to Cloudflare R2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       name: voice-kit
       esphome-version: 2024.7.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
-      release-url: ${{ github.event_name == 'release' && github.event.release.url || '' }}
+      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       upload: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build ESPHome firmware
+name: Build
 
 on:
   push:
@@ -16,12 +16,14 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@jesserockz-2024-326
+    uses: esphome/workflows/.github/workflows/build.yml@main
     with:
       files: |
         voice-kit.yaml
-      name: ESPHome Voice Kit
+      name: voice-kit
       esphome-version: 2024.7.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.url || '' }}
-      upload: ${{ github.event_name == 'release' }}
+      upload: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') }}
+      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - dev
   pull_request:
   workflow_dispatch:
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -23,81 +25,12 @@ jobs:
 
   build-firmware:
     name: Build Firmware
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.7
-      - name: Build Firmware
-        uses: esphome/build-action@v3.2.0
-        id: esphome-build
-        with:
-          yaml_file: voice-kit.yaml
-          version: latest
-          cache: true
-      - name: Move generated files to output
-        run: |
-          mkdir -p output
-          mv ${{ steps.esphome-build.outputs.name }} output/
-          jq --arg version "${{ steps.esphome-build.outputs.project-version }}" \
-            '{"name": "ESPHome Voice Kit", "version": $version, "home_assistant_domain": "esphome", "new_install_prompt_erase": false, "builds":[.]}' \
-            output/${{ steps.esphome-build.outputs.name }}/manifest.json > output/manifest.json
-
-      - name: Upload firmware
-        id: upload-artifact
-        uses: actions/upload-artifact@v4.3.4
-        with:
-          path: output
-          name: voice-kit
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7.0.1
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Firmware built successfully! :tada:
-
-            [Download][download] and extract the firmware to install with https://web.esphome.io
-
-            Make sure to choose \`esphome-voice-kit-esp32s3/esphome-voice-kit-esp32s3.factory.bin\`.
-
-            [download]: ${{ steps.upload-artifact.outputs.artifact-url }}`
-            })
-
-  build-pages:
-    name: Build pages
-    runs-on: ubuntu-latest
-    needs:
-      - build-firmware
-    steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/download-artifact@v4.1.8
-        with:
-          name: voice-kit
-          path: output
-      - run: cp -R static/* output/
-      - uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: output
-          retention-days: 1
-
-  deploy:
-    # TODO: Change this to `release` later.
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build-pages
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4.0.5
+    uses: esphome/workflows/.github/workflows/build.yml@jesserockz-2024-326
+    with:
+      files: |
+        voice-kit.yml
+      name: ESPHome Voice Kit
+      esphome-version: 2024.7.3
+      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
+      release-url: ${{ github.event_name == 'release' && github.event.release.url || '' }}
+      upload: ${{ github.event_name == 'release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  yamllint:
-    name: 🧹 yamllint
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out configuration from GitHub
-        uses: actions/checkout@v4.1.7
-      - name: 🚀 Run yamllint
-        run: yamllint --strict .
-
   build-firmware:
     name: Build Firmware
     uses: esphome/workflows/.github/workflows/build.yml@jesserockz-2024-326

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@jesserockz-2024-326
     with:
       files: |
-        voice-kit.yml
+        voice-kit.yaml
       name: ESPHome Voice Kit
       esphome-version: 2024.7.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,22 @@
+name: YAML lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.yaml"
+      - "**.yml"
+  pull_request:
+    paths:
+      - "**.yaml"
+      - "**.yml"
+
+jobs:
+  yamllint:
+    name: 🧹 yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out configuration from GitHub
+        uses: actions/checkout@v4.1.7
+      - name: 🚀 Run yamllint
+        run: yamllint --strict .

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -23,7 +23,7 @@ esphome:
     board_build.flash_mode: dio
   project:
     name: esphome.voice-kit
-    version: "1.0"
+    version: dev
   on_boot:
     priority: 600
     then:


### PR DESCRIPTION
Moving to a new shared workflow that keeps all of the firmware building and uploading logic in a single place and keeps consistency across our firmware repositories.

The manifests and binaries will be stored in a Cloudflare R2 Bucket which will be referenced by the `firmware.esphome.io` domain once the other firmwares have all be set up as well.

To release a new version of firmware to "production", a GitHub release needs to be made with the desired version. The workflow will rewrite the `project_version` value in YAML before compiling with this version.