### PR TITLE
Microphone and mWW Improvements

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -12,13 +12,10 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const size_t SAMPLE_RATE_HZ = 16000;   // 16 kHz
 static const size_t RING_BUFFER_LENGTH = 64;  // 0.064 seconds
-static const size_t RING_BUFFER_SIZE = SAMPLE_RATE_HZ / 1000 * RING_BUFFER_LENGTH;
-static const size_t BUFFER_SIZE = 512;
-static const size_t BUFFER_COUNT = 10;
+static const size_t QUEUE_LENGTH = 10;
 
-static const size_t DMA_BUF_COUNT = 10;
+static const size_t DMA_BUF_COUNT = 4;
 static const size_t DMA_BUF_LEN = 512;
 static const size_t DMA_SAMPLES = DMA_BUF_COUNT * DMA_BUF_LEN * 2;  // left and right channels
 
@@ -27,6 +24,11 @@ static const size_t DMA_SAMPLES = DMA_BUF_COUNT * DMA_BUF_LEN * 2;  // left and 
 //   - Determine appropriate timeout durations for FreeRTOS operations
 
 static const char *const TAG = "i2s_audio.microphone";
+
+enum TaskNotificationBits : uint32_t {
+  COMMAND_START = (1 << 0),  // Starts the main task purpose
+  COMMAND_STOP = (1 << 1),   // stops the main task
+};
 
 void I2SAudioMicrophone::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2S Audio Microphone...");
@@ -47,19 +49,18 @@ void I2SAudioMicrophone::setup() {
     }
   }
 
-  this->command_queue_ = xQueueCreate(BUFFER_COUNT, sizeof(CommandEvent));
-  this->event_queue_ = xQueueCreate(BUFFER_COUNT, sizeof(TaskEvent));
+  this->event_queue_ = xQueueCreate(QUEUE_LENGTH, sizeof(TaskEvent));
 
-  size_t ring_buffer_size = RING_BUFFER_LENGTH * this->sample_rate_ / 1000 * sizeof(int16_t);
+  const size_t ring_buffer_size = RING_BUFFER_LENGTH * this->sample_rate_ / 1000 * sizeof(int16_t);
 
-  this->asr_ring_buffer_ = RingBuffer::create(RING_BUFFER_SIZE * sizeof(int16_t));
+  this->asr_ring_buffer_ = RingBuffer::create(ring_buffer_size);
   if (this->asr_ring_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate ASR ring buffer");
     this->mark_failed();
     return;
   }
 
-  this->comm_ring_buffer_ = RingBuffer::create(RING_BUFFER_SIZE * sizeof(int16_t));
+  this->comm_ring_buffer_ = RingBuffer::create(ring_buffer_size);
   if (this->comm_ring_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate COMM ring buffer");
     this->mark_failed();
@@ -67,44 +68,19 @@ void I2SAudioMicrophone::setup() {
   }
 }
 
-void I2SAudioMicrophone::read_task_(void *params) {
-  I2SAudioMicrophone *this_microphone = (I2SAudioMicrophone *) params;
-
-  TaskEvent event;
-  CommandEvent command_event;
-
-  event.type = TaskEventType::STARTING;
-  xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-  ExternalRAMAllocator<int32_t> allocator(ExternalRAMAllocator<int32_t>::ALLOW_FAILURE);
-  int32_t *buffer = allocator.allocate(DMA_SAMPLES);
-
-  if (buffer == nullptr) {
-    event.type = TaskEventType::WARNING;
-    event.err = ESP_ERR_NO_MEM;
-    xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-    event.type = TaskEventType::STOPPED;
-    event.err = ESP_OK;
-    xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-    while (true) {
-      delay(10);
-    }
-
-    return;
-  }
+esp_err_t I2SAudioMicrophone::start_i2s_driver_() {
+  esp_err_t err;
 
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (this_microphone->parent_->get_i2s_mode() | I2S_MODE_RX),
-      .sample_rate = this_microphone->sample_rate_,
-      .bits_per_sample = this_microphone->bits_per_sample_,
-      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // this_microphone->channel_,
+      .mode = (i2s_mode_t) (this->parent_->get_i2s_mode() | I2S_MODE_RX),
+      .sample_rate = this->sample_rate_,
+      .bits_per_sample = this->bits_per_sample_,
+      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // this->channel_,
       .communication_format = I2S_COMM_FORMAT_STAND_I2S,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
       .dma_buf_count = DMA_BUF_COUNT,
       .dma_buf_len = DMA_BUF_LEN,
-      .use_apll = this_microphone->use_apll_,
+      .use_apll = this->use_apll_,
       .tx_desc_auto_clear = false,
       .fixed_mclk = 0,
       .mclk_multiple = I2S_MCLK_MULTIPLE_256,
@@ -119,127 +95,133 @@ void I2SAudioMicrophone::read_task_(void *params) {
 #endif
   };
 
-  esp_err_t err;
-
 #if SOC_I2S_SUPPORTS_ADC
-  if (this_microphone->adc_) {
+  if (this->adc_) {
     config.mode = (i2s_mode_t) (config.mode | I2S_MODE_ADC_BUILT_IN);
-    i2s_driver_install(this_microphone->parent_->get_port(), &config, 0, nullptr);
+    i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
 
-    i2s_set_adc_mode(ADC_UNIT_1, this_microphone->adc_channel_);
-    i2s_adc_enable(this_microphone->parent_->get_port());
+    i2s_set_adc_mode(ADC_UNIT_1, this->adc_channel_);
+    i2s_adc_enable(this->parent_->get_port());
   } else
 #endif
   {
-    if (this_microphone->pdm_)
+    if (this->pdm_)
       config.mode = (i2s_mode_t) (config.mode | I2S_MODE_PDM);
 
-    err = i2s_driver_install(this_microphone->parent_->get_port(), &config, 0, nullptr);
+    err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
     if (err != ESP_OK) {
-      event.type = TaskEventType::WARNING;
-      event.err = err;
-      xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-      event.type = TaskEventType::STOPPED;
-      event.err = ESP_OK;
-      xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-      while (true) {
-        delay(10);
-      }
-
-      return;
+      return err;
     }
 
-    i2s_pin_config_t pin_config = this_microphone->parent_->get_pin_config();
-    pin_config.data_in_num = this_microphone->din_pin_;
+    i2s_pin_config_t pin_config = this->parent_->get_pin_config();
+    pin_config.data_in_num = this->din_pin_;
 
-    err = i2s_set_pin(this_microphone->parent_->get_port(), &pin_config);
+    err = i2s_set_pin(this->parent_->get_port(), &pin_config);
     if (err != ESP_OK) {
-      event.type = TaskEventType::WARNING;
-      event.err = err;
-      xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-      event.type = TaskEventType::STOPPED;
-      event.err = ESP_OK;
-      xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-      while (true) {
-        delay(10);
-      }
-
-      return;
+      return err;
     }
   }
 
-  event.type = TaskEventType::STARTED;
-  xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-  std::vector<int16_t, ExternalRAMAllocator<int16_t>> asr_samples;
-  std::vector<int16_t, ExternalRAMAllocator<int16_t>> comm_samples;
+  return ESP_OK;
+}
 
-  asr_samples.resize(DMA_SAMPLES);
-  comm_samples.resize(DMA_SAMPLES);
+void I2SAudioMicrophone::read_task_(void *params) {
+  I2SAudioMicrophone *this_microphone = (I2SAudioMicrophone *) params;
+  TaskEvent event;
+  esp_err_t err;
 
   while (true) {
-    if (xQueueReceive(this_microphone->command_queue_, &command_event, 0) == pdTRUE) {
-      if (command_event.stop) {
-        // Stop signal from main thread
-        break;
-      }
-    }
-    size_t bytes_read;
-    esp_err_t err = i2s_read(this_microphone->parent_->get_port(), buffer, DMA_SAMPLES * sizeof(int32_t), &bytes_read,
-                             (10 / portTICK_PERIOD_MS));
-    if (err != ESP_OK) {
-      event.type = TaskEventType::WARNING;
-      event.err = err;
+    uint32_t notification_bits = 0;
+    xTaskNotifyWait(pdTRUE,              // clear all bits at start of wait
+                    ULONG_MAX,           // clear all bits after waiting
+                    &notification_bits,  // notifcation value after wait is finished
+                    portMAX_DELAY);      // how long to wait
+
+    if (notification_bits & TaskNotificationBits::COMMAND_START) {
+      event.type = TaskEventType::STARTING;
       xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-    }
 
-    if (bytes_read > 0) {
-      // TODO: Handle 16 bits per sample, currently it won't allow that option at codegen stage
+      ExternalRAMAllocator<int32_t> allocator(ExternalRAMAllocator<int32_t>::ALLOW_FAILURE);
+      int32_t *buffer = allocator.allocate(DMA_SAMPLES);
 
-      // if (this_microphone->bits_per_sample_ == I2S_BITS_PER_SAMPLE_16BIT) {
-      //   this_microphone->output_ring_buffer_->write(buffer, bytes_read);
-      // } else if (this_microphone->bits_per_sample_ == I2S_BITS_PER_SAMPLE_32BIT) {
+      std::vector<int16_t, ExternalRAMAllocator<int16_t>> asr_samples;
+      std::vector<int16_t, ExternalRAMAllocator<int16_t>> comm_samples;
 
-      // At 48000 kHz, the current XMOS firmware is sending the same sample 3 times
-      const size_t sample_rate_factor = this_microphone->sample_rate_ / 16000;
+      asr_samples.reserve(DMA_SAMPLES);
+      comm_samples.reserve(DMA_SAMPLES);
 
-      size_t samples_read = (bytes_read / sizeof(int32_t)) / (sample_rate_factor);
-      size_t frames_read = samples_read / 2;  // Left and right channel samples combine into 1 frame
+      if ((buffer == nullptr) || (asr_samples.capacity() < DMA_SAMPLES) || (comm_samples.capacity() < DMA_SAMPLES)) {
+        event.type = TaskEventType::WARNING;
+        event.err = ESP_ERR_NO_MEM;
+        xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+      } else {
+        err = this_microphone->start_i2s_driver_();
+        if (err != ESP_OK) {
+          event.type = TaskEventType::WARNING;
+          event.err = err;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+        } else {
+          event.type = TaskEventType::STARTED;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
 
-      // asr_samples.resize(frames_read);
-      // comm_samples.resize(frames_read);
-      for (size_t i = 0; i < frames_read; i++) {
-        asr_samples[i] = buffer[2 * sample_rate_factor * i] >> 16;
-        comm_samples[i] = buffer[2 * sample_rate_factor * i + 1] >> 16;
-        // int32_t temp = reinterpret_cast<int32_t *>(buffer)[i] >> 16;    // We are amplifying by a factor of 4 by only
-        // shifting 14 bits... samples[i] = clamp<int16_t>(temp, INT16_MIN, INT16_MAX);
+          while (true) {
+            notification_bits = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(10));
+            if (notification_bits & TaskNotificationBits::COMMAND_STOP) {
+              break;
+            }
+
+            size_t bytes_read;
+            esp_err_t err = i2s_read(this_microphone->parent_->get_port(), buffer, DMA_SAMPLES * sizeof(int32_t),
+                                     &bytes_read, (10 / portTICK_PERIOD_MS));
+            if (err != ESP_OK) {
+              event.type = TaskEventType::WARNING;
+              event.err = err;
+              xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+            }
+
+            if (bytes_read > 0) {
+              // TODO: Handle 16 bits per sample, currently it won't allow that option at codegen stage
+
+              // if (this_microphone->bits_per_sample_ == I2S_BITS_PER_SAMPLE_16BIT) {
+              //   this_microphone->output_ring_buffer_->write(buffer, bytes_read);
+              // } else if (this_microphone->bits_per_sample_ == I2S_BITS_PER_SAMPLE_32BIT) {
+
+              // At 48000 kHz, the current XMOS firmware is sending the same sample 3 times
+              const size_t sample_rate_factor = this_microphone->sample_rate_ / 16000;
+
+              size_t samples_read = (bytes_read / sizeof(int32_t)) / (sample_rate_factor);
+              size_t frames_read = samples_read / 2;  // Left and right channel samples combine into 1 frame
+
+              for (size_t i = 0; i < frames_read; i++) {
+                asr_samples[i] = buffer[2 * sample_rate_factor * i] >> 16;
+                comm_samples[i] = buffer[2 * sample_rate_factor * i + 1] >> 16;
+              }
+              size_t bytes_to_write = frames_read * sizeof(int16_t);
+
+              this_microphone->asr_ring_buffer_->write((void *) asr_samples.data(), bytes_to_write);
+              this_microphone->comm_ring_buffer_->write((void *) comm_samples.data(), bytes_to_write);
+              // }
+            }
+
+            event.type = TaskEventType::RUNNING;
+            xQueueSend(this_microphone->event_queue_, &event, 0);
+          }
+
+          event.type = TaskEventType::STOPPING;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+
+          allocator.deallocate(buffer, DMA_SAMPLES);
+          i2s_stop(this_microphone->parent_->get_port());
+          i2s_driver_uninstall(this_microphone->parent_->get_port());
+
+          event.type = TaskEventType::STOPPED;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+        }
       }
-      size_t bytes_to_write = frames_read * sizeof(int16_t);
-
-      this_microphone->asr_ring_buffer_->write((void *) asr_samples.data(), bytes_to_write);
-      this_microphone->comm_ring_buffer_->write((void *) comm_samples.data(), bytes_to_write);
-      // }
     }
-
-    event.type = TaskEventType::RUNNING;
-    xQueueSend(this_microphone->event_queue_, &event, 0);
-  }
-
-  event.type = TaskEventType::STOPPING;
-  xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-  allocator.deallocate(buffer, DMA_SAMPLES);
-  i2s_stop(this_microphone->parent_->get_port());
-  i2s_driver_uninstall(this_microphone->parent_->get_port());
-
-  event.type = TaskEventType::STOPPED;
-  xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
-
-  while (true) {
-    delay(10);
+    event.type = TaskEventType::STOPPED;
+    event.err = ESP_OK;
+    xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
   }
 }
 
@@ -256,7 +238,10 @@ void I2SAudioMicrophone::start_() {
     return;
   }
 
-  xTaskCreate(I2SAudioMicrophone::read_task_, "microphone_task", 3584, (void *) this, 23, &this->read_task_handle_);
+  if (this->read_task_handle_ == nullptr) {
+    xTaskCreate(I2SAudioMicrophone::read_task_, "microphone_task", 3584, (void *) this, 23, &this->read_task_handle_);
+  }
+  xTaskNotify(this->read_task_handle_, TaskNotificationBits::COMMAND_START, eSetValueWithoutOverwrite);
 }
 
 void I2SAudioMicrophone::stop() {
@@ -270,9 +255,7 @@ void I2SAudioMicrophone::stop() {
 }
 
 void I2SAudioMicrophone::stop_() {
-  CommandEvent event;
-  event.stop = true;
-  xQueueSendToFront(this->command_queue_, &event, portMAX_DELAY);
+  xTaskNotify(this->read_task_handle_, TaskNotificationBits::COMMAND_STOP, eSetValueWithOverwrite);
 }
 
 size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
@@ -286,12 +269,14 @@ size_t I2SAudioMicrophone::read_secondary(int16_t *buf, size_t len) {
 }
 
 void I2SAudioMicrophone::read_() {
-  std::vector<int16_t, ExternalRAMAllocator<int16_t>> samples;
-  samples.resize(BUFFER_SIZE);
-  // TODO this probably isn't correct
-  size_t bytes_read = this->read(samples.data(), BUFFER_SIZE / sizeof(int16_t));
-  samples.resize(bytes_read / sizeof(int16_t));
-  // this->data_callbacks_.call(samples);
+  // TODO: Does anything acutally use the callbacks?
+
+  // std::vector<int16_t, ExternalRAMAllocator<int16_t>> samples;
+  // samples.resize(BUFFER_SIZE);
+  // // TODO this probably isn't correct
+  // size_t bytes_read = this->read(samples.data(), BUFFER_SIZE / sizeof(int16_t));
+  // samples.resize(bytes_read / sizeof(int16_t));
+  // // this->data_callbacks_.call(samples);
 }
 
 void I2SAudioMicrophone::loop() {
@@ -301,9 +286,9 @@ void I2SAudioMicrophone::loop() {
       this->start_();
       break;
     case microphone::STATE_RUNNING:
-      if (this->data_callbacks_.size() > 0) {
-        this->read_();
-      }
+      // if (this->data_callbacks_.size() > 0) {
+      //   this->read_();
+      // }
       break;
     case microphone::STATE_STOPPING:
       this->stop_();
@@ -333,14 +318,11 @@ void I2SAudioMicrophone::watch_() {
       case TaskEventType::STOPPED:
         this->state_ = microphone::STATE_STOPPED;
 
-        vTaskDelete(this->read_task_handle_);
-        this->read_task_handle_ = nullptr;
         this->parent_->unlock();
 
         this->asr_ring_buffer_->reset();
         this->comm_ring_buffer_->reset();
         xQueueReset(this->event_queue_);
-        xQueueReset(this->command_queue_);
 
         ESP_LOGD(TAG, "Stopped I2S Audio Microphone");
         break;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -29,7 +29,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   size_t read_secondary(int16_t *buf, size_t len) override;
 
 #if SOC_I2S_SUPPORTS_ADC
-      void set_adc_channel(adc1_channel_t channel) {
+  void set_adc_channel(adc1_channel_t channel) {
     this->adc_channel_ = channel;
     this->adc_ = true;
   }
@@ -44,9 +44,10 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   static void read_task_(void *params);
   void watch_();
 
+  esp_err_t start_i2s_driver_();
+
   TaskHandle_t read_task_handle_{nullptr};
   QueueHandle_t event_queue_;
-  QueueHandle_t command_queue_;
   std::unique_ptr<RingBuffer> asr_ring_buffer_;
   std::unique_ptr<RingBuffer> comm_ring_buffer_;
 

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -14,9 +14,6 @@
 namespace esphome {
 namespace i2s_audio {
 
-
-
-
 class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
   void setup() override;
@@ -29,9 +26,10 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
   size_t read(int16_t *buf, size_t len) override;
+  size_t read_secondary(int16_t *buf, size_t len) override;
 
 #if SOC_I2S_SUPPORTS_ADC
-  void set_adc_channel(adc1_channel_t channel) {
+      void set_adc_channel(adc1_channel_t channel) {
     this->adc_channel_ = channel;
     this->adc_ = true;
   }
@@ -49,7 +47,8 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   TaskHandle_t read_task_handle_{nullptr};
   QueueHandle_t event_queue_;
   QueueHandle_t command_queue_;
-  std::unique_ptr<RingBuffer> output_ring_buffer_;
+  std::unique_ptr<RingBuffer> asr_ring_buffer_;
+  std::unique_ptr<RingBuffer> comm_ring_buffer_;
 
   void start_();
   void stop_();

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -22,9 +22,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
 
   void loop() override;
 
-  void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
-  void set_pdm(bool pdm) { this->pdm_ = pdm; }
-
   size_t read(int16_t *buf, size_t len) override;
   size_t read_secondary(int16_t *buf, size_t len) override;
 
@@ -40,31 +37,31 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
   void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
 
- protected:
-  static void read_task_(void *params);
-  void watch_();
+  void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
+  void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
+ protected:
   esp_err_t start_i2s_driver_();
+
+  static void read_task_(void *params);
 
   TaskHandle_t read_task_handle_{nullptr};
   QueueHandle_t event_queue_;
   std::unique_ptr<RingBuffer> asr_ring_buffer_;
   std::unique_ptr<RingBuffer> comm_ring_buffer_;
 
-  void start_();
-  void stop_();
-  void read_();
-
-  int8_t din_pin_{I2S_PIN_NO_CHANGE};
-#if SOC_I2S_SUPPORTS_ADC
-  adc1_channel_t adc_channel_{ADC1_CHANNEL_MAX};
-  bool adc_{false};
-#endif
+  bool use_apll_;
   bool pdm_{false};
+  int8_t din_pin_{I2S_PIN_NO_CHANGE};
+
+#if SOC_I2S_SUPPORTS_ADC
+  bool adc_{false};
+  adc1_channel_t adc_channel_{ADC1_CHANNEL_MAX};
+#endif
+
+  i2s_bits_per_sample_t bits_per_sample_;
   i2s_channel_fmt_t channel_;
   uint32_t sample_rate_;
-  i2s_bits_per_sample_t bits_per_sample_;
-  bool use_apll_;
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -25,6 +25,8 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   size_t read(int16_t *buf, size_t len) override;
   size_t read_secondary(int16_t *buf, size_t len) override;
 
+  size_t available_secondary() override { return this->comm_ring_buffer_->available(); }
+
 #if SOC_I2S_SUPPORTS_ADC
   void set_adc_channel(adc1_channel_t channel) {
     this->adc_channel_ = channel;

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -476,6 +476,8 @@ async def to_code(config):
         probability_cutoff = model_parameters.get(
             CONF_PROBABILITY_CUTOFF, manifest[KEY_MICRO][CONF_PROBABILITY_CUTOFF]
         )
+        quantized_probability_cutoff = int(probability_cutoff * 255)
+
         sliding_window_size = model_parameters.get(
             CONF_SLIDING_WINDOW_SIZE,
             manifest[KEY_MICRO][CONF_SLIDING_WINDOW_SIZE],
@@ -485,7 +487,7 @@ async def to_code(config):
             cg.add(
                 var.add_vad_model(
                     prog_arr,
-                    probability_cutoff,
+                    quantized_probability_cutoff,
                     sliding_window_size,
                     manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
                 )
@@ -494,7 +496,7 @@ async def to_code(config):
             cg.add(
                 var.add_wake_word_model(
                     prog_arr,
-                    probability_cutoff,
+                    quantized_probability_cutoff,
                     sliding_window_size,
                     manifest[KEY_WAKE_WORD],
                     manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
@@ -502,7 +504,11 @@ async def to_code(config):
             )
 
     cg.add(var.set_features_step_size(manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]))
-    cg.add_library(None,None,"https://github.com/kahrendt/ESPMicroSpeechFeatures.git#psram-allocations")
+    cg.add_library(
+        None,
+        None,
+        "https://github.com/kahrendt/ESPMicroSpeechFeatures.git#psram-allocations",
+    )
     # cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.0.0")
 
 

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -30,7 +30,11 @@ static const char *const TAG = "micro_wake_word";
 static const size_t SAMPLE_RATE_HZ = 16000;  // 16 kHz
 static const size_t BUFFER_LENGTH = 64;      // 0.064 seconds
 static const size_t BUFFER_SIZE = SAMPLE_RATE_HZ / 1000 * BUFFER_LENGTH;
-static const size_t INPUT_BUFFER_SIZE = 32 * SAMPLE_RATE_HZ / 1000;  // 16ms * 16kHz / 1000ms
+
+enum TaskNotificationBits : uint32_t {
+  COMMAND_START = (1 << 0),  // Starts the main task purpose
+  COMMAND_STOP = (1 << 1),   // stops the main task
+};
 
 float MicroWakeWord::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 
@@ -72,8 +76,6 @@ void MicroWakeWord::setup() {
     return;
   }
 
-  ESP_LOGCONFIG(TAG, "Micro Wake Word initialized");
-
   this->frontend_config_.window.size_ms = FEATURE_DURATION_MS;
   this->frontend_config_.window.step_size_ms = this->features_step_size_;
   this->frontend_config_.filterbank.num_channels = PREPROCESSOR_FEATURE_SIZE;
@@ -89,6 +91,151 @@ void MicroWakeWord::setup() {
   this->frontend_config_.pcan_gain_control.gain_bits = 21;
   this->frontend_config_.log_scale.enable_log = 1;
   this->frontend_config_.log_scale.scale_shift = 6;
+
+  ExternalRAMAllocator<StackType_t> allocator(ExternalRAMAllocator<StackType_t>::ALLOW_FAILURE);
+
+  this->preprocessor_task_stack_buffer_ = allocator.allocate(8192);
+  this->inference_task_stack_buffer_ = allocator.allocate(8192);
+
+  ESP_LOGCONFIG(TAG, "Micro Wake Word initialized");
+}
+
+void MicroWakeWord::preprocessor_task_(void *params) {
+  MicroWakeWord *this_mww = (MicroWakeWord *) params;
+
+  while (true) {
+    uint32_t notification_bits = 0;
+    xTaskNotifyWait(ULONG_MAX,           // clear all bits at start of wait
+                    ULONG_MAX,           // clear all bits after waiting
+                    &notification_bits,  // notifcation value after wait is finished
+                    portMAX_DELAY);      // how long to wait
+
+    if (notification_bits & TaskNotificationBits::COMMAND_START) {
+      // Setup preprocesor feature generator
+      if (!FrontendPopulateState(&this_mww->frontend_config_, &this_mww->frontend_state_, AUDIO_SAMPLE_FREQUENCY)) {
+        // TODO: Handle failure
+        FrontendFreeStateContents(&this_mww->frontend_state_);
+        continue;
+      }
+
+      const size_t new_samples_to_read = this_mww->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000);
+
+      ExternalRAMAllocator<int8_t> int8_allocator(ExternalRAMAllocator<int8_t>::ALLOW_FAILURE);
+      ExternalRAMAllocator<int16_t> int16_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
+
+      int8_t *features_buffer = int8_allocator.allocate(PREPROCESSOR_FEATURE_SIZE);
+      int16_t *audio_buffer = int16_allocator.allocate(new_samples_to_read);
+
+      if ((audio_buffer == nullptr) || (features_buffer == nullptr)) {
+        // TODO: Handle buffer allocation failure
+        continue;
+      }
+
+      if (this_mww->features_ring_buffer_ == nullptr) {
+        this_mww->features_ring_buffer_ = RingBuffer::create(PREPROCESSOR_FEATURE_SIZE * 10);  // TODO: Tweak this
+        if (this_mww->features_ring_buffer_ == nullptr) {
+          // TODO: Handle failure
+          continue;
+        }
+      }
+
+      if (this_mww->microphone_->is_stopped()) {
+        this_mww->microphone_->start();
+      }
+
+      while (true) {
+        notification_bits = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5));
+        if (notification_bits & TaskNotificationBits::COMMAND_STOP) {
+          break;
+        }
+
+        while (this_mww->microphone_->available_secondary() / sizeof(int16_t) >= new_samples_to_read) {
+          size_t bytes_read =
+              this_mww->microphone_->read_secondary(audio_buffer, new_samples_to_read * sizeof(int16_t));
+          if (bytes_read < new_samples_to_read * sizeof(int16_t)) {
+            // TODO: Handle not enough samples read
+            continue;
+          }
+
+          size_t num_samples_processed;
+          struct FrontendOutput frontend_output = FrontendProcessSamples(&this_mww->frontend_state_, audio_buffer,
+                                                                         new_samples_to_read, &num_samples_processed);
+
+          for (size_t i = 0; i < frontend_output.size; ++i) {
+            // These scaling values are set to match the TFLite audio frontend int8 output.
+            // The feature pipeline outputs 16-bit signed integers in roughly a 0 to 670
+            // range. In training, these are then arbitrarily divided by 25.6 to get
+            // float values in the rough range of 0.0 to 26.0. This scaling is performed
+            // for historical reasons, to match up with the output of other feature
+            // generators.
+            // The process is then further complicated when we quantize the model. This
+            // means we have to scale the 0.0 to 26.0 real values to the -128 to 127
+            // signed integer numbers.
+            // All this means that to get matching values from our integer feature
+            // output into the tensor input, we have to perform:
+            // input = (((feature / 25.6) / 26.0) * 256) - 128
+            // To simplify this and perform it in 32-bit integer math, we rearrange to:
+            // input = (feature * 256) / (25.6 * 26.0) - 128
+            constexpr int32_t value_scale = 256;
+            constexpr int32_t value_div = 666;  // 666 = 25.6 * 26.0 after rounding
+            int32_t value = ((frontend_output.values[i] * value_scale) + (value_div / 2)) / value_div;
+            value -= 128;
+            if (value < -128) {
+              value = -128;
+            }
+            if (value > 127) {
+              value = 127;
+            }
+            features_buffer[i] = value;
+          }
+
+          this_mww->features_ring_buffer_->write((void *) features_buffer, PREPROCESSOR_FEATURE_SIZE);
+        }
+      }
+
+      FrontendFreeStateContents(&this_mww->frontend_state_);
+      int8_allocator.deallocate(features_buffer, PREPROCESSOR_FEATURE_SIZE);
+      int16_allocator.deallocate(audio_buffer, new_samples_to_read);
+    }
+  }
+}
+
+void MicroWakeWord::inference_task_(void *params) {
+  MicroWakeWord *this_mww = (MicroWakeWord *) params;
+
+  while (true) {
+    uint32_t notification_bits = 0;
+    xTaskNotifyWait(ULONG_MAX,           // clear all bits at start of wait
+                    ULONG_MAX,           // clear all bits after waiting
+                    &notification_bits,  // notifcation value after wait is finished
+                    portMAX_DELAY);      // how long to wait
+
+    if (notification_bits & TaskNotificationBits::COMMAND_START) {
+      if (!this_mww->load_models_()) {
+        // TODO: Handle failure
+        continue;
+      }
+
+      while (true) {
+        notification_bits = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(10));
+        if (notification_bits & TaskNotificationBits::COMMAND_STOP) {
+          break;
+        }
+
+        while (this_mww->features_ring_buffer_->available() > PREPROCESSOR_FEATURE_SIZE) {
+          this_mww->update_model_probabilities_();
+
+          // TODO: Use a queue to send this information
+          if (this_mww->detect_wake_words_()) {
+            this_mww->detected_ = true;
+            this_mww->reset_states_();  // Do we really want to reset all states?
+          }
+        }
+      }
+
+      this_mww->unload_models_();
+    }
+  }
 }
 
 void MicroWakeWord::add_wake_word_model(const uint8_t *model_start, float probability_cutoff,
@@ -111,43 +258,47 @@ void MicroWakeWord::loop() {
       break;
     case State::START_MICROPHONE:
       ESP_LOGD(TAG, "Starting Microphone");
-      this->microphone_->start();
+
+      if (this->preprocessor_task_handle_ == nullptr) {
+        this->preprocessor_task_handle_ =
+            xTaskCreateStatic(MicroWakeWord::preprocessor_task_, "preprocessor", 8192, (void *) this, 10,
+                              this->preprocessor_task_stack_buffer_, &this->preprocessor_task_stack_);
+      }
+      // TODO: Should we overwrite? If stop and start are called in quick succession, what behavior do we want
+      xTaskNotify(this->preprocessor_task_handle_, TaskNotificationBits::COMMAND_START, eSetValueWithoutOverwrite);
+
       this->set_state_(State::STARTING_MICROPHONE);
-      // this->high_freq_.start();
       break;
     case State::STARTING_MICROPHONE:
       if (this->microphone_->is_running()) {
         this->set_state_(State::DETECTING_WAKE_WORD);
+
+        if (this->inference_task_handle_ == nullptr) {
+          this->inference_task_handle_ =
+              xTaskCreateStatic(MicroWakeWord::inference_task_, "inference", 8192, (void *) this, 5,
+                                this->inference_task_stack_buffer_, &this->inference_task_stack_);
+        }
+        // TODO: Should we overwrite? If stop and start are called in quick succession, what behavior do we want
+        xTaskNotify(this->inference_task_handle_, TaskNotificationBits::COMMAND_START, eSetValueWithoutOverwrite);
       }
       break;
     case State::DETECTING_WAKE_WORD:
-      // while (!this->has_enough_samples_()) {
-        this->read_microphone_();
-      // }
-      this->update_model_probabilities_();
-      if (this->detect_wake_words_()) {
-        ESP_LOGD(TAG, "Wake Word '%s' Detected", (this->detected_wake_word_).c_str());
-        this->detected_ = true;
-        this->set_state_(State::STOP_MICROPHONE);
+      if (this->detected_) {
+        if (this->detected_) {
+          this->wake_word_detected_trigger_->trigger(this->detected_wake_word_);
+          this->detected_ = false;
+          this->detected_wake_word_ = "";
+        }
       }
       break;
     case State::STOP_MICROPHONE:
-      ESP_LOGD(TAG, "Stopping Microphone");
-      // this->microphone_->stop();
+      xTaskNotify(this->preprocessor_task_handle_, TaskNotificationBits::COMMAND_STOP, eSetValueWithOverwrite);
+      xTaskNotify(this->inference_task_handle_, TaskNotificationBits::COMMAND_STOP, eSetValueWithOverwrite);
+      ESP_LOGD(TAG, "Stopping microWakeWord");
       this->set_state_(State::STOPPING_MICROPHONE);
-      // this->high_freq_.stop();
-      this->unload_models_();
-      this->deallocate_buffers_();
       break;
     case State::STOPPING_MICROPHONE:
-      // if (this->microphone_->is_stopped()) {
       this->set_state_(State::IDLE);
-      if (this->detected_) {
-        this->wake_word_detected_trigger_->trigger(this->detected_wake_word_);
-        this->detected_ = false;
-        this->detected_wake_word_ = "";
-      }
-      // }
       break;
   }
 }
@@ -163,7 +314,7 @@ void MicroWakeWord::start() {
     return;
   }
 
-  if (!this->load_models_() || !this->allocate_buffers_()) {
+  if (!this->load_models_()) {
     ESP_LOGE(TAG, "Failed to load the wake word model(s) or allocate buffers");
     this->status_set_error();
   } else {
@@ -202,72 +353,7 @@ void MicroWakeWord::set_state_(State state) {
   this->state_ = state;
 }
 
-size_t MicroWakeWord::read_microphone_() {
-  size_t bytes_read = this->microphone_->read_secondary(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
-  if (bytes_read == 0) {
-    return 0;
-  }
-
-  size_t bytes_free = this->ring_buffer_->free();
-
-  if (bytes_free < bytes_read) {
-    ESP_LOGW(TAG,
-             "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
-             "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
-             bytes_free, bytes_read);
-
-    this->ring_buffer_->reset();
-  }
-  // ESP_LOGD(TAG, "microphone_read %d", this->input_buffer_[0]);
-  return this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
-}
-
-bool MicroWakeWord::allocate_buffers_() {
-  ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
-
-  if (this->input_buffer_ == nullptr) {
-    this->input_buffer_ = audio_samples_allocator.allocate(INPUT_BUFFER_SIZE * sizeof(int16_t));
-    if (this->input_buffer_ == nullptr) {
-      ESP_LOGE(TAG, "Could not allocate input buffer");
-      return false;
-    }
-  }
-
-  if (this->preprocessor_audio_buffer_ == nullptr) {
-    this->preprocessor_audio_buffer_ = audio_samples_allocator.allocate(this->new_samples_to_get_());
-    if (this->preprocessor_audio_buffer_ == nullptr) {
-      ESP_LOGE(TAG, "Could not allocate the audio preprocessor's buffer.");
-      return false;
-    }
-  }
-
-  if (this->ring_buffer_ == nullptr) {
-    this->ring_buffer_ = RingBuffer::create(BUFFER_SIZE * sizeof(int16_t));
-    if (this->ring_buffer_ == nullptr) {
-      ESP_LOGE(TAG, "Could not allocate ring buffer");
-      return false;
-    }
-  }
-
-  return true;
-}
-
-void MicroWakeWord::deallocate_buffers_() {
-  ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
-  audio_samples_allocator.deallocate(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
-  this->input_buffer_ = nullptr;
-  audio_samples_allocator.deallocate(this->preprocessor_audio_buffer_, this->new_samples_to_get_());
-  this->preprocessor_audio_buffer_ = nullptr;
-}
-
 bool MicroWakeWord::load_models_() {
-  // Setup preprocesor feature generator
-  if (!FrontendPopulateState(&this->frontend_config_, &this->frontend_state_, AUDIO_SAMPLE_FREQUENCY)) {
-    ESP_LOGD(TAG, "Failed to populate frontend state");
-    FrontendFreeStateContents(&this->frontend_state_);
-    return false;
-  }
-
   // Setup streaming models
   for (auto &model : this->wake_word_models_) {
     if (!model.load_model(this->streaming_op_resolver_)) {
@@ -286,8 +372,6 @@ bool MicroWakeWord::load_models_() {
 }
 
 void MicroWakeWord::unload_models_() {
-  FrontendFreeStateContents(&this->frontend_state_);
-
   for (auto &model : this->wake_word_models_) {
     model.unload_model();
   }
@@ -299,11 +383,8 @@ void MicroWakeWord::unload_models_() {
 void MicroWakeWord::update_model_probabilities_() {
   int8_t audio_features[PREPROCESSOR_FEATURE_SIZE];
 
-  // if (!this->generate_features_for_window_(audio_features)) {
-  //   return;
-  // }
-
-  while (this->generate_features_for_window_(audio_features)) {
+  while (this->features_ring_buffer_->available() >= PREPROCESSOR_FEATURE_SIZE) {
+    this->features_ring_buffer_->read((void *) audio_features, PREPROCESSOR_FEATURE_SIZE);
     // Increase the counter since the last positive detection
     this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
 
@@ -356,67 +437,8 @@ bool MicroWakeWord::detect_wake_words_() {
   return false;
 }
 
-bool MicroWakeWord::has_enough_samples_() {
-  return this->ring_buffer_->available() >=
-         (this->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000)) * sizeof(int16_t);
-}
-
-bool MicroWakeWord::generate_features_for_window_(int8_t features[PREPROCESSOR_FEATURE_SIZE]) {
-  // Ensure we have enough new audio samples in the ring buffer for a full window
-  if (!this->has_enough_samples_()) {
-    return false;
-  }
-
-  size_t bytes_read = this->ring_buffer_->read((void *) (this->preprocessor_audio_buffer_),
-                                               this->new_samples_to_get_() * sizeof(int16_t), pdMS_TO_TICKS(200));
-
-  if (bytes_read == 0) {
-    ESP_LOGE(TAG, "Could not read data from Ring Buffer");
-  } else if (bytes_read < this->new_samples_to_get_() * sizeof(int16_t)) {
-    ESP_LOGD(TAG, "Partial Read of Data by Model");
-    ESP_LOGD(TAG, "Could only read %d bytes when required %d bytes ", bytes_read,
-             (int) (this->new_samples_to_get_() * sizeof(int16_t)));
-    return false;
-  }
-
-  size_t num_samples_read;
-  struct FrontendOutput frontend_output = FrontendProcessSamples(
-      &this->frontend_state_, this->preprocessor_audio_buffer_, this->new_samples_to_get_(), &num_samples_read);
-
-  for (size_t i = 0; i < frontend_output.size; ++i) {
-    // These scaling values are set to match the TFLite audio frontend int8 output.
-    // The feature pipeline outputs 16-bit signed integers in roughly a 0 to 670
-    // range. In training, these are then arbitrarily divided by 25.6 to get
-    // float values in the rough range of 0.0 to 26.0. This scaling is performed
-    // for historical reasons, to match up with the output of other feature
-    // generators.
-    // The process is then further complicated when we quantize the model. This
-    // means we have to scale the 0.0 to 26.0 real values to the -128 to 127
-    // signed integer numbers.
-    // All this means that to get matching values from our integer feature
-    // output into the tensor input, we have to perform:
-    // input = (((feature / 25.6) / 26.0) * 256) - 128
-    // To simplify this and perform it in 32-bit integer math, we rearrange to:
-    // input = (feature * 256) / (25.6 * 26.0) - 128
-    constexpr int32_t value_scale = 256;
-    constexpr int32_t value_div = 666;  // 666 = 25.6 * 26.0 after rounding
-    int32_t value = ((frontend_output.values[i] * value_scale) + (value_div / 2)) / value_div;
-    value -= 128;
-    if (value < -128) {
-      value = -128;
-    }
-    if (value > 127) {
-      value = 127;
-    }
-    features[i] = value;
-  }
-
-  return true;
-}
-
 void MicroWakeWord::reset_states_() {
   ESP_LOGD(TAG, "Resetting buffers and probabilities");
-  this->ring_buffer_->reset();
   this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
   for (auto &model : this->wake_word_models_) {
     model.reset_probabilities();

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -121,9 +121,9 @@ void MicroWakeWord::loop() {
       }
       break;
     case State::DETECTING_WAKE_WORD:
-      while (!this->has_enough_samples_()) {
+      // while (!this->has_enough_samples_()) {
         this->read_microphone_();
-      }
+      // }
       this->update_model_probabilities_();
       if (this->detect_wake_words_()) {
         ESP_LOGD(TAG, "Wake Word '%s' Detected", (this->detected_wake_word_).c_str());

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -255,7 +255,7 @@ void MicroWakeWord::inference_task_(void *params) {
   }
 }
 
-void MicroWakeWord::add_wake_word_model(const uint8_t *model_start, float probability_cutoff,
+void MicroWakeWord::add_wake_word_model(const uint8_t *model_start, uint8_t probability_cutoff,
                                         size_t sliding_window_average_size, const std::string &wake_word,
                                         size_t tensor_arena_size) {
   this->wake_word_models_.emplace_back(model_start, probability_cutoff, sliding_window_average_size, wake_word,
@@ -263,7 +263,7 @@ void MicroWakeWord::add_wake_word_model(const uint8_t *model_start, float probab
 }
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
-void MicroWakeWord::add_vad_model(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_size,
+void MicroWakeWord::add_vad_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
                                   size_t tensor_arena_size) {
   this->vad_model_ = make_unique<VADModel>(model_start, probability_cutoff, sliding_window_size, tensor_arena_size);
 }
@@ -444,7 +444,7 @@ bool MicroWakeWord::detect_wake_words_() {
         return true;
 #ifdef USE_MICRO_WAKE_WORD_VAD
       } else {
-        ESP_LOGD(TAG, "Wake word model predicts %s, but VAD model doesn't.", model.get_wake_word().c_str());
+        ESP_LOGD(TAG, "Wake word model predicts '%s', but VAD model doesn't.", model.get_wake_word().c_str());
       }
 #endif
     }

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -203,7 +203,7 @@ void MicroWakeWord::set_state_(State state) {
 }
 
 size_t MicroWakeWord::read_microphone_() {
-  size_t bytes_read = this->microphone_->read(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
+  size_t bytes_read = this->microphone_->read_secondary(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
   if (bytes_read == 0) {
     return 0;
   }

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -116,7 +116,6 @@ void MicroWakeWord::preprocessor_task_(void *params) {
     {
       // Setup preprocesor feature generator
       if (!FrontendPopulateState(&this_mww->frontend_config_, &this_mww->frontend_state_, AUDIO_SAMPLE_FREQUENCY)) {
-        // TODO: Potentially better handle failure
         FrontendFreeStateContents(&this_mww->frontend_state_);
         xEventGroupSetBits(this_mww->event_group_,
                            EventGroupBits::PREPROCESSOR_MESSAGE_ERROR | EventGroupBits::COMMAND_STOP);
@@ -131,7 +130,6 @@ void MicroWakeWord::preprocessor_task_(void *params) {
       int16_t *audio_buffer = int16_allocator.allocate(new_samples_to_read);
 
       if ((audio_buffer == nullptr) || (features_buffer == nullptr)) {
-        // TODO: Potentially better handle buffer allocation failure
         xEventGroupSetBits(this_mww->event_group_,
                            EventGroupBits::PREPROCESSOR_MESSAGE_ERROR | EventGroupBits::COMMAND_STOP);
       }
@@ -139,7 +137,6 @@ void MicroWakeWord::preprocessor_task_(void *params) {
       if (this_mww->features_ring_buffer_ == nullptr) {
         this_mww->features_ring_buffer_ = RingBuffer::create(PREPROCESSOR_FEATURE_SIZE * 10);  // TODO: Tweak this
         if (this_mww->features_ring_buffer_ == nullptr) {
-          // TODO: Potentially better handle failure
           xEventGroupSetBits(this_mww->event_group_,
                              EventGroupBits::PREPROCESSOR_MESSAGE_ERROR | EventGroupBits::COMMAND_STOP);
         }
@@ -158,7 +155,7 @@ void MicroWakeWord::preprocessor_task_(void *params) {
           size_t bytes_read =
               this_mww->microphone_->read_secondary(audio_buffer, new_samples_to_read * sizeof(int16_t));
           if (bytes_read < new_samples_to_read * sizeof(int16_t)) {
-            // TODO: Handle not enough samples read
+            // This shouldn't ever happen, but if we somehow don't have enough samples, just drop this frame
             continue;
           }
 
@@ -230,7 +227,6 @@ void MicroWakeWord::inference_task_(void *params) {
 
     {
       if (!this_mww->load_models_()) {
-        // TODO: Potentially handle failure better
         xEventGroupSetBits(this_mww->event_group_,
                            EventGroupBits::INFERENCE_MESSAGE_ERROR | EventGroupBits::COMMAND_STOP);
       }

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -26,9 +26,6 @@ enum State {
   DETECTING_WAKE_WORD,
 };
 
-// The number of audio slices to process before accepting a positive detection
-static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
-
 class MicroWakeWord : public Component {
  public:
   void setup() override;
@@ -74,10 +71,6 @@ class MicroWakeWord : public Component {
   struct FrontendConfig frontend_config_;
   struct FrontendState frontend_state_;
 
-  // When the wake word detection first starts, we ignore this many audio
-  // feature slices before accepting a positive detection
-  int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
-
   uint8_t features_step_size_;
 
   bool detected_{false};
@@ -99,17 +92,6 @@ class MicroWakeWord : public Component {
    * It then loops through and performs inference with each of the loaded models.
    */
   void update_model_probabilities_();
-
-  /** Checks every model's recent probabilities to determine if the wake word has been predicted
-   *
-   * Verifies the models have processed enough new samples for accurate predictions.
-   * Sets detected_wake_word_ to the wake word, if one is detected.
-   * @return True if a wake word is predicted, false otherwise
-   */
-  bool detect_wake_words_();
-
-  /// @brief Resets the ring buffer, ignore_windows_, and sliding window probabilities
-  void reset_states_();
 
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
   bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -47,11 +47,11 @@ class MicroWakeWord : public Component {
 
   Trigger<std::string> *get_wake_word_detected_trigger() const { return this->wake_word_detected_trigger_; }
 
-  void add_wake_word_model(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_average_size,
+  void add_wake_word_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_average_size,
                            const std::string &wake_word, size_t tensor_arena_size);
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
-  void add_vad_model(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_size,
+  void add_vad_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
                      size_t tensor_arena_size);
 #endif
 

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -23,11 +23,7 @@ namespace micro_wake_word {
 
 enum State {
   IDLE,
-  START_MICROPHONE,
-  STARTING_MICROPHONE,
   DETECTING_WAKE_WORD,
-  STOP_MICROPHONE,
-  STOPPING_MICROPHONE,
 };
 
 // The number of audio slices to process before accepting a positive detection

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -73,9 +73,6 @@ class MicroWakeWord : public Component {
 
   uint8_t features_step_size_;
 
-  bool detected_{false};
-  std::string detected_wake_word_{""};
-
   void set_state_(State state);
 
   /// @brief Loads streaming models and prepares the feature generation frontend

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -98,7 +98,11 @@ class MicroWakeWord : public Component {
 
   inline uint16_t new_samples_to_get_() { return (this->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000)); }
 
+  // Handles managing the start/stop/state of the preprocessor and inference tasks
   EventGroupHandle_t event_group_;
+
+  // Used to send messages about the model's states to the main loop
+  QueueHandle_t detection_queue_;
 
   static void preprocessor_task_(void *params);
   TaskHandle_t preprocessor_task_handle_{nullptr};

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -17,6 +17,7 @@
 #include <tensorflow/lite/micro/micro_interpreter.h>
 #include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
 
+#include <freertos/event_groups.h>
 namespace esphome {
 namespace micro_wake_word {
 
@@ -118,6 +119,8 @@ class MicroWakeWord : public Component {
   bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);
 
   inline uint16_t new_samples_to_get_() { return (this->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000)); }
+
+  EventGroupHandle_t event_group_;
 
   static void preprocessor_task_(void *params);
   TaskHandle_t preprocessor_task_handle_{nullptr};

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -11,6 +11,7 @@
 namespace esphome {
 namespace micro_wake_word {
 
+static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
 static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
 
 class StreamingModel {
@@ -33,9 +34,9 @@ class StreamingModel {
 
  protected:
   uint8_t current_stride_step_{0};
+  int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
 
-  uint8_t probability_cutoff_;  // Quantized cutoff between 0 and 255
-  //float probability_cutoff_;
+  uint8_t probability_cutoff_;  // Quantized probability cutoff mapping 0.0 - 1.0 to 0 - 255
   size_t sliding_window_size_;
   size_t last_n_index_{0};
   size_t tensor_arena_size_;
@@ -69,7 +70,8 @@ class WakeWordModel final : public StreamingModel {
 
 class VADModel final : public StreamingModel {
  public:
-  VADModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size, size_t tensor_arena_size);
+  VADModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
+           size_t tensor_arena_size);
 
   void log_model_config() override;
 

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -14,14 +14,21 @@ namespace micro_wake_word {
 static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
 static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
 
+struct DetectionEvent {
+  std::string *wake_word;
+  bool detected;
+  uint8_t max_probability;
+  uint8_t average_probability;
+};
+
 class StreamingModel {
  public:
   virtual void log_model_config() = 0;
-  virtual bool determine_detected() = 0;
+  virtual DetectionEvent determine_detected() = 0;
 
   bool perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]);
 
-  /// @brief Sets all recent_streaming_probabilities to 0
+  /// @brief Sets all recent_streaming_probabilities to 0 and resets the ignore window count
   void reset_probabilities();
 
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
@@ -60,7 +67,7 @@ class WakeWordModel final : public StreamingModel {
   /// @brief Checks for the wake word by comparing the mean probability in the sliding window with the probability
   /// cutoff
   /// @return True if wake word is detected, false otherwise
-  bool determine_detected() override;
+  DetectionEvent determine_detected() override;
 
   const std::string &get_wake_word() const { return this->wake_word_; }
 
@@ -78,7 +85,7 @@ class VADModel final : public StreamingModel {
   /// @brief Checks for voice activity by comparing the max probability in the sliding window with the probability
   /// cutoff
   /// @return True if voice activity is detected, false otherwise
-  bool determine_detected() override;
+  DetectionEvent determine_detected() override;
 };
 
 }  // namespace micro_wake_word

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -19,6 +19,7 @@ struct DetectionEvent {
   bool detected;
   uint8_t max_probability;
   uint8_t average_probability;
+  bool blocked_by_vad = false;
 };
 
 class StreamingModel {

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -34,7 +34,8 @@ class StreamingModel {
  protected:
   uint8_t current_stride_step_{0};
 
-  float probability_cutoff_;
+  uint8_t probability_cutoff_;  // Quantized cutoff between 0 and 255
+  //float probability_cutoff_;
   size_t sliding_window_size_;
   size_t last_n_index_{0};
   size_t tensor_arena_size_;
@@ -50,7 +51,7 @@ class StreamingModel {
 
 class WakeWordModel final : public StreamingModel {
  public:
-  WakeWordModel(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_average_size,
+  WakeWordModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_average_size,
                 const std::string &wake_word, size_t tensor_arena_size);
 
   void log_model_config() override;
@@ -68,7 +69,7 @@ class WakeWordModel final : public StreamingModel {
 
 class VADModel final : public StreamingModel {
  public:
-  VADModel(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_size, size_t tensor_arena_size);
+  VADModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size, size_t tensor_arena_size);
 
   void log_model_config() override;
 

--- a/esphome/components/microphone/__init__.py
+++ b/esphome/components/microphone/__init__.py
@@ -1,0 +1,91 @@
+from esphome import automation
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+from esphome.automation import maybe_simple_id
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
+from esphome.core import CORE
+from esphome.coroutine import coroutine_with_priority
+
+
+CODEOWNERS = ["@jesserockz"]
+
+IS_PLATFORM_COMPONENT = True
+
+CONF_ON_DATA = "on_data"
+
+microphone_ns = cg.esphome_ns.namespace("microphone")
+
+Microphone = microphone_ns.class_("Microphone")
+
+CaptureAction = microphone_ns.class_(
+    "CaptureAction", automation.Action, cg.Parented.template(Microphone)
+)
+StopCaptureAction = microphone_ns.class_(
+    "StopCaptureAction", automation.Action, cg.Parented.template(Microphone)
+)
+
+
+DataTrigger = microphone_ns.class_(
+    "DataTrigger",
+    automation.Trigger.template(cg.std_vector.template(cg.int16).operator("ref")),
+)
+
+IsCapturingCondition = microphone_ns.class_(
+    "IsCapturingCondition", automation.Condition
+)
+
+
+async def setup_microphone_core_(var, config):
+    for conf in config.get(CONF_ON_DATA, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(
+            trigger,
+            [(cg.std_vector.template(cg.int16).operator("ref").operator("const"), "x")],
+            conf,
+        )
+
+
+async def register_microphone(var, config):
+    if not CORE.has_id(config[CONF_ID]):
+        var = cg.Pvariable(config[CONF_ID], var)
+    await setup_microphone_core_(var, config)
+
+
+MICROPHONE_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_ON_DATA): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DataTrigger),
+            }
+        ),
+    }
+)
+
+
+MICROPHONE_ACTION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(Microphone)})
+
+
+async def media_player_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+automation.register_action(
+    "microphone.capture", CaptureAction, MICROPHONE_ACTION_SCHEMA
+)(media_player_action)
+
+automation.register_action(
+    "microphone.stop_capture", StopCaptureAction, MICROPHONE_ACTION_SCHEMA
+)(media_player_action)
+
+automation.register_condition(
+    "microphone.is_capturing", IsCapturingCondition, MICROPHONE_ACTION_SCHEMA
+)(media_player_action)
+
+
+@coroutine_with_priority(100.0)
+async def to_code(config):
+    cg.add_global(microphone_ns.using)
+    cg.add_define("USE_MICROPHONE")

--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "microphone.h"
+
+#include <vector>
+
+namespace esphome {
+namespace microphone {
+
+template<typename... Ts> class CaptureAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->start(); }
+};
+
+template<typename... Ts> class StopCaptureAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->stop(); }
+};
+
+class DataTrigger : public Trigger<const std::vector<int16_t> &> {
+ public:
+  explicit DataTrigger(Microphone *mic) {
+    mic->add_data_callback([this](const std::vector<int16_t> &data) { this->trigger(data); });
+  }
+};
+
+template<typename... Ts> class IsCapturingCondition : public Condition<Ts...>, public Parented<Microphone> {
+ public:
+  bool check(Ts... x) override { return this->parent_->is_running(); }
+};
+
+}  // namespace microphone
+}  // namespace esphome

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "esphome/core/entity_base.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace microphone {
+
+enum State : uint8_t {
+  STATE_STOPPED = 0,
+  STATE_STARTING,
+  STATE_RUNNING,
+  STATE_STOPPING,
+};
+
+class Microphone {
+ public:
+  virtual void start() = 0;
+  virtual void stop() = 0;
+  void add_data_callback(std::function<void(const std::vector<int16_t> &)> &&data_callback) {
+    this->data_callbacks_.add(std::move(data_callback));
+  }
+  virtual size_t read(int16_t *buf, size_t len) = 0;
+  virtual size_t read_secondary(int16_t *buf, size_t len) { return this->read(buf, len); };
+
+  bool is_running() const { return this->state_ == STATE_RUNNING; }
+  bool is_stopped() const { return this->state_ == STATE_STOPPED; }
+
+ protected:
+  State state_{STATE_STOPPED};
+
+  CallbackManager<void(const std::vector<int16_t> &)> data_callbacks_{};
+};
+
+}  // namespace microphone
+}  // namespace esphome

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -21,7 +21,9 @@ class Microphone {
     this->data_callbacks_.add(std::move(data_callback));
   }
   virtual size_t read(int16_t *buf, size_t len) = 0;
-  virtual size_t read_secondary(int16_t *buf, size_t len) { return this->read(buf, len); };
+  virtual size_t read_secondary(int16_t *buf, size_t len) { return this->read(buf, len); }
+
+  virtual size_t available_secondary() { return 0; }
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -191,7 +191,7 @@ static void stats_task(void *arg) {
 static const char *const TAG = "nabu_media_player";
 
 void NabuMediaPlayer::setup() {
-  xTaskCreatePinnedToCore(stats_task, "stats", 4096, NULL, STATS_TASK_PRIO, NULL, tskNO_AFFINITY);
+  // xTaskCreatePinnedToCore(stats_task, "stats", 4096, NULL, STATS_TASK_PRIO, NULL, tskNO_AFFINITY);
 
   state = media_player::MEDIA_PLAYER_STATE_IDLE;
 

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -191,7 +191,7 @@ static void stats_task(void *arg) {
 static const char *const TAG = "nabu_media_player";
 
 void NabuMediaPlayer::setup() {
-  // xTaskCreatePinnedToCore(stats_task, "stats", 4096, NULL, STATS_TASK_PRIO, NULL, tskNO_AFFINITY);
+  xTaskCreatePinnedToCore(stats_task, "stats", 4096, NULL, STATS_TASK_PRIO, NULL, tskNO_AFFINITY);
 
   state = media_player::MEDIA_PLAYER_STATE_IDLE;
 

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1233,6 +1233,7 @@ voice_assistant:
         not:
           voice_assistant.is_running:
     - lambda: id(nabu_media_player).set_ducking_ratio(1.0);
+    - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
     - script.execute: control_leds
   on_timer_finished:

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1151,7 +1151,6 @@ micro_wake_word:
         else:
           - micro_wake_word.start:
 
-
 select:
   - platform: template
     name: "Wake word select"

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1104,8 +1104,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: dev
-    components: [i2s_audio, nabu, voice_assistant, media_player, micro_wake_word]
+      ref: kahrendt-20240805-audio-in
+    components: [i2s_audio, microphone, nabu, voice_assistant, media_player, micro_wake_word]
     refresh: 0s
 
   - source: github://esphome/esphome@dev
@@ -1115,6 +1115,11 @@ external_components:
 micro_wake_word:
   models:
     - model: okay_nabu
+      id: okay_nabu
+    - model: hey_jarvis
+      id: hey_jarvis
+    - model: hey_mycroft
+      id: hey_mycroft
   vad:
   on_wake_word_detected:
     # If the wake word is detected when the device is muted (Possible with the software mute switch): Do nothing (Just restart micro wake word)
@@ -1145,6 +1150,32 @@ micro_wake_word:
                     wake_word: !lambda return wake_word;
         else:
           - micro_wake_word.start:
+
+
+select:
+  - platform: template
+    name: "Wake word select"
+    options:
+      - "OK Nabu"
+      - "Hey Jarvis"
+      - "Hey Mycroft"
+    optimistic: true
+    on_value:
+      then:
+        - lambda: |-
+            if (x == "OK Nabu") {
+              id(okay_nabu).enable();
+              id(hey_mycroft).disable();
+              id(hey_jarvis).disable();
+            } else if (x == "Hey Mycroft") {
+              id(okay_nabu).disable();
+              id(hey_mycroft).enable();
+              id(hey_jarvis).disable();
+            } else if (x == "Hey Jarvis") {
+              id(okay_nabu).disable();
+              id(hey_mycroft).disable();
+              id(hey_jarvis).enable();
+            }
 
 voice_assistant:
   id: va
@@ -1203,7 +1234,6 @@ voice_assistant:
         not:
           voice_assistant.is_running:
     - lambda: id(nabu_media_player).set_ducking_ratio(1.0);
-    - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
     - script.execute: control_leds
   on_timer_finished:

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1187,6 +1187,7 @@ voice_assistant:
   on_client_connected:
     - wait_until:
         not: ble.enabled
+    - delay: 2s
     - lambda: id(init_in_progress) = false;
     - micro_wake_word.start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};


### PR DESCRIPTION
- Reading from I2S microphone is in a task
  - Handles the hacked 48kHz audio that triplicates the 16kHz signal in the current 48kHz XMOS firmware
  - Puts left and right channels into separate ring buffers to pass less filtered audio to mWW and the fully clean file to the voice assistant (prepared for a future XMOS firmware update)
  - TODO: These changes really should be under a new microphone platform, not bolted onto the existing I2S microphone
- mWW runs in tasks instead of in the main loop: one for spectrogram feature generation and another for the actual inference
  - Tasks communicate and are controlled by an Event Group
  - Wake word detection information is passed from the inference task to the main loop using a queue
- mWW models can be enabled or disabled on the fly. They will automatically be loaded and unloaded as needed
- mWW will always run unless stopped, even while the assist pipeline is running

I'm holding off merging because I haven't tested it on the 16 kHz XMOS firmware that most people are running. I may have broken the microphone!

**This will require a follow up PR after merging to change the external component branch back to dev in the yaml file**