### PR TITLE
Do not stop micro-wake-word on Push-to-talk

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -224,7 +224,6 @@ binary_sensor:
                                   - not:
                                       voice_assistant.is_running
                               then:
-                                - micro_wake_word.stop:
                                 - voice_assistant.start:
       # Double Click
       #  . Exposed as an event entity. To be used in automations inside Home Assistant


### PR DESCRIPTION
No need to stop micro-wake-word when a user is using push to talk.
(It's actually not working anymore if we stop mmW)