### PR TITLE
[beta firmware] Better support different microphone audio streams

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -150,9 +150,9 @@ void MicroWakeWord::preprocessor_task_(void *params) {
       }
 
       while (!(xEventGroupGetBits(this_mww->event_group_) & COMMAND_STOP)) {
-        while (this_mww->microphone_->available_secondary() / sizeof(int16_t) >= new_samples_to_read) {
+        while (this_mww->microphone_->available() / sizeof(int16_t) >= new_samples_to_read) {
           size_t bytes_read =
-              this_mww->microphone_->read_secondary(audio_buffer, new_samples_to_read * sizeof(int16_t));
+              this_mww->microphone_->read(audio_buffer, new_samples_to_read * sizeof(int16_t));
           if (bytes_read < new_samples_to_read * sizeof(int16_t)) {
             // This shouldn't ever happen, but if we somehow don't have enough samples, just drop this frame
             continue;

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -24,6 +24,8 @@ class Microphone {
 
   virtual size_t available() { return 0; }
 
+  virtual void reset() {}
+
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -29,13 +29,8 @@ class Microphone {
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 
-  void set_amplify(bool amplify) { this->amplify_ = amplify; }
-  bool get_amplify() { return this->amplify_; }
-
  protected:
   State state_{STATE_STOPPED};
-
-  bool amplify_;
 
   CallbackManager<void(const std::vector<int16_t> &)> data_callbacks_{};
 };

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -21,9 +21,8 @@ class Microphone {
     this->data_callbacks_.add(std::move(data_callback));
   }
   virtual size_t read(int16_t *buf, size_t len) = 0;
-  virtual size_t read_secondary(int16_t *buf, size_t len) { return this->read(buf, len); }
 
-  virtual size_t available_secondary() { return 0; }
+  virtual size_t available() { return 0; }
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -29,8 +29,13 @@ class Microphone {
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 
+  void set_amplify(bool amplify) { this->amplify_ = amplify; }
+  bool get_amplify() { return this->amplify_; }
+
  protected:
   State state_{STATE_STOPPED};
+
+  bool amplify_;
 
   CallbackManager<void(const std::vector<int16_t> &)> data_callbacks_{};
 };

--- a/esphome/components/nabu_microphone/microphone.py
+++ b/esphome/components/nabu_microphone/microphone.py
@@ -27,6 +27,7 @@ CONF_SAMPLE_RATE = "sample_rate"
 CONF_USE_APLL = "use_apll"
 CONF_CHANNEL_1 = "channel_1"
 CONF_CHANNEL_2 = "channel_2"
+CONF_AMPLIFY = "amplify"
 
 nabu_microphone_ns = cg.esphome_ns.namespace("nabu_microphone")
 
@@ -71,11 +72,13 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_CHANNEL_1): microphone.MICROPHONE_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(NabuMicrophoneChannel),
+                cv.Optional(CONF_AMPLIFY, default=True): cv.boolean,
             }
         ),
         cv.Optional(CONF_CHANNEL_2): microphone.MICROPHONE_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(NabuMicrophoneChannel),
+                cv.Optional(CONF_AMPLIFY, default=True): cv.boolean,
             }
         ),
     }
@@ -114,6 +117,7 @@ async def to_code(config):
         await cg.register_parented(channel_1, config[CONF_ID])
         await microphone.register_microphone(channel_1, channel_1_config)
         cg.add(var.set_channel_1(channel_1))
+        cg.add(channel_1.set_amplify(channel_1_config[CONF_AMPLIFY]))
 
     if channel_2_config := config.get(CONF_CHANNEL_2):
         channel_2 = cg.new_Pvariable(channel_2_config[CONF_ID])
@@ -121,6 +125,7 @@ async def to_code(config):
         await cg.register_parented(channel_2, config[CONF_ID])
         await microphone.register_microphone(channel_2, channel_2_config)
         cg.add(var.set_channel_2(channel_2))
+        cg.add(channel_2.set_amplify(channel_2_config[CONF_AMPLIFY]))
 
     if config[CONF_ADC_TYPE] == "internal":
         variant = esp32.get_esp32_variant()

--- a/esphome/components/nabu_microphone/microphone.py
+++ b/esphome/components/nabu_microphone/microphone.py
@@ -1,0 +1,113 @@
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+from esphome import pins
+from esphome.const import CONF_CHANNEL, CONF_ID, CONF_NUMBER
+from esphome.components import microphone, esp32
+from esphome.components.adc import ESP32_VARIANT_ADC1_PIN_TO_CHANNEL, validate_adc_pin
+
+from esphome.components.i2s_audio import (
+    # i2s_audio_ns,
+    I2SAudioComponent,
+    I2SAudioIn,
+    BITS_PER_SAMPLE,
+    CONF_BITS_PER_SAMPLE,
+    CONF_I2S_AUDIO_ID,
+    CONF_I2S_DIN_PIN,
+    _validate_bits,
+)
+
+CODEOWNERS = ["@kahrendt"]
+DEPENDENCIES = ["i2s_audio"]
+
+CONF_ADC_PIN = "adc_pin"
+CONF_ADC_TYPE = "adc_type"
+CONF_PDM = "pdm"
+CONF_SAMPLE_RATE = "sample_rate"
+CONF_USE_APLL = "use_apll"
+
+nabu_microphone_ns = cg.esphome_ns.namespace("nabu_microphone")
+
+NabuMicrophone = nabu_microphone_ns.class_(
+    "NabuMicrophone", I2SAudioIn, microphone.Microphone, cg.Component
+)
+
+i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
+CHANNELS = {
+    "left": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
+    "right": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
+}
+
+INTERNAL_ADC_VARIANTS = [esp32.const.VARIANT_ESP32]
+PDM_VARIANTS = [esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S3]
+
+
+def validate_esp32_variant(config):
+    variant = esp32.get_esp32_variant()
+    if config[CONF_ADC_TYPE] == "external":
+        if config[CONF_PDM]:
+            if variant not in PDM_VARIANTS:
+                raise cv.Invalid(f"{variant} does not support PDM")
+        return config
+    if config[CONF_ADC_TYPE] == "internal":
+        if variant not in INTERNAL_ADC_VARIANTS:
+            raise cv.Invalid(f"{variant} does not have an internal ADC")
+        return config
+    raise NotImplementedError
+
+
+BASE_SCHEMA = microphone.MICROPHONE_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(NabuMicrophone),
+        cv.GenerateID(CONF_I2S_AUDIO_ID): cv.use_id(I2SAudioComponent),
+        cv.Optional(CONF_CHANNEL, default="right"): cv.enum(CHANNELS),
+        cv.Optional(CONF_SAMPLE_RATE, default=16000): cv.int_range(min=1),
+        cv.Optional(CONF_BITS_PER_SAMPLE, default="32bit"): cv.All(
+            _validate_bits, cv.enum(BITS_PER_SAMPLE)
+        ),
+        cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+CONFIG_SCHEMA = cv.All(
+    cv.typed_schema(
+        {
+            "internal": BASE_SCHEMA.extend(
+                {
+                    cv.Required(CONF_ADC_PIN): validate_adc_pin,
+                }
+            ),
+            "external": BASE_SCHEMA.extend(
+                {
+                    cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
+                    cv.Required(CONF_PDM): cv.boolean,
+                }
+            ),
+        },
+        key=CONF_ADC_TYPE,
+    ),
+    validate_esp32_variant,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
+
+    if config[CONF_ADC_TYPE] == "internal":
+        variant = esp32.get_esp32_variant()
+        pin_num = config[CONF_ADC_PIN][CONF_NUMBER]
+        channel = ESP32_VARIANT_ADC1_PIN_TO_CHANNEL[variant][pin_num]
+        cg.add(var.set_adc_channel(channel))
+    else:
+        cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
+        cg.add(var.set_pdm(config[CONF_PDM]))
+
+    # cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
+    cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))
+    cg.add(var.set_use_apll(config[CONF_USE_APLL]))
+
+    await microphone.register_microphone(var, config)

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -236,7 +236,8 @@ void NabuMicrophone::read_task_(void *params) {
               if (this_microphone->channel_1_ != nullptr) {
                 this_microphone->channel_1_->get_ring_buffer()->write((void *) channel_1_samples.data(),
                                                                       bytes_to_write);
-              } else {
+              }
+              if (this_microphone->channel_2_ != nullptr) {
                 this_microphone->channel_2_->get_ring_buffer()->write((void *) channel_2_samples.data(),
                                                                       bytes_to_write);
               }

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -226,7 +226,7 @@ void NabuMicrophone::read_task_(void *params) {
 
               for (size_t i = 0; i < frames_read; i++) {
                 int32_t channel_1_sample = buffer[CHANNELS * sample_rate_factor * i] >> channel_1_shift;
-                int32_t channel_2_sample = buffer[CHANNELS * sample_rate_factor * i] >> channel_2_shift;
+                int32_t channel_2_sample = buffer[CHANNELS * sample_rate_factor * i + 1] >> channel_2_shift;
 
                 channel_1_samples[i] = clamp<int16_t>(channel_1_sample, INT16_MIN, INT16_MAX);
                 channel_2_samples[i] = clamp<int16_t>(channel_2_sample, INT16_MIN, INT16_MAX);

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -1,0 +1,306 @@
+#include "nabu_microphone.h"
+
+#ifdef USE_ESP32
+
+#include <driver/i2s.h>
+
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/core/ring_buffer.h"
+
+namespace esphome {
+namespace nabu_microphone {
+
+static const size_t RING_BUFFER_LENGTH = 64;  // Measured in milliseconds
+static const size_t QUEUE_LENGTH = 10;
+
+static const size_t DMA_BUF_COUNT = 4;
+static const size_t DMA_BUF_LEN = 512;
+static const size_t CHANNELS = 2;  // XMOS sends different info on left and right channels
+static const size_t DMA_SAMPLES = DMA_BUF_COUNT * DMA_BUF_LEN * CHANNELS;
+
+// TODO:
+//   - Determine optimal buffer sizes (dma included)
+//   - Determine appropriate timeout durations for FreeRTOS operations
+//   - Test if stopping the microphone behaves properly
+
+// Notes on things taken out/removed:
+//   - Doesn't properly handle 16 bit samples
+//   - Removed the watch_ function and handling any callbacks
+//   - Channels are fixed to left and right for the XMOS chip
+
+static const char *const TAG = "i2s_audio.microphone";
+
+enum TaskNotificationBits : uint32_t {
+  COMMAND_START = (1 << 0),  // Starts the main task purpose
+  COMMAND_STOP = (1 << 1),   // stops the main task
+};
+
+void NabuMicrophone::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up I2S Audio Microphone...");
+#if SOC_I2S_SUPPORTS_ADC
+  if (this->adc_) {
+    if (this->parent_->get_port() != I2S_NUM_0) {
+      ESP_LOGE(TAG, "Internal ADC only works on I2S0!");
+      this->mark_failed();
+      return;
+    }
+  } else
+#endif
+      if (this->pdm_) {
+    if (this->parent_->get_port() != I2S_NUM_0) {
+      ESP_LOGE(TAG, "PDM only works on I2S0!");
+      this->mark_failed();
+      return;
+    }
+  }
+
+  this->event_queue_ = xQueueCreate(QUEUE_LENGTH, sizeof(i2s_audio::TaskEvent));
+
+  const size_t ring_buffer_size = RING_BUFFER_LENGTH * this->sample_rate_ / 1000 * sizeof(int16_t);
+
+  this->asr_ring_buffer_ = RingBuffer::create(ring_buffer_size);
+  if (this->asr_ring_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate ASR ring buffer");
+    this->mark_failed();
+    return;
+  }
+
+  this->comm_ring_buffer_ = RingBuffer::create(ring_buffer_size);
+  if (this->comm_ring_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate COMM ring buffer");
+    this->mark_failed();
+    return;
+  }
+}
+
+esp_err_t NabuMicrophone::start_i2s_driver_() {
+  if (!this->parent_->try_lock()) {
+    return ESP_ERR_INVALID_STATE;
+  }
+
+  esp_err_t err;
+
+  i2s_driver_config_t config = {
+      .mode = (i2s_mode_t) (this->parent_->get_i2s_mode() | I2S_MODE_RX),
+      .sample_rate = this->sample_rate_,
+      .bits_per_sample = this->bits_per_sample_,
+      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,  // this->channel_,
+      .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+      .dma_buf_count = DMA_BUF_COUNT,
+      .dma_buf_len = DMA_BUF_LEN,
+      .use_apll = this->use_apll_,
+      .tx_desc_auto_clear = false,
+      .fixed_mclk = 0,
+      .mclk_multiple = I2S_MCLK_MULTIPLE_256,
+      .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+#if SOC_I2S_SUPPORTS_TDM
+      .chan_mask = (i2s_channel_t) (I2S_TDM_ACTIVE_CH0 | I2S_TDM_ACTIVE_CH1),
+      .total_chan = 2,
+      .left_align = false,
+      .big_edin = false,
+      .bit_order_msb = false,
+      .skip_msk = false,
+#endif
+  };
+
+#if SOC_I2S_SUPPORTS_ADC
+  if (this->adc_) {
+    config.mode = (i2s_mode_t) (config.mode | I2S_MODE_ADC_BUILT_IN);
+    i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+
+    i2s_set_adc_mode(ADC_UNIT_1, this->adc_channel_);
+    i2s_adc_enable(this->parent_->get_port());
+  } else
+#endif
+  {
+    if (this->pdm_)
+      config.mode = (i2s_mode_t) (config.mode | I2S_MODE_PDM);
+
+    err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+    if (err != ESP_OK) {
+      return err;
+    }
+
+    i2s_pin_config_t pin_config = this->parent_->get_pin_config();
+    pin_config.data_in_num = this->din_pin_;
+
+    err = i2s_set_pin(this->parent_->get_port(), &pin_config);
+    if (err != ESP_OK) {
+      return err;
+    }
+  }
+
+  return ESP_OK;
+}
+
+void NabuMicrophone::read_task_(void *params) {
+  NabuMicrophone *this_microphone = (NabuMicrophone *) params;
+  i2s_audio::TaskEvent event;
+  esp_err_t err;
+
+  while (true) {
+    uint32_t notification_bits = 0;
+    xTaskNotifyWait(ULONG_MAX,           // clear all bits at start of wait
+                    ULONG_MAX,           // clear all bits after waiting
+                    &notification_bits,  // notifcation value after wait is finished
+                    portMAX_DELAY);      // how long to wait
+
+    if (notification_bits & TaskNotificationBits::COMMAND_START) {
+      event.type = i2s_audio::TaskEventType::STARTING;
+      xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+
+      // Note, if we have 16 bit samples incoming, this requires modification
+      ExternalRAMAllocator<int32_t> allocator(ExternalRAMAllocator<int32_t>::ALLOW_FAILURE);
+      int32_t *buffer = allocator.allocate(DMA_SAMPLES);
+
+      std::vector<int16_t, ExternalRAMAllocator<int16_t>> asr_samples;
+      std::vector<int16_t, ExternalRAMAllocator<int16_t>> comm_samples;
+
+      asr_samples.reserve(DMA_SAMPLES);
+      comm_samples.reserve(DMA_SAMPLES);
+
+      if ((buffer == nullptr) || (asr_samples.capacity() < DMA_SAMPLES) || (comm_samples.capacity() < DMA_SAMPLES)) {
+        event.type = i2s_audio::TaskEventType::WARNING;
+        event.err = ESP_ERR_NO_MEM;
+        xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+      } else {
+        err = this_microphone->start_i2s_driver_();
+        if (err != ESP_OK) {
+          event.type = i2s_audio::TaskEventType::WARNING;
+          event.err = err;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+        } else {
+          // TODO: Is this the ideal spot to reset the ring buffers?
+          this_microphone->asr_ring_buffer_->reset();
+          this_microphone->comm_ring_buffer_->reset();
+
+          event.type = i2s_audio::TaskEventType::STARTED;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+
+          while (true) {
+            notification_bits = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(10));
+            if (notification_bits & TaskNotificationBits::COMMAND_STOP) {
+              break;
+            }
+
+            size_t bytes_read;
+            esp_err_t err = i2s_read(this_microphone->parent_->get_port(), buffer, DMA_SAMPLES * sizeof(int32_t),
+                                     &bytes_read, (10 / portTICK_PERIOD_MS));
+            if (err != ESP_OK) {
+              event.type = i2s_audio::TaskEventType::WARNING;
+              event.err = err;
+              xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+            }
+
+            if (bytes_read > 0) {
+              // TODO: Handle 16 bits per sample, currently it won't allow that option at codegen stage
+
+              // At 48000 kHz, the current XMOS firmware is sending the same sample 3 times as a hack
+              const size_t sample_rate_factor = this_microphone->sample_rate_ / 16000;
+
+              size_t samples_read = (bytes_read / sizeof(int32_t)) / (sample_rate_factor);
+              size_t frames_read = samples_read / CHANNELS;  // Left and right channel samples combine into 1 frame
+
+              for (size_t i = 0; i < frames_read; i++) {
+                asr_samples[i] = buffer[CHANNELS * sample_rate_factor * i] >> 16;
+                comm_samples[i] = buffer[CHANNELS * sample_rate_factor * i + 1] >> 16;
+              }
+              size_t bytes_to_write = frames_read * sizeof(int16_t);
+
+              this_microphone->asr_ring_buffer_->write((void *) asr_samples.data(), bytes_to_write);
+              this_microphone->comm_ring_buffer_->write((void *) comm_samples.data(), bytes_to_write);
+            }
+
+            event.type = i2s_audio::TaskEventType::RUNNING;
+            xQueueSend(this_microphone->event_queue_, &event, 0);
+          }
+
+          event.type = i2s_audio::TaskEventType::STOPPING;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+
+          allocator.deallocate(buffer, DMA_SAMPLES);
+          i2s_stop(this_microphone->parent_->get_port());
+          i2s_driver_uninstall(this_microphone->parent_->get_port());
+
+          this_microphone->parent_->unlock();
+
+          event.type = i2s_audio::TaskEventType::STOPPED;
+          xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+        }
+      }
+    }
+    event.type = i2s_audio::TaskEventType::STOPPED;
+    event.err = ESP_OK;
+    xQueueSend(this_microphone->event_queue_, &event, portMAX_DELAY);
+  }
+}
+
+void NabuMicrophone::start() {
+  if (this->is_failed())
+    return;
+  if ((this->state_ == microphone::STATE_STARTING) || (this->state_ == microphone::STATE_RUNNING))
+    return;
+
+  if (this->read_task_handle_ == nullptr) {
+    xTaskCreate(NabuMicrophone::read_task_, "microphone_task", 3584, (void *) this, 23, &this->read_task_handle_);
+  }
+
+  // TODO: Should we overwrite? If stop and start are called in quick succession, what behavior do we want
+  xTaskNotify(this->read_task_handle_, TaskNotificationBits::COMMAND_START, eSetValueWithoutOverwrite);
+}
+
+void NabuMicrophone::stop() {
+  if (this->state_ == microphone::STATE_STOPPED || this->is_failed())
+    return;
+
+  xTaskNotify(this->read_task_handle_, TaskNotificationBits::COMMAND_STOP, eSetValueWithOverwrite);
+}
+
+size_t NabuMicrophone::read(int16_t *buf, size_t len) { return this->asr_ring_buffer_->read((void *) buf, len, 0); }
+
+size_t NabuMicrophone::read_secondary(int16_t *buf, size_t len) {
+  return this->comm_ring_buffer_->read((void *) buf, len, 0);
+}
+
+void NabuMicrophone::loop() {
+  // Note this->state_ is only modified here based on the status of the task
+
+  i2s_audio::TaskEvent event;
+  while (xQueueReceive(this->event_queue_, &event, 0)) {
+    switch (event.type) {
+      case i2s_audio::TaskEventType::STARTING:
+        this->state_ = microphone::STATE_STARTING;
+        ESP_LOGD(TAG, "Starting I2S Audio Microphne");
+        break;
+      case i2s_audio::TaskEventType::STARTED:
+        this->state_ = microphone::STATE_RUNNING;
+        ESP_LOGD(TAG, "Started I2S Audio Microphone");
+        break;
+      case i2s_audio::TaskEventType::RUNNING:
+        this->status_clear_warning();
+        break;
+      case i2s_audio::TaskEventType::STOPPING:
+        this->state_ = microphone::STATE_STOPPING;
+        ESP_LOGD(TAG, "Stopping I2S Audio Microphone");
+        break;
+      case i2s_audio::TaskEventType::STOPPED:
+        this->state_ = microphone::STATE_STOPPED;
+        ESP_LOGD(TAG, "Stopped I2S Audio Microphone");
+        break;
+      case i2s_audio::TaskEventType::WARNING:
+        ESP_LOGW(TAG, "Error involving I2S: %s", esp_err_to_name(event.err));
+        this->status_set_warning();
+        break;
+      case i2s_audio::TaskEventType::IDLE:
+        break;
+    }
+  }
+}
+
+}  // namespace i2s_audio
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -233,8 +233,13 @@ void NabuMicrophone::read_task_(void *params) {
               }
               size_t bytes_to_write = frames_read * sizeof(int16_t);
 
-              this_microphone->channel_1_->get_ring_buffer()->write((void *) channel_1_samples.data(), bytes_to_write);
-              this_microphone->channel_2_->get_ring_buffer()->write((void *) channel_2_samples.data(), bytes_to_write);
+              if (this_microphone->channel_1_ != nullptr) {
+                this_microphone->channel_1_->get_ring_buffer()->write((void *) channel_1_samples.data(),
+                                                                      bytes_to_write);
+              } else {
+                this_microphone->channel_2_->get_ring_buffer()->write((void *) channel_2_samples.data(),
+                                                                      bytes_to_write);
+              }
             }
 
             event.type = i2s_audio::TaskEventType::RUNNING;

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -221,9 +221,15 @@ void NabuMicrophone::read_task_(void *params) {
               size_t samples_read = (bytes_read / sizeof(int32_t)) / (sample_rate_factor);
               size_t frames_read = samples_read / CHANNELS;  // Left and right channel samples combine into 1 frame
 
+              uint8_t channel_1_shift = 16 - 2 * this_microphone->channel_1_->get_amplify();
+              uint8_t channel_2_shift = 16 - 2 * this_microphone->channel_2_->get_amplify();
+
               for (size_t i = 0; i < frames_read; i++) {
-                channel_1_samples[i] = buffer[CHANNELS * sample_rate_factor * i] >> 16;
-                channel_2_samples[i] = buffer[CHANNELS * sample_rate_factor * i + 1] >> 16;
+                int32_t channel_1_sample = buffer[CHANNELS * sample_rate_factor * i] >> channel_1_shift;
+                int32_t channel_2_sample = buffer[CHANNELS * sample_rate_factor * i] >> channel_2_shift;
+
+                channel_1_samples[i] = clamp<int16_t>(channel_1_sample, INT16_MIN, INT16_MAX);
+                channel_2_samples[i] = clamp<int16_t>(channel_2_sample, INT16_MIN, INT16_MAX);
               }
               size_t bytes_to_write = frames_read * sizeof(int16_t);
 

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+
+#include "esphome/components/i2s_audio/i2s_audio.h"
+#include "esphome/components/microphone/microphone.h"
+#include "esphome/core/component.h"
+#include "esphome/core/ring_buffer.h"
+
+namespace esphome {
+namespace nabu_microphone {
+
+class NabuMicrophone : public i2s_audio::I2SAudioIn, public microphone::Microphone, public Component {
+ public:
+  void setup() override;
+  void start() override;
+  void stop() override;
+
+  void loop() override;
+
+  size_t read(int16_t *buf, size_t len) override;
+  size_t read_secondary(int16_t *buf, size_t len) override;
+
+  size_t available_secondary() override { return this->comm_ring_buffer_->available(); }
+
+#if SOC_I2S_SUPPORTS_ADC
+  void set_adc_channel(adc1_channel_t channel) {
+    this->adc_channel_ = channel;
+    this->adc_ = true;
+  }
+#endif
+
+  void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
+  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
+  void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
+
+  void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
+  void set_pdm(bool pdm) { this->pdm_ = pdm; }
+
+ protected:
+  esp_err_t start_i2s_driver_();
+
+  static void read_task_(void *params);
+
+  TaskHandle_t read_task_handle_{nullptr};
+  QueueHandle_t event_queue_;
+  std::unique_ptr<RingBuffer> asr_ring_buffer_;
+  std::unique_ptr<RingBuffer> comm_ring_buffer_;
+
+  bool use_apll_;
+  bool pdm_{false};
+  int8_t din_pin_{I2S_PIN_NO_CHANGE};
+
+#if SOC_I2S_SUPPORTS_ADC
+  bool adc_{false};
+  adc1_channel_t adc_channel_{ADC1_CHANNEL_MAX};
+#endif
+
+  i2s_bits_per_sample_t bits_per_sample_;
+  i2s_channel_fmt_t channel_;
+  uint32_t sample_rate_;
+};
+
+}  // namespace i2s_audio
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -2,7 +2,6 @@
 
 #ifdef USE_ESP32
 
-
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 
@@ -14,18 +13,22 @@
 namespace esphome {
 namespace nabu_microphone {
 
-class NabuMicrophone : public i2s_audio::I2SAudioIn, public microphone::Microphone, public Component {
+class NabuMicrophoneChannel;
+
+class NabuMicrophone : public i2s_audio::I2SAudioIn, public Component {
  public:
   void setup() override;
-  void start() override;
-  void stop() override;
+  void start();
+  void stop();
 
   void loop() override;
 
-  size_t read(int16_t *buf, size_t len) override;
-  size_t read_secondary(int16_t *buf, size_t len) override;
+  // size_t read(int16_t *buf, size_t len) override;
+  // size_t read_secondary(int16_t *buf, size_t len) override;
 
-  size_t available_secondary() override { return this->comm_ring_buffer_->available(); }
+  // size_t available_secondary() override { return this->comm_ring_buffer_->available(); }
+  void set_channel_1(NabuMicrophoneChannel *microphone) { this->channel_1_ = microphone; }
+  void set_channel_2(NabuMicrophoneChannel *microphone) { this->channel_2_ = microphone; }
 
 #if SOC_I2S_SUPPORTS_ADC
   void set_adc_channel(adc1_channel_t channel) {
@@ -41,15 +44,21 @@ class NabuMicrophone : public i2s_audio::I2SAudioIn, public microphone::Micropho
   void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
+  bool is_running() { return this->state_ == microphone::STATE_RUNNING; }
+  uint32_t get_sample_rate() { return this->sample_rate_; }
+
  protected:
   esp_err_t start_i2s_driver_();
+
+  microphone::State state_{microphone::STATE_STOPPED};
 
   static void read_task_(void *params);
 
   TaskHandle_t read_task_handle_{nullptr};
   QueueHandle_t event_queue_;
-  std::unique_ptr<RingBuffer> asr_ring_buffer_;
-  std::unique_ptr<RingBuffer> comm_ring_buffer_;
+
+  NabuMicrophoneChannel *channel_1_{nullptr};
+  NabuMicrophoneChannel *channel_2_{nullptr};
 
   bool use_apll_;
   bool pdm_{false};
@@ -65,7 +74,28 @@ class NabuMicrophone : public i2s_audio::I2SAudioIn, public microphone::Micropho
   uint32_t sample_rate_;
 };
 
-}  // namespace i2s_audio
+class NabuMicrophoneChannel : public microphone::Microphone, public Component {
+ public:
+  void setup() override;
+
+  void start() override { this->parent_->start(); }
+
+  void set_parent(NabuMicrophone *nabu_microphone) { this->parent_ = nabu_microphone; }
+
+  void stop() override {};
+  void loop() override;
+
+  size_t read(int16_t *buf, size_t len) override { return this->ring_buffer_->read((void *) buf, len, 0); };
+  size_t available() override { return this->ring_buffer_->available(); }
+
+  RingBuffer *get_ring_buffer() { return this->ring_buffer_.get(); }
+
+ protected:
+  NabuMicrophone *parent_;
+  std::unique_ptr<RingBuffer> ring_buffer_;
+};
+
+}  // namespace nabu_microphone
 }  // namespace esphome
 
 #endif  // USE_ESP32

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -87,6 +87,7 @@ class NabuMicrophoneChannel : public microphone::Microphone, public Component {
 
   size_t read(int16_t *buf, size_t len) override { return this->ring_buffer_->read((void *) buf, len, 0); };
   size_t available() override { return this->ring_buffer_->available(); }
+  void reset() override { this->ring_buffer_->reset(); }
 
   RingBuffer *get_ring_buffer() { return this->ring_buffer_.get(); }
 

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -91,9 +91,14 @@ class NabuMicrophoneChannel : public microphone::Microphone, public Component {
 
   RingBuffer *get_ring_buffer() { return this->ring_buffer_.get(); }
 
+  void set_amplify(bool amplify) { this->amplify_ = amplify; }
+  bool get_amplify() { return this->amplify_; }
+
  protected:
   NabuMicrophone *parent_;
   std::unique_ptr<RingBuffer> ring_buffer_;
+
+  bool amplify_;
 };
 
 }  // namespace nabu_microphone

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -238,7 +238,7 @@ void VoiceAssistant::loop() {
     case State::STARTING_MICROPHONE: {
       if (this->mic_->is_running()) {
         this->set_state_(this->desired_state_);
-        this->mic_->reset();
+        // this->mic_->reset();
       }
       break;
     }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -238,6 +238,7 @@ void VoiceAssistant::loop() {
     case State::STARTING_MICROPHONE: {
       if (this->mic_->is_running()) {
         this->set_state_(this->desired_state_);
+        this->mic_->reset();
       }
       break;
     }

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1066,7 +1066,7 @@ microphone:
     i2s_din_pin: GPIO11
     adc_type: external
     pdm: false
-    sample_rate: 48000
+    sample_rate: 16000  # use 48000 for beta firmware
     bits_per_sample: 32bit
     i2s_audio_id: i2s_input
     channel_1:
@@ -1074,14 +1074,14 @@ microphone:
       amplify: false
     channel_2:
       id: comm_mic
-      amplify: true
+      amplify: false  # should be true for firmware with two different streams
 
 media_player:
   - platform: nabu
     id: nabu_media_player
     name: Media Player
     internal: false
-    sample_rate: 48000
+    sample_rate: 16000  # use 48000 for beta firmware
     i2s_dout_pin: GPIO10
     bits_per_sample: 32bit
     i2s_audio_id: i2s_output
@@ -1109,7 +1109,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: dev
+      ref: kahrendt-20240808-microphone-cleanup
     components: [i2s_audio, microphone, nabu_microphone, nabu, voice_assistant, media_player, micro_wake_word]
     refresh: 0s
 

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1062,20 +1062,26 @@ i2s_audio:
   # yamllint enable rule:comments-indentation
 
 microphone:
-  - platform: i2s_audio
-    id: kit_mic
+  - platform: nabu_microphone
     i2s_din_pin: GPIO11
     adc_type: external
     pdm: false
+    sample_rate: 48000
     bits_per_sample: 32bit
-    channel: left
     i2s_audio_id: i2s_input
+    channel_1:
+      id: asr_mic
+      amplify: false
+    channel_2:
+      id: comm_mic
+      amplify: true
 
 media_player:
   - platform: nabu
     id: nabu_media_player
     name: Media Player
     internal: false
+    sample_rate: 48000
     i2s_dout_pin: GPIO10
     bits_per_sample: 32bit
     i2s_audio_id: i2s_output
@@ -1104,7 +1110,7 @@ external_components:
       type: git
       url: https://github.com/esphome/voice-kit
       ref: dev
-    components: [i2s_audio, microphone, nabu, voice_assistant, media_player, micro_wake_word]
+    components: [i2s_audio, microphone, nabu_microphone, nabu, voice_assistant, media_player, micro_wake_word]
     refresh: 0s
 
   - source: github://esphome/esphome@dev
@@ -1120,6 +1126,7 @@ micro_wake_word:
     - model: hey_mycroft
       id: hey_mycroft
   vad:
+  microphone: comm_mic
   on_wake_word_detected:
     # If the wake word is detected when the device is muted (Possible with the software mute switch): Do nothing (Just restart micro wake word)
     - if:
@@ -1145,6 +1152,19 @@ micro_wake_word:
                           .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
                           .set_announcement(true)
                           .perform();
+                - lambda: |-
+                    id(nabu_media_player)
+                      ->make_call()
+                      .set_announcement(true)
+                      .set_local_media_file(id(awake_wave_file))
+                      .perform();
+                - wait_until:
+                    lambda: |-
+                      return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                - wait_until:
+                    not:
+                      lambda: |-
+                        return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
                 - voice_assistant.start:
                     wake_word: !lambda return wake_word;
         else:
@@ -1177,7 +1197,7 @@ select:
 
 voice_assistant:
   id: va
-  microphone: kit_mic
+  microphone: asr_mic
   media_player: nabu_media_player
   use_wake_word: false
   noise_suppression_level: 0
@@ -1208,12 +1228,6 @@ voice_assistant:
           - script.execute: control_leds
   # When the voice assistant starts: Play a wake up sound, duck audio.
   on_start:
-    - lambda: |-
-        id(nabu_media_player)
-          ->make_call()
-          .set_announcement(true)
-          .set_local_media_file(id(awake_wave_file))
-          .perform();
     - lambda: id(nabu_media_player).set_ducking_ratio(0.25);
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_waiting_for_command_phase_id};


### PR DESCRIPTION
**This requires an updated XMOS firmware that outputs fully cleaned up and partially cleaned up mic audio**

This PR adds a new ``nabu_microphone`` component that has two child microphones, one for each channel. The yaml file shows how to set this up to pass the AEC audio to mWW and the fully cleaned up audio stream to the voice assistant. There is an optional parameter to amplify a microphone to match the built in factor of 4 in the current ESPHome code (since the mWW audio channel doesn't have gain control automatically applied). I've also rearranged the logic around the wake up noise so that the voice assistant pipeline starts only after the wakeup noise has played.