### PR TITLE
Reference dev branch in yaml

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1104,7 +1104,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: kahrendt-20240805-audio-in
+      ref: dev
     components: [i2s_audio, microphone, nabu, voice_assistant, media_player, micro_wake_word]
     refresh: 0s
 


### PR DESCRIPTION
Follow up to #43 to switch the external component branch reference back to dev