### PR TITLE
Media Player Cleanup

### DIFF
--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -46,6 +46,21 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
   }
 }
 
+const char *media_player_file_type_to_string(MediaFileType file_type) {
+  switch (file_type) {
+    // case MediaFileType::NONE:
+    //   return "unknown";
+    case MediaFileType::FLAC:
+      return "FLAC";
+    case MediaFileType::MP3:
+      return "MP3";
+    case MediaFileType::WAV:
+      return "WAV";
+    default:
+      return "unknonw";
+  }
+}
+
 void MediaPlayerCall::validate_() {
   if (this->media_url_.has_value()) {
     if (this->command_.has_value()) {

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -43,13 +43,13 @@ enum class MediaFileType : uint8_t {
   MP3,
   FLAC,
 };
+const char *media_player_file_type_to_string(MediaFileType file_type);
 
 struct MediaFile {
   const uint8_t *data;
   size_t length;
   MediaFileType file_type;
 };
-
 
 class MediaPlayer;
 
@@ -85,7 +85,7 @@ class MediaPlayerCall {
   const optional<std::string> &get_media_url() const { return media_url_; }
   const optional<float> &get_volume() const { return volume_; }
   const optional<bool> &get_announcement() const { return announcement_; }
-  const optional<MediaFile*> &get_local_media_file() const { return media_file_; }
+  const optional<MediaFile *> &get_local_media_file() const { return media_file_; }
 
  protected:
   void validate_();
@@ -94,7 +94,7 @@ class MediaPlayerCall {
   optional<std::string> media_url_;
   optional<float> volume_;
   optional<bool> announcement_;
-  optional<MediaFile*> media_file_;
+  optional<MediaFile *> media_file_;
 };
 
 class MediaPlayer : public EntityBase {
@@ -112,7 +112,7 @@ class MediaPlayer : public EntityBase {
 
   virtual MediaPlayerTraits get_traits() = 0;
 
-  virtual void set_ducking_ratio(float ducking_ratio) { return;}
+  virtual void set_ducking_ratio(float ducking_ratio) { return; }
 
  protected:
   friend MediaPlayerCall;

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -112,8 +112,6 @@ class MediaPlayer : public EntityBase {
 
   virtual MediaPlayerTraits get_traits() = 0;
 
-  virtual void set_ducking_ratio(float ducking_ratio) { return; }
-
  protected:
   friend MediaPlayerCall;
 

--- a/esphome/components/nabu/audio_decoder.cpp
+++ b/esphome/components/nabu/audio_decoder.cpp
@@ -26,34 +26,18 @@ AudioDecoder::~AudioDecoder() {
 
   if (this->flac_decoder_ != nullptr) {
     this->flac_decoder_->free_buffers();
-    delete this->flac_decoder_;
+    this->flac_decoder_.reset();  // Free the unique_ptr
     this->flac_decoder_ = nullptr;
-  }
-
-  if (this->wav_decoder_ != nullptr) {
-    delete this->wav_decoder_;
-    this->wav_decoder_ = nullptr;
   }
 
   if (this->media_file_type_ == media_player::MediaFileType::MP3) {
     MP3FreeDecoder(this->mp3_decoder_);
   }
-}
 
-esp_err_t AudioDecoder::allocate_buffers_() {
-  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-
-  if (this->input_buffer_ == nullptr)
-    this->input_buffer_ = allocator.allocate(this->internal_buffer_size_);
-
-  if (this->output_buffer_ == nullptr)
-    this->output_buffer_ = allocator.allocate(this->internal_buffer_size_);
-
-  if ((this->input_buffer_ == nullptr) || (this->output_buffer_ == nullptr)) {
-    return ESP_ERR_NO_MEM;
+  if (this->wav_decoder_ != nullptr) {
+    this->wav_decoder_.reset();  // Free the unique_ptr
+    this->wav_decoder_ = nullptr;
   }
-
-  return ESP_OK;
 }
 
 esp_err_t AudioDecoder::start(media_player::MediaFileType media_file_type) {
@@ -74,15 +58,15 @@ esp_err_t AudioDecoder::start(media_player::MediaFileType media_file_type) {
   this->end_of_file_ = false;
 
   switch (this->media_file_type_) {
-    case media_player::MediaFileType::WAV:
-      this->wav_decoder_ = new wav_decoder::WAVDecoder(&this->input_buffer_current_);
-      this->wav_decoder_->reset();
+    case media_player::MediaFileType::FLAC:
+      this->flac_decoder_ = make_unique<flac::FLACDecoder>(this->input_buffer_);
       break;
     case media_player::MediaFileType::MP3:
       this->mp3_decoder_ = MP3InitDecoder();
       break;
-    case media_player::MediaFileType::FLAC:
-      this->flac_decoder_ = new flac::FLACDecoder(this->input_buffer_);
+    case media_player::MediaFileType::WAV:
+      this->wav_decoder_ = make_unique<wav_decoder::WAVDecoder>(&this->input_buffer_current_);
+      this->wav_decoder_->reset();
       break;
     case media_player::MediaFileType::NONE:
       break;
@@ -159,14 +143,14 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
         state = FileDecoderState::IDLE;
       } else {
         switch (this->media_file_type_) {
-          case media_player::MediaFileType::WAV:
-            state = this->decode_wav_();
+          case media_player::MediaFileType::FLAC:
+            state = this->decode_flac_();
             break;
           case media_player::MediaFileType::MP3:
             state = this->decode_mp3_();
             break;
-          case media_player::MediaFileType::FLAC:
-            state = this->decode_flac_();
+          case media_player::MediaFileType::WAV:
+            state = this->decode_wav_();
             break;
           case media_player::MediaFileType::NONE:
             state = FileDecoderState::IDLE;
@@ -185,6 +169,126 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
     }
   }
   return AudioDecoderState::DECODING;
+}
+
+esp_err_t AudioDecoder::allocate_buffers_() {
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  if (this->input_buffer_ == nullptr)
+    this->input_buffer_ = allocator.allocate(this->internal_buffer_size_);
+
+  if (this->output_buffer_ == nullptr)
+    this->output_buffer_ = allocator.allocate(this->internal_buffer_size_);
+
+  if ((this->input_buffer_ == nullptr) || (this->output_buffer_ == nullptr)) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  return ESP_OK;
+}
+
+FileDecoderState AudioDecoder::decode_flac_() {
+  if (!this->stream_info_.has_value()) {
+    // Header hasn't been read
+    auto result = this->flac_decoder_->read_header(this->input_buffer_length_);
+
+    size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
+    this->input_buffer_current_ += bytes_consumed;
+    this->input_buffer_length_ = this->flac_decoder_->get_bytes_left();
+
+    if (result == flac::FLAC_DECODER_HEADER_OUT_OF_DATA) {
+      return FileDecoderState::POTENTIALLY_FAILED;
+    }
+
+    if (result != flac::FLAC_DECODER_SUCCESS) {
+      printf("failed to read flac header. Error: %d\n", result);
+      return FileDecoderState::FAILED;
+    }
+
+    media_player::StreamInfo stream_info;
+    stream_info.channels = this->flac_decoder_->get_num_channels();
+    stream_info.sample_rate = this->flac_decoder_->get_sample_rate();
+    stream_info.bits_per_sample = this->flac_decoder_->get_sample_depth();
+
+    size_t flac_decoder_output_buffer_min_size = flac_decoder_->get_output_buffer_size();
+    if (this->internal_buffer_size_ < flac_decoder_output_buffer_min_size * sizeof(int16_t)) {
+      printf("output buffer is not big enough\n");
+      return FileDecoderState::FAILED;
+    }
+
+    return FileDecoderState::MORE_TO_PROCESS;
+  }
+
+  uint32_t output_samples = 0;
+  auto result =
+      this->flac_decoder_->decode_frame(this->input_buffer_length_, (int16_t *) this->output_buffer_, &output_samples);
+
+  if (result == flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
+    // Not an issue, just needs more data that we'll get next time.
+    return FileDecoderState::POTENTIALLY_FAILED;
+  } else if (result > flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
+    // Serious error, can't recover
+    printf("FLAC Decoder Error %d\n", result);
+    return FileDecoderState::FAILED;
+  }
+
+  // We have successfully decoded some input data and have new output data
+  size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
+  this->input_buffer_current_ += bytes_consumed;
+  this->input_buffer_length_ = this->flac_decoder_->get_bytes_left();
+
+  this->output_buffer_current_ = this->output_buffer_;
+  this->output_buffer_length_ = output_samples * sizeof(int16_t);
+
+  if (result == flac::FLAC_DECODER_NO_MORE_FRAMES) {
+    return FileDecoderState::END_OF_FILE;
+  }
+
+  return FileDecoderState::MORE_TO_PROCESS;
+}
+
+FileDecoderState AudioDecoder::decode_mp3_() {
+  // Look for the next sync word
+  int32_t offset = MP3FindSyncWord(this->input_buffer_current_, this->input_buffer_length_);
+  if (offset < 0) {
+    // We may recover if we have more data
+    return FileDecoderState::POTENTIALLY_FAILED;
+  }
+
+  // Advance read pointer
+  this->input_buffer_current_ += offset;
+  this->input_buffer_length_ -= offset;
+
+  int err = MP3Decode(this->mp3_decoder_, &this->input_buffer_current_, (int *) &this->input_buffer_length_,
+                      (int16_t *) this->output_buffer_, 0);
+  if (err) {
+    switch (err) {
+      case ERR_MP3_MAINDATA_UNDERFLOW:
+        // Not a problem. Next call to decode will provide more data.
+        return FileDecoderState::POTENTIALLY_FAILED;
+        break;
+      default:
+        // TODO: Better handle mp3 decoder errors
+        return FileDecoderState::FAILED;
+        break;
+    }
+  } else {
+    MP3FrameInfo mp3_frame_info;
+    MP3GetLastFrameInfo(this->mp3_decoder_, &mp3_frame_info);
+    if (mp3_frame_info.outputSamps > 0) {
+      int bytes_per_sample = (mp3_frame_info.bitsPerSample / 8);
+      this->output_buffer_length_ = mp3_frame_info.outputSamps * bytes_per_sample;
+      this->output_buffer_current_ = this->output_buffer_;
+
+      media_player::StreamInfo stream_info;
+      stream_info.channels = mp3_frame_info.nChans;
+      stream_info.sample_rate = mp3_frame_info.samprate;
+      stream_info.bits_per_sample = mp3_frame_info.bitsPerSample;
+      this->stream_info_ = stream_info;
+    }
+  }
+  // }
+  return FileDecoderState::MORE_TO_PROCESS;
 }
 
 FileDecoderState AudioDecoder::decode_wav_() {
@@ -257,110 +361,6 @@ FileDecoderState AudioDecoder::decode_wav_() {
   }
 
   return FileDecoderState::END_OF_FILE;
-}
-
-FileDecoderState AudioDecoder::decode_mp3_() {
-  // Look for the next sync word
-  int32_t offset = MP3FindSyncWord(this->input_buffer_current_, this->input_buffer_length_);
-  if (offset < 0) {
-    // We may recover if we have more data
-    return FileDecoderState::POTENTIALLY_FAILED;
-  }
-
-  // Advance read pointer
-  this->input_buffer_current_ += offset;
-  this->input_buffer_length_ -= offset;
-
-  int err = MP3Decode(this->mp3_decoder_, &this->input_buffer_current_, (int *) &this->input_buffer_length_,
-                      (int16_t *) this->output_buffer_, 0);
-  if (err) {
-    switch (err) {
-      case ERR_MP3_MAINDATA_UNDERFLOW:
-        // Not a problem. Next call to decode will provide more data.
-        return FileDecoderState::POTENTIALLY_FAILED;
-        break;
-      default:
-        // TODO: Better handle mp3 decoder errors
-        return FileDecoderState::FAILED;
-        break;
-    }
-  } else {
-    MP3FrameInfo mp3_frame_info;
-    MP3GetLastFrameInfo(this->mp3_decoder_, &mp3_frame_info);
-    if (mp3_frame_info.outputSamps > 0) {
-      int bytes_per_sample = (mp3_frame_info.bitsPerSample / 8);
-      this->output_buffer_length_ = mp3_frame_info.outputSamps * bytes_per_sample;
-      this->output_buffer_current_ = this->output_buffer_;
-
-      media_player::StreamInfo stream_info;
-      stream_info.channels = mp3_frame_info.nChans;
-      stream_info.sample_rate = mp3_frame_info.samprate;
-      stream_info.bits_per_sample = mp3_frame_info.bitsPerSample;
-      this->stream_info_ = stream_info;
-    }
-  }
-  // }
-  return FileDecoderState::MORE_TO_PROCESS;
-}
-
-FileDecoderState AudioDecoder::decode_flac_() {
-  if (!this->stream_info_.has_value()) {
-    // Header hasn't been read
-    auto result = this->flac_decoder_->read_header(this->input_buffer_length_);
-
-    size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
-    this->input_buffer_current_ += bytes_consumed;
-    this->input_buffer_length_ = this->flac_decoder_->get_bytes_left();
-
-    if (result == flac::FLAC_DECODER_HEADER_OUT_OF_DATA) {
-      return FileDecoderState::POTENTIALLY_FAILED;
-    }
-
-    if (result != flac::FLAC_DECODER_SUCCESS) {
-      printf("failed to read flac header. Error: %d\n", result);
-      return FileDecoderState::FAILED;
-    }
-
-    media_player::StreamInfo stream_info;
-    stream_info.channels = this->flac_decoder_->get_num_channels();
-    stream_info.sample_rate = this->flac_decoder_->get_sample_rate();
-    stream_info.bits_per_sample = this->flac_decoder_->get_sample_depth();
-
-    size_t flac_decoder_output_buffer_min_size = flac_decoder_->get_output_buffer_size();
-    if (this->internal_buffer_size_ < flac_decoder_output_buffer_min_size * sizeof(int16_t)) {
-      printf("output buffer is not big enough\n");
-      return FileDecoderState::FAILED;
-    }
-
-    return FileDecoderState::MORE_TO_PROCESS;
-  }
-
-  uint32_t output_samples = 0;
-  auto result =
-      this->flac_decoder_->decode_frame(this->input_buffer_length_, (int16_t *) this->output_buffer_, &output_samples);
-
-  if (result == flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
-    // Not an issue, just needs more data that we'll get next time.
-    return FileDecoderState::POTENTIALLY_FAILED;
-  } else if (result > flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
-    // Serious error, can't recover
-    printf("FLAC Decoder Error %d\n", result);
-    return FileDecoderState::FAILED;
-  }
-
-  // We have successfully decoded some input data and have new output data
-  size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
-  this->input_buffer_current_ += bytes_consumed;
-  this->input_buffer_length_ = this->flac_decoder_->get_bytes_left();
-
-  this->output_buffer_current_ = this->output_buffer_;
-  this->output_buffer_length_ = output_samples * sizeof(int16_t);
-
-  if (result == flac::FLAC_DECODER_NO_MORE_FRAMES) {
-    return FileDecoderState::END_OF_FILE;
-  }
-
-  return FileDecoderState::MORE_TO_PROCESS;
 }
 
 }  // namespace nabu

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -30,16 +30,15 @@ enum class FileDecoderState : uint8_t {
 
 class AudioDecoder {
  public:
-  AudioDecoder(esphome::RingBuffer *input_ring_buffer, esphome::RingBuffer *output_ring_buffer, size_t internal_buffer_size);
+  AudioDecoder(esphome::RingBuffer *input_ring_buffer, esphome::RingBuffer *output_ring_buffer,
+               size_t internal_buffer_size);
   ~AudioDecoder();
 
   void start(media_player::MediaFileType media_file_type);
 
   AudioDecoderState decode(bool stop_gracefully);
 
-  const optional<uint8_t> &get_channels() const { return this->channels_; }
-  const optional<uint8_t> &get_sample_depth() const { return this->sample_depth_; }
-  const optional<uint32_t> &get_sample_rate() const { return this->sample_rate_; }
+  const optional<media_player::StreamInfo> &get_stream_info() const { return this->stream_info_; }
 
  protected:
   FileDecoderState decode_wav_();
@@ -66,9 +65,7 @@ class AudioDecoder {
   flac::FLACDecoder *flac_decoder_{nullptr};
 
   media_player::MediaFileType media_file_type_{media_player::MediaFileType::NONE};
-  optional<uint8_t> channels_;
-  optional<uint8_t> sample_depth_;
-  optional<uint32_t> sample_rate_;
+  optional<media_player::StreamInfo> stream_info_{};
 
   size_t potentially_failed_count_{0};
   bool end_of_file_{false};

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -34,13 +34,15 @@ class AudioDecoder {
                size_t internal_buffer_size);
   ~AudioDecoder();
 
-  void start(media_player::MediaFileType media_file_type);
+  esp_err_t start(media_player::MediaFileType media_file_type);
 
   AudioDecoderState decode(bool stop_gracefully);
 
   const optional<media_player::StreamInfo> &get_stream_info() const { return this->stream_info_; }
 
  protected:
+  esp_err_t allocate_buffers_();
+
   FileDecoderState decode_wav_();
   FileDecoderState decode_mp3_();
   FileDecoderState decode_flac_();
@@ -49,12 +51,12 @@ class AudioDecoder {
   esphome::RingBuffer *output_ring_buffer_;
   size_t internal_buffer_size_;
 
-  uint8_t *input_buffer_;
-  uint8_t *input_buffer_current_;
+  uint8_t *input_buffer_{nullptr};
+  uint8_t *input_buffer_current_{nullptr};
   size_t input_buffer_length_;
 
-  uint8_t *output_buffer_;
-  uint8_t *output_buffer_current_;
+  uint8_t *output_buffer_{nullptr};
+  uint8_t *output_buffer_current_{nullptr};
   size_t output_buffer_length_;
 
   HMP3Decoder mp3_decoder_;

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -43,9 +43,9 @@ class AudioDecoder {
  protected:
   esp_err_t allocate_buffers_();
 
-  FileDecoderState decode_wav_();
-  FileDecoderState decode_mp3_();
   FileDecoderState decode_flac_();
+  FileDecoderState decode_mp3_();
+  FileDecoderState decode_wav_();
 
   esphome::RingBuffer *input_ring_buffer_;
   esphome::RingBuffer *output_ring_buffer_;
@@ -59,12 +59,12 @@ class AudioDecoder {
   uint8_t *output_buffer_current_{nullptr};
   size_t output_buffer_length_;
 
+  std::unique_ptr<flac::FLACDecoder> flac_decoder_;
+
   HMP3Decoder mp3_decoder_;
 
-  wav_decoder::WAVDecoder *wav_decoder_{nullptr};
+  std::unique_ptr<wav_decoder::WAVDecoder> wav_decoder_;
   size_t wav_bytes_left_;
-
-  flac::FLACDecoder *flac_decoder_{nullptr};
 
   media_player::MediaFileType media_file_type_{media_player::MediaFileType::NONE};
   optional<media_player::StreamInfo> stream_info_{};

--- a/esphome/components/nabu/audio_mixer.cpp
+++ b/esphome/components/nabu/audio_mixer.cpp
@@ -11,10 +11,11 @@ namespace esphome {
 namespace nabu {
 
 static const size_t INPUT_RING_BUFFER_SIZE = 32768;  // Audio samples
-static const size_t BUFFER_SIZE = 4096;              // Audio samples - keep small for fast pausing
+static const size_t BUFFER_SIZE = 9600;              // Audio samples - keep small for fast pausing
 static const size_t QUEUE_COUNT = 20;
 
 static const uint32_t TASK_STACK_SIZE = 3072;
+static const size_t DURATION_TASK_DELAY_MS = 20;
 
 size_t AudioMixer::write_media(uint8_t *buffer, size_t length) {
   size_t free_bytes = this->media_free();
@@ -130,13 +131,34 @@ void AudioMixer::mix_task_(void *params) {
   int16_t q15_ducking_ratio = (int16_t) (1 * std::pow(2, 15));  // esp-dsp using q15 fixed point numbers
   bool transfer_media = true;
 
+  size_t samples_per_transition = 1;
+
+  float target_ducking_ratio = 0.0f;
+  float starting_ducking_ratio = 0.0f;
+  size_t ducking_transition_samples_remaining = 0;
+
+  size_t current_ducking_step = 10;
+  const size_t total_ducking_steps = 10;
+  float factor_per_step = 0.0f;
   while (true) {
-    if (xQueueReceive(this_mixer->command_queue_, &command_event, (10 / portTICK_PERIOD_MS)) == pdTRUE) {
+    if (xQueueReceive(this_mixer->command_queue_, &command_event, pdMS_TO_TICKS(DURATION_TASK_DELAY_MS)) == pdTRUE) {
       if (command_event.command == CommandEventType::STOP) {
         break;
       } else if (command_event.command == CommandEventType::DUCK) {
-        float ducking_ratio = command_event.ducking_ratio;
-        q15_ducking_ratio = (int16_t) (ducking_ratio * std::pow(2, 15));  // convert float to q15 fixed point
+        target_ducking_ratio = command_event.ducking_ratio;
+        ducking_transition_samples_remaining = command_event.samples;
+
+        current_ducking_step = 0;
+        starting_ducking_ratio = this_mixer->ducking_ratio_;
+        this_mixer->ducking_ratio_ = target_ducking_ratio;
+
+        // Split the ducking into 10 equal sized steps over the number of samples remaining
+        samples_per_transition = command_event.samples / total_ducking_steps;
+
+        factor_per_step = (target_ducking_ratio - starting_ducking_ratio) / pow(2, total_ducking_steps);
+        printf("factor_per_step=%.5f; starting_ducking_ratio=%.3f\n", factor_per_step, starting_ducking_ratio);
+        // printf("new ducking ratio = %.3f\n", command_event.ducking_ratio);
+
       } else if (command_event.command == CommandEventType::PAUSE_MEDIA) {
         transfer_media = false;
       } else if (command_event.command == CommandEventType::RESUME_MEDIA) {
@@ -168,8 +190,55 @@ void AudioMixer::mix_task_(void *params) {
         if (media_available * transfer_media > 0) {
           media_bytes_read = this_mixer->media_ring_buffer_->read((void *) media_buffer, bytes_to_read, 0);
           if (media_bytes_read > 0) {
-            if (q15_ducking_ratio < (1 * std::pow(2, 15))) {
-              dsps_mulc_s16_ae32(media_buffer, combination_buffer, media_bytes_read, q15_ducking_ratio, 1, 1);
+            // if (q15_ducking_ratio < (1 * std::pow(2, 15))) {
+            if (ducking_transition_samples_remaining > 0) {
+              // We are transitioning
+              size_t samples_read = media_bytes_read / sizeof(int16_t);
+              size_t samples_left = ducking_transition_samples_remaining;
+
+              int16_t *current_media_buffer = media_buffer;
+              int16_t *current_combination_buffer = combination_buffer;
+
+              size_t samples_left_in_step = samples_left % samples_per_transition;
+              if (samples_left_in_step == 0) {
+                // Start of a new step
+                // ++current_ducking_step;
+                samples_left_in_step = samples_per_transition;
+              }
+              size_t samples_left_to_duck = std::min(samples_left_in_step, samples_read);
+
+              while (samples_left_to_duck > 0) {
+                float ducking_ratio = starting_ducking_ratio + pow(2, current_ducking_step) * factor_per_step;
+
+                q15_ducking_ratio = (int16_t) (ducking_ratio * std::pow(2, 15));  // convert float to q15 fixed point
+
+                dsps_mulc_s16_ae32(current_media_buffer, current_combination_buffer, samples_left_to_duck,
+                                   q15_ducking_ratio, 1, 1);
+
+                current_media_buffer += samples_left_to_duck;
+                current_combination_buffer += samples_left_to_duck;
+
+                samples_read -= samples_left_to_duck;
+                samples_left -= samples_left_to_duck;
+
+                samples_left_in_step = samples_left % samples_per_transition;
+                if (samples_left_in_step == 0) {
+                  // Start of a new step
+                  ++current_ducking_step;
+                  samples_left_in_step = samples_per_transition;
+                  printf("ducking_ratio transitioning from %.5f\n", ducking_ratio);
+                }
+                samples_left_to_duck = std::min(samples_left_in_step, samples_read);
+              }
+
+              std::memcpy((void *) media_buffer, (void *) combination_buffer, media_bytes_read);
+            } else if (this_mixer->ducking_ratio_ < 1.0f) {
+              // Old ducking value in place, but we are done transitioning
+              q15_ducking_ratio =
+                  (int16_t) (this_mixer->ducking_ratio_ * std::pow(2, 15));  // convert float to q15 fixed point
+
+              dsps_mulc_s16_ae32(media_buffer, combination_buffer, media_bytes_read / sizeof(int16_t),
+                                 q15_ducking_ratio, 1, 1);
               std::memcpy((void *) media_buffer, (void *) combination_buffer, media_bytes_read);
             }
           }
@@ -218,8 +287,16 @@ void AudioMixer::mix_task_(void *params) {
         } else if (announcement_bytes_read > 0) {
           bytes_written = this_mixer->output_ring_buffer_->write((void *) announcement_buffer, announcement_bytes_read);
         }
+
+        size_t samples_written = bytes_written / sizeof(int16_t);
+        if (ducking_transition_samples_remaining > 0) {
+          ducking_transition_samples_remaining -= std::min(samples_written, ducking_transition_samples_remaining);
+        }
+
       }
     }
+
+    // delay(DURATION_TASK_DELAY_MS);
   }
 
   event.type = EventType::STOPPING;

--- a/esphome/components/nabu/audio_mixer.cpp
+++ b/esphome/components/nabu/audio_mixer.cpp
@@ -53,8 +53,8 @@ size_t AudioMixer::write_announcement(uint8_t *buffer, size_t length) {
 
 void AudioMixer::start(const std::string &task_name, UBaseType_t priority) {
   if (this->task_handle_ == nullptr) {
-    this->task_handle_ = xTaskCreateStatic(AudioMixer::mix_task_, task_name.c_str(), 3072, (void *) this,
-                                           priority, this->stack_buffer_, &this->task_stack_);
+    this->task_handle_ = xTaskCreateStatic(AudioMixer::mix_task_, task_name.c_str(), 3072, (void *) this, priority,
+                                           this->stack_buffer_, &this->task_stack_);
   }
 }
 
@@ -70,9 +70,6 @@ void AudioMixer::mix_task_(void *params) {
   TaskEvent event;
   CommandEvent command_event;
 
-  //  ?big? assumption here is that incoming stream is 16 bits per sample... TODO: Check and verify this
-  // TODO: doesn't handle different sample rates
-  // TODO: doesn't handle different amount of channels
   ExternalRAMAllocator<int16_t> allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
   int16_t *media_buffer = allocator.allocate(BUFFER_SIZE);
   int16_t *announcement_buffer = allocator.allocate(BUFFER_SIZE);
@@ -186,17 +183,8 @@ void AudioMixer::mix_task_(void *params) {
           bytes_written = this_mixer->output_ring_buffer_->write((void *) media_buffer, media_bytes_read);
 
         } else if (announcement_bytes_read > 0) {
-          bytes_written =
-              this_mixer->output_ring_buffer_->write((void *) announcement_buffer, announcement_bytes_read);
+          bytes_written = this_mixer->output_ring_buffer_->write((void *) announcement_buffer, announcement_bytes_read);
         }
-
-        // if (bytes_written) {
-        //   event.type = EventType::RUNNING;
-        //   xQueueSend(this_mixer->event_queue_, &event, portMAX_DELAY);
-        // } else if (this_mixer->output_ring_buffer_->available() == 0) {
-        //   event.type = EventType::IDLE;
-        //   xQueueSend(this_mixer->event_queue_, &event, portMAX_DELAY);
-        // }
       }
     }
   }

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -42,6 +42,7 @@ enum class CommandEventType : uint8_t {
 struct CommandEvent {
   CommandEventType command;
   float ducking_ratio = 0.0;
+  size_t samples = 1;
 };
 
 class AudioMixer {
@@ -51,6 +52,10 @@ class AudioMixer {
 
   BaseType_t send_command(CommandEvent *command, TickType_t ticks_to_wait = portMAX_DELAY) {
     return xQueueSend(this->command_queue_, command, ticks_to_wait);
+  }
+
+  BaseType_t send_command_to_front(CommandEvent *command, TickType_t ticks_to_wait = portMAX_DELAY) {
+    return xQueueSendToFront(this->command_queue_, command, ticks_to_wait);
   }
 
   BaseType_t read_event(TaskEvent *event, TickType_t ticks_to_wait = 0) {
@@ -98,8 +103,15 @@ class AudioMixer {
   RingBuffer *get_media_ring_buffer() { return this->media_ring_buffer_.get(); }
   RingBuffer *get_announcement_ring_buffer() { return this->announcement_ring_buffer_.get(); }
 
+  float get_ducking_ratio() { return this->ducking_ratio_; }
+
  protected:
   esp_err_t allocate_buffers_();
+
+  float ducking_ratio_{1.0f};
+  // float target_ducking_ratio_{1.0f};
+  // float starting_ducking_ratio_{1.0f};
+  // size_t ducking_transition_samples_remaining_;
 
   static void mix_task_(void *params);
   TaskHandle_t task_handle_{nullptr};

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -41,8 +41,8 @@ enum class CommandEventType : uint8_t {
 
 struct CommandEvent {
   CommandEventType command;
-  float ducking_ratio = 0.0;
-  size_t samples = 1;
+  uint8_t decibel_reduction;
+  size_t transition_samples = 0;
 };
 
 class AudioMixer {
@@ -103,15 +103,8 @@ class AudioMixer {
   RingBuffer *get_media_ring_buffer() { return this->media_ring_buffer_.get(); }
   RingBuffer *get_announcement_ring_buffer() { return this->announcement_ring_buffer_.get(); }
 
-  float get_ducking_ratio() { return this->ducking_ratio_; }
-
  protected:
   esp_err_t allocate_buffers_();
-
-  float ducking_ratio_{1.0f};
-  // float target_ducking_ratio_{1.0f};
-  // float starting_ducking_ratio_{1.0f};
-  // size_t ducking_transition_samples_remaining_;
 
   static void mix_task_(void *params);
   TaskHandle_t task_handle_{nullptr};

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -99,6 +99,9 @@ class AudioMixer {
   RingBuffer *get_announcement_ring_buffer() { return this->announcement_ring_buffer_.get(); }
 
  protected:
+  esp_err_t allocate_buffers_();
+
+  static void mix_task_(void *params);
   TaskHandle_t task_handle_{nullptr};
   StaticTask_t task_stack_;
   StackType_t *stack_buffer_{nullptr};
@@ -106,8 +109,6 @@ class AudioMixer {
   std::unique_ptr<RingBuffer> output_ring_buffer_;
   QueueHandle_t event_queue_;
   QueueHandle_t command_queue_;
-
-  static void mix_task_(void *params);
 
   std::unique_ptr<RingBuffer> media_ring_buffer_;
   std::unique_ptr<RingBuffer> announcement_ring_buffer_;

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -46,8 +46,6 @@ struct CommandEvent {
 
 class AudioMixer {
  public:
-  AudioMixer();
-
   /// @brief Returns the number of bytes available to read from the ring buffer
   size_t available() { return this->output_ring_buffer_->available(); }
 
@@ -59,7 +57,7 @@ class AudioMixer {
     return xQueueReceive(this->event_queue_, event, ticks_to_wait);
   }
 
-  void start(const std::string &task_name, UBaseType_t priority = 1);
+  esp_err_t start(const std::string &task_name, UBaseType_t priority = 1);
 
   void stop() {
     vTaskDelete(this->task_handle_);

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -14,9 +14,10 @@ static const size_t HTTP_BUFFER_SIZE = 64 * 1024;
 static const size_t BUFFER_SIZE_SAMPLES = 32768;
 static const size_t BUFFER_SIZE_BYTES = BUFFER_SIZE_SAMPLES * sizeof(int16_t);
 
-static const uint32_t READER_TASK_STACK_SIZE = 8192;
-static const uint32_t DECODER_TASK_STACK_SIZE = 8192;
-static const uint32_t RESAMPLER_TASK_STACK_SIZE = 8192;
+static const uint32_t READER_TASK_STACK_SIZE = 4096;
+static const uint32_t DECODER_TASK_STACK_SIZE = 4096;
+static const uint32_t RESAMPLER_TASK_STACK_SIZE = 4096;
+static const size_t DURATION_TASK_DELAY_MS = 10;
 
 static const size_t INFO_ERROR_QUEUE_COUNT = 5;
 
@@ -161,7 +162,7 @@ AudioPipelineState AudioPipeline::get_state() {
             ESP_LOGE(TAG, "Media reader encountered an error: %s", esp_err_to_name(event.err.value()));
           } else if (event.file_type.has_value()) {
             ESP_LOGD(TAG, "Reading %s file type",
-                      media_player::media_player_file_type_to_string(event.file_type.value()));
+                     media_player::media_player_file_type_to_string(event.file_type.value()));
           }
 
           break;
@@ -317,7 +318,7 @@ void AudioPipeline::read_task_(void *params) {
         }
 
         // Block to give other tasks opportunity to run
-        delay(10);
+        delay(DURATION_TASK_DELAY_MS);
       }
     }
   }
@@ -390,7 +391,7 @@ void AudioPipeline::decode_task_(void *params) {
         }
 
         // Block to give other tasks opportunity to run
-        delay(10);
+        delay(DURATION_TASK_DELAY_MS);
       }
     }
   }
@@ -461,7 +462,7 @@ void AudioPipeline::resample_task_(void *params) {
         }
 
         // Block to give other tasks opportunity to run
-        delay(10);
+        delay(DURATION_TASK_DELAY_MS);
       }
     }
   }

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -93,12 +93,12 @@ AudioPipelineState AudioPipeline::get_state() {
   if (!this->read_task_handle_ && !this->decode_task_handle_ && !this->resample_task_handle_) {
     return AudioPipelineState::STOPPED;
   }
-  
+
   if ((event_bits & READER_MESSAGE_ERROR)) {
     xEventGroupClearBits(this->event_group_, READER_MESSAGE_ERROR);
     return AudioPipelineState::ERROR_READING;
   }
-  
+
   if ((event_bits & DECODER_MESSAGE_ERROR)) {
     xEventGroupClearBits(this->event_group_, DECODER_MESSAGE_ERROR);
     return AudioPipelineState::ERROR_DECODING;
@@ -110,7 +110,7 @@ AudioPipelineState AudioPipeline::get_state() {
   }
 
   if ((event_bits & READER_MESSAGE_FINISHED) && (event_bits & DECODER_MESSAGE_FINISHED) &&
-             (event_bits & RESAMPLER_MESSAGE_FINISHED)) {
+      (event_bits & RESAMPLER_MESSAGE_FINISHED)) {
     return AudioPipelineState::STOPPED;
   }
 
@@ -243,12 +243,10 @@ void AudioPipeline::decode_task_(void *params) {
           break;
         }
 
-        if (!has_stream_info && decoder.get_channels().has_value()) {
+        if (!has_stream_info && decoder.get_stream_info().has_value()) {
           has_stream_info = true;
 
-          this_pipeline->current_stream_info_.channels = decoder.get_channels().value();
-          this_pipeline->current_stream_info_.bits_per_sample = decoder.get_sample_depth().value();
-          this_pipeline->current_stream_info_.sample_rate = decoder.get_sample_rate().value();
+          this_pipeline->current_stream_info_ = decoder.get_stream_info().value();
 
           // Inform the resampler that the stream information is available
           xEventGroupSetBits(this_pipeline->event_group_, EventGroupBits::DECODER_MESSAGE_LOADED_STREAM_INFO);

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -42,7 +42,7 @@ class AudioPipeline {
   esp_err_t start(const std::string &uri, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
   esp_err_t start(media_player::MediaFile *media_file, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
 
-  void stop();
+  esp_err_t stop();
 
   AudioPipelineState get_state();
 

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -39,8 +39,8 @@ class AudioPipeline {
  public:
   AudioPipeline(AudioMixer *mixer, AudioPipelineType pipeline_type);
 
-  void start(const std::string &uri, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
-  void start(media_player::MediaFile *media_file, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
+  esp_err_t start(const std::string &uri, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
+  esp_err_t start(media_player::MediaFile *media_file, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
 
   void stop();
 
@@ -49,7 +49,8 @@ class AudioPipeline {
   void reset_ring_buffers();
 
  protected:
-  void common_start_(uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority);
+  esp_err_t allocate_buffers_();
+  esp_err_t common_start_(uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority);
 
   uint32_t target_sample_rate_;
 
@@ -67,7 +68,7 @@ class AudioPipeline {
   std::unique_ptr<RingBuffer> decoded_ring_buffer_;
   std::unique_ptr<RingBuffer> resampled_ring_buffer_;
 
-  EventGroupHandle_t event_group_;
+  EventGroupHandle_t event_group_{nullptr};
 
   static void read_task_(void *params);
   TaskHandle_t read_task_handle_{nullptr};

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -17,8 +17,6 @@
 #include <freertos/event_groups.h>
 #include <freertos/queue.h>
 
-
-
 namespace esphome {
 namespace nabu {
 
@@ -35,12 +33,28 @@ enum class AudioPipelineState : uint8_t {
   ERROR_RESAMPLING,
 };
 
+enum class InfoErrorSource : uint8_t {
+  READER = 0,
+  DECODER,
+  RESAMPLER,
+};
+
+struct InfoErrorEvent {
+  InfoErrorSource source;
+  optional<esp_err_t> err;
+  optional<media_player::MediaFileType> file_type;
+  optional<media_player::StreamInfo> stream_info;
+  optional<ResampleInfo> resample_info;
+};
+
 class AudioPipeline {
  public:
   AudioPipeline(AudioMixer *mixer, AudioPipelineType pipeline_type);
 
-  esp_err_t start(const std::string &uri, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
-  esp_err_t start(media_player::MediaFile *media_file, uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority = 1);
+  esp_err_t start(const std::string &uri, uint32_t target_sample_rate, const std::string &task_name,
+                  UBaseType_t priority = 1);
+  esp_err_t start(media_player::MediaFile *media_file, uint32_t target_sample_rate, const std::string &task_name,
+                  UBaseType_t priority = 1);
 
   esp_err_t stop();
 
@@ -61,6 +75,7 @@ class AudioPipeline {
 
   media_player::MediaFileType current_media_file_type_;
   media_player::StreamInfo current_stream_info_;
+  ResampleInfo current_resample_info_;
 
   AudioPipelineType pipeline_type_;
 
@@ -68,7 +83,11 @@ class AudioPipeline {
   std::unique_ptr<RingBuffer> decoded_ring_buffer_;
   std::unique_ptr<RingBuffer> resampled_ring_buffer_;
 
+  // Handles basic control/state of the three tasks
   EventGroupHandle_t event_group_{nullptr};
+
+  // Receives detailed info (file type, stream info, resampling info) or specific errors from the three tasks
+  QueueHandle_t info_error_queue_{nullptr};
 
   static void read_task_(void *params);
   TaskHandle_t read_task_handle_{nullptr};

--- a/esphome/components/nabu/audio_reader.cpp
+++ b/esphome/components/nabu/audio_reader.cpp
@@ -32,32 +32,35 @@ esp_err_t AudioReader::allocate_buffers_() {
   return ESP_OK;
 }
 
-media_player::MediaFileType AudioReader::start(media_player::MediaFile *media_file) {
-  esp_err_t err = this->allocate_buffers_();
+esp_err_t AudioReader::start(media_player::MediaFile *media_file, media_player::MediaFileType &file_type) {
+  file_type = media_player::MediaFileType::NONE;
 
+  esp_err_t err = this->allocate_buffers_();
   if (err != ESP_OK) {
-    return media_player::MediaFileType::NONE;
+    return err;
   }
 
   this->current_media_file_ = media_file;
 
   this->media_file_data_current_ = media_file->data;
   this->media_file_bytes_left_ = media_file->length;
+  file_type = media_file->file_type;
 
-  return media_file->file_type;
+  return ESP_OK;
 }
 
-media_player::MediaFileType AudioReader::start(const std::string &uri) {
-  esp_err_t err = this->allocate_buffers_();
+esp_err_t AudioReader::start(const std::string &uri, media_player::MediaFileType &file_type) {
+  file_type = media_player::MediaFileType::NONE;
 
+  esp_err_t err = this->allocate_buffers_();
   if (err != ESP_OK) {
-    return media_player::MediaFileType::NONE;
+    return err;
   }
 
   this->cleanup_connection_();
 
   if (uri.empty()) {
-    return media_player::MediaFileType::NONE;
+    return ESP_ERR_INVALID_ARG;
   }
 
   esp_http_client_config_t config = {
@@ -69,42 +72,34 @@ media_player::MediaFileType AudioReader::start(const std::string &uri) {
   this->client_ = esp_http_client_init(&config);
 
   if (this->client_ == nullptr) {
-    printf("Failed to initialize HTTP connection");
-    return media_player::MediaFileType::NONE;
+    return ESP_FAIL;
   }
 
   if ((err = esp_http_client_open(this->client_, 0)) != ESP_OK) {
-    printf("Failed to open HTTP connection");
     this->cleanup_connection_();
-    return media_player::MediaFileType::NONE;
+    return err;
   }
 
   int content_length = esp_http_client_fetch_headers(this->client_);
 
-  // TODO: Figure out how to handle this better! Music Assistant streams don't send a content length
-  // if (content_length <= 0) {
-  //   printf("Fialed to get content length");
-  //   this->cleanup_connection_(client);
-  //   return media_player::MediaFileType::NONE;
-  // }
-
   char url[500];
-  if (esp_http_client_get_url(this->client_, url, 500) != ESP_OK) {
+  err = esp_http_client_get_url(this->client_, url, 500);
+  if (err != ESP_OK) {
     this->cleanup_connection_();
-    return media_player::MediaFileType::NONE;
+    return err;
   }
 
   std::string url_string = url;
 
   if (str_endswith(url_string, ".wav")) {
-    return media_player::MediaFileType::WAV;
+    file_type = media_player::MediaFileType::WAV;
   } else if (str_endswith(url_string, ".mp3")) {
-    return media_player::MediaFileType::MP3;
+    file_type = media_player::MediaFileType::MP3;
   } else if (str_endswith(url_string, ".flac")) {
-    return media_player::MediaFileType::FLAC;
+    file_type = media_player::MediaFileType::FLAC;
   }
 
-  return media_player::MediaFileType::NONE;
+  return ESP_OK;
 }
 
 AudioReaderState AudioReader::read() {

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -28,13 +28,15 @@ class AudioReader {
   AudioReaderState read();
 
  protected:
+  esp_err_t allocate_buffers_();
+
   AudioReaderState file_read_();
   AudioReaderState http_read_();
 
   void cleanup_connection_();
 
   esphome::RingBuffer *output_ring_buffer_;
-  uint8_t *transfer_buffer_;
+  uint8_t *transfer_buffer_{nullptr};
   size_t transfer_buffer_size_;
 
   esp_http_client_handle_t client_{nullptr};

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -22,8 +22,8 @@ class AudioReader {
   AudioReader(esphome::RingBuffer *output_ring_buffer, size_t transfer_buffer_size);
   ~AudioReader();
 
-  media_player::MediaFileType start(const std::string &uri);
-  media_player::MediaFileType start(media_player::MediaFile *media_file);
+  esp_err_t start(const std::string &uri, media_player::MediaFileType &file_type);
+  esp_err_t start(media_player::MediaFile *media_file, media_player::MediaFileType &file_type);
 
   AudioReaderState read();
 

--- a/esphome/components/nabu/audio_resampler.cpp
+++ b/esphome/components/nabu/audio_resampler.cpp
@@ -65,10 +65,10 @@ esp_err_t AudioResampler::allocate_buffers_() {
   return ESP_OK;
 }
 
-bool AudioResampler::start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate) {
+esp_err_t AudioResampler::start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate) {
   esp_err_t err = this->allocate_buffers_();
   if (err != ESP_OK) {
-    return false;
+    return err;
   }
 
   this->stream_info_ = stream_info;
@@ -87,7 +87,7 @@ bool AudioResampler::start(media_player::StreamInfo &stream_info, uint32_t targe
 
   if ((stream_info.channels > 2) || (stream_info_.bits_per_sample != 16)) {
     // TODO: Make these values configurable
-    return false;
+    return ESP_ERR_NOT_SUPPORTED;
   }
 
   if (stream_info.channels > 0) {
@@ -167,7 +167,7 @@ bool AudioResampler::start(media_player::StreamInfo &stream_info, uint32_t targe
     this->needs_resampling_ = false;
   }
 
-  return true;
+  return ESP_OK;
 }
 
 AudioResamplerState AudioResampler::resample(bool stop_gracefully) {

--- a/esphome/components/nabu/audio_resampler.h
+++ b/esphome/components/nabu/audio_resampler.h
@@ -2,8 +2,6 @@
 
 #ifdef USE_ESP_IDF
 
-#include "audio_pipeline.h"
-
 #include "biquad.h"
 #include "resampler.h"
 
@@ -24,6 +22,11 @@ enum class AudioResamplerState : uint8_t {
   FAILED,
 };
 
+struct ResampleInfo {
+  bool resample;
+  bool mono_to_stereo;
+};
+
 class AudioResampler {
  public:
   AudioResampler(esphome::RingBuffer *input_ring_buffer, esphome::RingBuffer *output_ring_buffer,
@@ -34,7 +37,7 @@ class AudioResampler {
   /// @param stream_info the incoming sample rate, bits per sample, and number of channels
   /// @param target_sample_rate the necessary sample rate to convert to
   /// @return ESP_OK if it is able to convert the incoming stream or an error otherwise
-  esp_err_t start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate);
+  esp_err_t start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate, ResampleInfo &resample_info);
 
   AudioResamplerState resample(bool stop_gracefully);
 
@@ -62,8 +65,9 @@ class AudioResampler {
   size_t float_output_buffer_length_;
 
   media_player::StreamInfo stream_info_;
-  bool needs_resampling_{false};
-  bool needs_mono_to_stereo_{false};
+  ResampleInfo resample_info_;
+  // bool needs_resampling_{false};
+  // bool needs_mono_to_stereo_{false};
 
   Resample *resampler_{nullptr};
 
@@ -87,7 +91,6 @@ class AudioResampler {
 
   int16_t float_to_q15_(float q, uint32_t shift);
   int8_t generate_q15_fir_coefficients_(int16_t *fir_coeffs, const unsigned int fir_len, const float ft);
-
 };
 }  // namespace nabu
 }  // namespace esphome

--- a/esphome/components/nabu/audio_resampler.h
+++ b/esphome/components/nabu/audio_resampler.h
@@ -33,8 +33,8 @@ class AudioResampler {
   /// @brief Sets up the various bits necessary to resample
   /// @param stream_info the incoming sample rate, bits per sample, and number of channels
   /// @param target_sample_rate the necessary sample rate to convert to
-  /// @return True if it convert the incoming stream, false otherwise
-  bool start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate);
+  /// @return ESP_OK if it is able to convert the incoming stream or an error otherwise
+  esp_err_t start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate);
 
   AudioResamplerState resample(bool stop_gracefully);
 

--- a/esphome/components/nabu/audio_resampler.h
+++ b/esphome/components/nabu/audio_resampler.h
@@ -39,24 +39,26 @@ class AudioResampler {
   AudioResamplerState resample(bool stop_gracefully);
 
  protected:
+  esp_err_t allocate_buffers_();
+
   esphome::RingBuffer *input_ring_buffer_;
   esphome::RingBuffer *output_ring_buffer_;
   size_t internal_buffer_samples_;
 
-  int16_t *input_buffer_;
-  int16_t *input_buffer_current_;
+  int16_t *input_buffer_{nullptr};
+  int16_t *input_buffer_current_{nullptr};
   size_t input_buffer_length_;
 
-  int16_t *output_buffer_;
-  int16_t *output_buffer_current_;
+  int16_t *output_buffer_{nullptr};
+  int16_t *output_buffer_current_{nullptr};
   size_t output_buffer_length_;
 
-  float *float_input_buffer_;
-  float *float_input_buffer_current_;
+  float *float_input_buffer_{nullptr};
+  float *float_input_buffer_current_{nullptr};
   size_t float_input_buffer_length_;
 
-  float *float_output_buffer_;
-  float *float_output_buffer_current_;
+  float *float_output_buffer_{nullptr};
+  float *float_output_buffer_current_{nullptr};
   size_t float_output_buffer_length_;
 
   media_player::StreamInfo stream_info_;

--- a/esphome/components/nabu/biquad.c
+++ b/esphome/components/nabu/biquad.c
@@ -8,86 +8,88 @@
 
 // biquad.c
 
+#ifdef USE_ESP_IDF
+
 #include "biquad.h"
 
 // Second-order Lowpass
 
-void biquad_lowpass (BiquadCoefficients *filter, double frequency)
-{
-    double Q = sqrt (0.5), K = tan (M_PI * frequency);
-    double norm = 1.0 / (1.0 + K / Q + K * K);
+void biquad_lowpass(BiquadCoefficients *filter, double frequency) {
+  double Q = sqrt(0.5), K = tan(M_PI * frequency);
+  double norm = 1.0 / (1.0 + K / Q + K * K);
 
-    filter->a0 = K * K * norm;
-    filter->a1 = 2 * filter->a0;
-    filter->a2 = filter->a0;
-    filter->b1 = 2.0 * (K * K - 1.0) * norm;
-    filter->b2 = (1.0 - K / Q + K * K) * norm;
+  filter->a0 = K * K * norm;
+  filter->a1 = 2 * filter->a0;
+  filter->a2 = filter->a0;
+  filter->b1 = 2.0 * (K * K - 1.0) * norm;
+  filter->b2 = (1.0 - K / Q + K * K) * norm;
 }
 
 // Second-order Highpass
 
-void biquad_highpass (BiquadCoefficients *filter, double frequency)
-{
-    double Q = sqrt (0.5), K = tan (M_PI * frequency);
-    double norm = 1.0 / (1.0 + K / Q + K * K);
+void biquad_highpass(BiquadCoefficients *filter, double frequency) {
+  double Q = sqrt(0.5), K = tan(M_PI * frequency);
+  double norm = 1.0 / (1.0 + K / Q + K * K);
 
-    filter->a0 = norm;
-    filter->a1 = -2.0 * norm;
-    filter->a2 = filter->a0;
-    filter->b1 = 2.0 * (K * K - 1.0) * norm;
-    filter->b2 = (1.0 - K / Q + K * K) * norm;
+  filter->a0 = norm;
+  filter->a1 = -2.0 * norm;
+  filter->a2 = filter->a0;
+  filter->b1 = 2.0 * (K * K - 1.0) * norm;
+  filter->b2 = (1.0 - K / Q + K * K) * norm;
 }
 
 // Initialize the specified biquad filter with the given parameters. Note that the "gain" parameter is supplied here
 // to save a multiply every time the filter in applied.
 
-void biquad_init (Biquad *f, const BiquadCoefficients *coeffs, float gain)
-{
-    f->coeffs = *coeffs;
-    f->coeffs.a0 *= gain;
-    f->coeffs.a1 *= gain;
-    f->coeffs.a2 *= gain;
-    f->in_d1 = f->in_d2 = 0.0F;
-    f->out_d1 = f->out_d2 = 0.0F;
-    f->first_order = (coeffs->a2 == 0.0F && coeffs->b2 == 0.0F);
+void biquad_init(Biquad *f, const BiquadCoefficients *coeffs, float gain) {
+  f->coeffs = *coeffs;
+  f->coeffs.a0 *= gain;
+  f->coeffs.a1 *= gain;
+  f->coeffs.a2 *= gain;
+  f->in_d1 = f->in_d2 = 0.0F;
+  f->out_d1 = f->out_d2 = 0.0F;
+  f->first_order = (coeffs->a2 == 0.0F && coeffs->b2 == 0.0F);
 }
 
 // Apply the supplied sample to the specified biquad filter, which must have been initialized with biquad_init().
 
-float biquad_apply_sample (Biquad *f, float input)
-{
-    float sum;
+float biquad_apply_sample(Biquad *f, float input) {
+  float sum;
 
-    if (f->first_order)
-        sum = (input * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) - (f->coeffs.b1 * f->out_d1);
-    else
-        sum = (input * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) + (f->in_d2 * f->coeffs.a2) - (f->coeffs.b1 * f->out_d1) - (f->coeffs.b2 * f->out_d2);
+  if (f->first_order)
+    sum = (input * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) - (f->coeffs.b1 * f->out_d1);
+  else
+    sum = (input * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) + (f->in_d2 * f->coeffs.a2) - (f->coeffs.b1 * f->out_d1) -
+          (f->coeffs.b2 * f->out_d2);
 
-    f->out_d2 = f->out_d1;
-    f->out_d1 = sum;
-    f->in_d2 = f->in_d1;
-    f->in_d1 = input;
-    return sum;
+  f->out_d2 = f->out_d1;
+  f->out_d1 = sum;
+  f->in_d2 = f->in_d1;
+  f->in_d1 = input;
+  return sum;
 }
 
 // Apply the supplied buffer to the specified biquad filter, which must have been initialized with biquad_init().
 
-void biquad_apply_buffer (Biquad *f, float *buffer, int num_samples, int stride)
-{
-    if (f->first_order) while (num_samples--) {
-        float sum = (*buffer * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) - (f->coeffs.b1 * f->out_d1);
-        f->out_d2 = f->out_d1;
-        f->in_d2 = f->in_d1;
-        f->in_d1 = *buffer;
-        *buffer = f->out_d1 = sum;
-        buffer += stride;
+void biquad_apply_buffer(Biquad *f, float *buffer, int num_samples, int stride) {
+  if (f->first_order)
+    while (num_samples--) {
+      float sum = (*buffer * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) - (f->coeffs.b1 * f->out_d1);
+      f->out_d2 = f->out_d1;
+      f->in_d2 = f->in_d1;
+      f->in_d1 = *buffer;
+      *buffer = f->out_d1 = sum;
+      buffer += stride;
     }
-    else while (num_samples--) {
-        float sum = (*buffer * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) + (f->in_d2 * f->coeffs.a2) - (f->coeffs.b1 * f->out_d1) - (f->coeffs.b2 * f->out_d2);
-        f->out_d2 = f->out_d1;
-        f->in_d2 = f->in_d1;
-        f->in_d1 = *buffer;
-        *buffer = f->out_d1 = sum;
-        buffer += stride;
+  else
+    while (num_samples--) {
+      float sum = (*buffer * f->coeffs.a0) + (f->in_d1 * f->coeffs.a1) + (f->in_d2 * f->coeffs.a2) -
+                  (f->coeffs.b1 * f->out_d1) - (f->coeffs.b2 * f->out_d2);
+      f->out_d2 = f->out_d1;
+      f->in_d2 = f->in_d1;
+      f->in_d1 = *buffer;
+      *buffer = f->out_d1 = sum;
+      buffer += stride;
     }
 }
+#endif

--- a/esphome/components/nabu/biquad.h
+++ b/esphome/components/nabu/biquad.h
@@ -9,34 +9,37 @@
 
 // biquad.h
 
+#ifdef USE_ESP_IDF
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <math.h>
 
 typedef struct {
-    float a0, a1, a2, b1, b2;
+  float a0, a1, a2, b1, b2;
 } BiquadCoefficients;
 
 typedef struct {
-    BiquadCoefficients coeffs;  // coefficients
-    float in_d1, in_d2;	        // delayed input
-    float out_d1, out_d2;	// delayed output
-    int first_order;            // optimization
+  BiquadCoefficients coeffs;  // coefficients
+  float in_d1, in_d2;         // delayed input
+  float out_d1, out_d2;       // delayed output
+  int first_order;            // optimization
 } Biquad;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void biquad_init (Biquad *f, const BiquadCoefficients *coeffs, float gain);
+void biquad_init(Biquad *f, const BiquadCoefficients *coeffs, float gain);
 
-void biquad_lowpass (BiquadCoefficients *filter, double frequency);
-void biquad_highpass (BiquadCoefficients *filter, double frequency);
+void biquad_lowpass(BiquadCoefficients *filter, double frequency);
+void biquad_highpass(BiquadCoefficients *filter, double frequency);
 
-void biquad_apply_buffer (Biquad *f, float *buffer, int num_samples, int stride);
-float biquad_apply_sample (Biquad *f, float input);
+void biquad_apply_buffer(Biquad *f, float *buffer, int num_samples, int stride);
+float biquad_apply_sample(Biquad *f, float input);
 
 #ifdef __cplusplus
 }
+#endif
 #endif

--- a/esphome/components/nabu/flac_decoder.cpp
+++ b/esphome/components/nabu/flac_decoder.cpp
@@ -1,3 +1,5 @@
+#ifdef USE_ESP_IDF
+
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -432,3 +434,4 @@ int64_t FLACDecoder::read_rice_sint(uint8_t param) {
 void FLACDecoder::align_to_byte() { this->bit_buffer_length_ -= (this->bit_buffer_length_ % 8); }  // align_to_byte
 
 }  // namespace flac
+#endif

--- a/esphome/components/nabu/flac_decoder.h
+++ b/esphome/components/nabu/flac_decoder.h
@@ -4,6 +4,8 @@
 // Uses some small parts from: https://github.com/schreibfaul1/ESP32-audioI2S/
 // See also: https://xiph.org/flac/format.html
 
+#ifdef USE_ESP_IDF
+
 #ifndef _FLAC_DECODER_H
 #define _FLAC_DECODER_H
 
@@ -173,4 +175,5 @@ class FLACDecoder {
 
 }  // namespace flac
 
+#endif
 #endif

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -47,6 +47,7 @@ TYPE_WEB = "web"
 
 CONF_FILES = "files"
 CONF_SAMPLE_RATE = "sample_rate"
+CONF_VOLUME_INCREMENT = "volume_increment"
 
 nabu_ns = cg.esphome_ns.namespace("nabu")
 NabuMediaPlayer = nabu_ns.class_("NabuMediaPlayer")
@@ -181,6 +182,7 @@ CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
         cv.Optional(CONF_BITS_PER_SAMPLE, default="16bit"): cv.All(
             _validate_bits, cv.enum(BITS_PER_SAMPLE)
         ),
+        cv.Optional(CONF_VOLUME_INCREMENT, default=0.05): cv.percentage,
         cv.Optional(CONF_FILES): cv.ensure_list(MEDIA_FILE_TYPE_SCHEMA),
     }
 ).extend(i2c.i2c_device_schema(0x18))
@@ -206,9 +208,10 @@ async def to_code(config):
     cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
     cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
+    
+    cg.add(var.set_volume_increment(config[CONF_VOLUME_INCREMENT]))
 
     if files_list := config.get(CONF_FILES):
-        media_files = []
         for file_config in files_list:
             conf_file = file_config[CONF_FILE]
             file_source = conf_file[CONF_TYPE]

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -12,6 +12,7 @@ from esphome import automation, external_files, pins
 from esphome.components import esp32, i2c, media_player
 from esphome.components.media_player import MediaFile, MEDIA_FILE_TYPE_ENUM
 from esphome.const import (
+    CONF_DURATION,
     CONF_FILE,
     CONF_ID,
     CONF_PATH,
@@ -47,7 +48,6 @@ TYPE_LOCAL = "local"
 TYPE_WEB = "web"
 
 CONF_DECIBEL_REDUCTION = "decibel_reduction"
-CONF_TRANSITION_DURATION = "transition_duration"
 
 CONF_FILES = "files"
 CONF_SAMPLE_RATE = "sample_rate"
@@ -262,7 +262,7 @@ DUCKING_SET_SCHEMA = cv.Schema(
         cv.Required(CONF_DECIBEL_REDUCTION): cv.templatable(
             cv.int_range(min=0, max=51)
         ),
-        cv.Optional(CONF_TRANSITION_DURATION, default=0.0): cv.templatable(cv.float_),
+        cv.Optional(CONF_DURATION, default="0.0s"): cv.templatable(cv.positive_time_period_seconds),
     }
 )
 
@@ -275,8 +275,8 @@ async def ducking_set_to_code(config, action_id, template_arg, args):
         config[CONF_DECIBEL_REDUCTION], args, cg.uint8
     )
     cg.add(var.set_decibel_reduction(decibel_reduction))
-    transition_duration = await cg.templatable(
-        config[CONF_TRANSITION_DURATION], args, cg.float_
+    duration = await cg.templatable(
+        config[CONF_DURATION], args, cg.float_
     )
-    cg.add(var.set_transition_duration(transition_duration))
+    cg.add(var.set_duration(duration))
     return var

--- a/esphome/components/nabu/mp3_decoder.cpp
+++ b/esphome/components/nabu/mp3_decoder.cpp
@@ -40,6 +40,8 @@
  *
  **************************************************************************************/
 
+#ifdef USE_ESP_IDF
+
 #include "mp3_decoder.h"
 #include "esphome/core/helpers.h"
 
@@ -60,30 +62,21 @@ const int samplerateTab[3][3] = {
 const short bitrateTab[3][3][15] = {
     {
         /* MPEG-1 */
-        {0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416,
-         448}, /* Layer 1 */
-        {0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320,
-         384}, /* Layer 2 */
-        {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256,
-         320}, /* Layer 3 */
+        {0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448}, /* Layer 1 */
+        {0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384},    /* Layer 2 */
+        {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320},     /* Layer 3 */
     },
     {
         /* MPEG-2 */
-        {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224,
-         256}, /* Layer 1 */
-        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144,
-         160}, /* Layer 2 */
-        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144,
-         160}, /* Layer 3 */
+        {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, /* Layer 1 */
+        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      /* Layer 2 */
+        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      /* Layer 3 */
     },
     {
         /* MPEG-2.5 */
-        {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224,
-         256}, /* Layer 1 */
-        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144,
-         160}, /* Layer 2 */
-        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144,
-         160}, /* Layer 3 */
+        {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}, /* Layer 1 */
+        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      /* Layer 2 */
+        {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},      /* Layer 3 */
     },
 };
 
@@ -115,30 +108,21 @@ const short sideBytesTab[3][2] = {
 const short slotTab[3][3][15] = {
     {
         /* MPEG-1 */
-        {0, 104, 130, 156, 182, 208, 261, 313, 365, 417, 522, 626, 731, 835,
-         1044}, /* 44 kHz */
-        {0, 96, 120, 144, 168, 192, 240, 288, 336, 384, 480, 576, 672, 768,
-         960}, /* 48 kHz */
-        {0, 144, 180, 216, 252, 288, 360, 432, 504, 576, 720, 864, 1008, 1152,
-         1440}, /* 32 kHz */
+        {0, 104, 130, 156, 182, 208, 261, 313, 365, 417, 522, 626, 731, 835, 1044},   /* 44 kHz */
+        {0, 96, 120, 144, 168, 192, 240, 288, 336, 384, 480, 576, 672, 768, 960},     /* 48 kHz */
+        {0, 144, 180, 216, 252, 288, 360, 432, 504, 576, 720, 864, 1008, 1152, 1440}, /* 32 kHz */
     },
     {
         /* MPEG-2 */
-        {0, 26, 52, 78, 104, 130, 156, 182, 208, 261, 313, 365, 417, 470,
-         522}, /* 22 kHz */
-        {0, 24, 48, 72, 96, 120, 144, 168, 192, 240, 288, 336, 384, 432,
-         480}, /* 24 kHz */
-        {0, 36, 72, 108, 144, 180, 216, 252, 288, 360, 432, 504, 576, 648,
-         720}, /* 16 kHz */
+        {0, 26, 52, 78, 104, 130, 156, 182, 208, 261, 313, 365, 417, 470, 522},  /* 22 kHz */
+        {0, 24, 48, 72, 96, 120, 144, 168, 192, 240, 288, 336, 384, 432, 480},   /* 24 kHz */
+        {0, 36, 72, 108, 144, 180, 216, 252, 288, 360, 432, 504, 576, 648, 720}, /* 16 kHz */
     },
     {
         /* MPEG-2.5 */
-        {0, 52, 104, 156, 208, 261, 313, 365, 417, 522, 626, 731, 835, 940,
-         1044}, /* 11 kHz */
-        {0, 48, 96, 144, 192, 240, 288, 336, 384, 480, 576, 672, 768, 864,
-         960}, /* 12 kHz */
-        {0, 72, 144, 216, 288, 360, 432, 504, 576, 720, 864, 1008, 1152, 1296,
-         1440}, /*  8 kHz */
+        {0, 52, 104, 156, 208, 261, 313, 365, 417, 522, 626, 731, 835, 940, 1044},    /* 11 kHz */
+        {0, 48, 96, 144, 192, 240, 288, 336, 384, 480, 576, 672, 768, 864, 960},      /* 12 kHz */
+        {0, 72, 144, 216, 288, 360, 432, 504, 576, 720, 864, 1008, 1152, 1296, 1440}, /*  8 kHz */
     },
 };
 
@@ -149,75 +133,58 @@ const short slotTab[3][3][15] = {
  */
 const SFBandTable sfBandTable[3][3] = {
     {/* MPEG-1 (44, 48, 32 kHz) */
-     {{0,  4,  8,   12,  16,  20,  24,  30,  36,  44,  52, 62,
-       74, 90, 110, 134, 162, 196, 238, 288, 342, 418, 576},
+     {{0, 4, 8, 12, 16, 20, 24, 30, 36, 44, 52, 62, 74, 90, 110, 134, 162, 196, 238, 288, 342, 418, 576},
       {0, 4, 8, 12, 16, 22, 30, 40, 52, 66, 84, 106, 136, 192}},
-     {{0,  4,  8,   12,  16,  20,  24,  30,  36,  42,  50, 60,
-       72, 88, 106, 128, 156, 190, 230, 276, 330, 384, 576},
+     {{0, 4, 8, 12, 16, 20, 24, 30, 36, 42, 50, 60, 72, 88, 106, 128, 156, 190, 230, 276, 330, 384, 576},
       {0, 4, 8, 12, 16, 22, 28, 38, 50, 64, 80, 100, 126, 192}},
-     {{0,  4,   8,   12,  16,  20,  24,  30,  36,  44,  54, 66,
-       82, 102, 126, 156, 194, 240, 296, 364, 448, 550, 576},
+     {{0, 4, 8, 12, 16, 20, 24, 30, 36, 44, 54, 66, 82, 102, 126, 156, 194, 240, 296, 364, 448, 550, 576},
       {0, 4, 8, 12, 16, 22, 30, 42, 58, 78, 104, 138, 180, 192}}},
 
     {
         /* MPEG-2 (22, 24, 16 kHz) */
-        {{0,   6,   12,  18,  24,  30,  36,  44,  54,  66,  80, 96,
-          116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
+        {{0, 6, 12, 18, 24, 30, 36, 44, 54, 66, 80, 96, 116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
          {0, 4, 8, 12, 18, 24, 32, 42, 56, 74, 100, 132, 174, 192}},
-        {{0,   6,   12,  18,  24,  30,  36,  44,  54,  66,  80, 96,
-          114, 136, 162, 194, 232, 278, 332, 394, 464, 540, 576},
+        {{0, 6, 12, 18, 24, 30, 36, 44, 54, 66, 80, 96, 114, 136, 162, 194, 232, 278, 332, 394, 464, 540, 576},
          {0, 4, 8, 12, 18, 26, 36, 48, 62, 80, 104, 136, 180, 192}},
-        {{0,   6,   12,  18,  24,  30,  36,  44,  54,  66,  80, 96,
-          116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
+        {{0, 6, 12, 18, 24, 30, 36, 44, 54, 66, 80, 96, 116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
          {0, 4, 8, 12, 18, 26, 36, 48, 62, 80, 104, 134, 174, 192}},
     },
 
     {
         /* MPEG-2.5 (11, 12, 8 kHz) */
-        {{0,   6,   12,  18,  24,  30,  36,  44,  54,  66,  80, 96,
-          116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
+        {{0, 6, 12, 18, 24, 30, 36, 44, 54, 66, 80, 96, 116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
          {0, 4, 8, 12, 18, 26, 36, 48, 62, 80, 104, 134, 174, 192}},
-        {{0,   6,   12,  18,  24,  30,  36,  44,  54,  66,  80, 96,
-          116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
+        {{0, 6, 12, 18, 24, 30, 36, 44, 54, 66, 80, 96, 116, 140, 168, 200, 238, 284, 336, 396, 464, 522, 576},
          {0, 4, 8, 12, 18, 26, 36, 48, 62, 80, 104, 134, 174, 192}},
-        {{0,   12,  24,  36,  48,  60,  72,  88,  108, 132, 160, 192,
-          232, 280, 336, 400, 476, 566, 568, 570, 572, 574, 576},
+        {{0, 12, 24, 36, 48, 60, 72, 88, 108, 132, 160, 192, 232, 280, 336, 400, 476, 566, 568, 570, 572, 574, 576},
          {0, 8, 16, 24, 36, 52, 72, 96, 124, 160, 162, 164, 166, 192}},
     },
 };
 
 const int imdctWin[4][36] = {
     {
-        0x02aace8b, 0x07311c28, 0x0a868fec, 0x0c913b52, 0x0d413ccd, 0x0c913b52,
-        0x0a868fec, 0x07311c28, 0x02aace8b, 0xfd16d8dd, 0xf6a09e66, 0xef7a6275,
-        0xe7dbc161, 0xe0000000, 0xd8243e9f, 0xd0859d8b, 0xc95f619a, 0xc2e92723,
-        0xbd553175, 0xb8cee3d8, 0xb5797014, 0xb36ec4ae, 0xb2bec333, 0xb36ec4ae,
-        0xb5797014, 0xb8cee3d8, 0xbd553175, 0xc2e92723, 0xc95f619a, 0xd0859d8b,
-        0xd8243e9f, 0xe0000000, 0xe7dbc161, 0xef7a6275, 0xf6a09e66, 0xfd16d8dd,
+        0x02aace8b, 0x07311c28, 0x0a868fec, 0x0c913b52, 0x0d413ccd, 0x0c913b52, 0x0a868fec, 0x07311c28, 0x02aace8b,
+        0xfd16d8dd, 0xf6a09e66, 0xef7a6275, 0xe7dbc161, 0xe0000000, 0xd8243e9f, 0xd0859d8b, 0xc95f619a, 0xc2e92723,
+        0xbd553175, 0xb8cee3d8, 0xb5797014, 0xb36ec4ae, 0xb2bec333, 0xb36ec4ae, 0xb5797014, 0xb8cee3d8, 0xbd553175,
+        0xc2e92723, 0xc95f619a, 0xd0859d8b, 0xd8243e9f, 0xe0000000, 0xe7dbc161, 0xef7a6275, 0xf6a09e66, 0xfd16d8dd,
     },
     {
-        0x02aace8b, 0x07311c28, 0x0a868fec, 0x0c913b52, 0x0d413ccd, 0x0c913b52,
-        0x0a868fec, 0x07311c28, 0x02aace8b, 0xfd16d8dd, 0xf6a09e66, 0xef7a6275,
-        0xe7dbc161, 0xe0000000, 0xd8243e9f, 0xd0859d8b, 0xc95f619a, 0xc2e92723,
-        0xbd44ef14, 0xb831a052, 0xb3aa3837, 0xafb789a4, 0xac6145bb, 0xa9adecdc,
-        0xa864491f, 0xad1868f0, 0xb8431f49, 0xc8f42236, 0xdda8e6b1, 0xf47755dc,
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x02aace8b, 0x07311c28, 0x0a868fec, 0x0c913b52, 0x0d413ccd, 0x0c913b52, 0x0a868fec, 0x07311c28, 0x02aace8b,
+        0xfd16d8dd, 0xf6a09e66, 0xef7a6275, 0xe7dbc161, 0xe0000000, 0xd8243e9f, 0xd0859d8b, 0xc95f619a, 0xc2e92723,
+        0xbd44ef14, 0xb831a052, 0xb3aa3837, 0xafb789a4, 0xac6145bb, 0xa9adecdc, 0xa864491f, 0xad1868f0, 0xb8431f49,
+        0xc8f42236, 0xdda8e6b1, 0xf47755dc, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
     },
     {
-        0x07311c28, 0x0d413ccd, 0x07311c28, 0xf6a09e66, 0xe0000000, 0xc95f619a,
-        0xb8cee3d8, 0xb2bec333, 0xb8cee3d8, 0xc95f619a, 0xe0000000, 0xf6a09e66,
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x07311c28, 0x0d413ccd, 0x07311c28, 0xf6a09e66, 0xe0000000, 0xc95f619a, 0xb8cee3d8, 0xb2bec333, 0xb8cee3d8,
+        0xc95f619a, 0xe0000000, 0xf6a09e66, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
     },
     {
-        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
-        0x028e9709, 0x04855ec0, 0x026743a1, 0xfcde2c10, 0xf515dc82, 0xec93e53b,
-        0xe4c880f8, 0xdd5d0b08, 0xd63510b7, 0xcf5e834a, 0xc8e6b562, 0xc2da4105,
-        0xbd553175, 0xb8cee3d8, 0xb5797014, 0xb36ec4ae, 0xb2bec333, 0xb36ec4ae,
-        0xb5797014, 0xb8cee3d8, 0xbd553175, 0xc2e92723, 0xc95f619a, 0xd0859d8b,
-        0xd8243e9f, 0xe0000000, 0xe7dbc161, 0xef7a6275, 0xf6a09e66, 0xfd16d8dd,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x028e9709, 0x04855ec0, 0x026743a1,
+        0xfcde2c10, 0xf515dc82, 0xec93e53b, 0xe4c880f8, 0xdd5d0b08, 0xd63510b7, 0xcf5e834a, 0xc8e6b562, 0xc2da4105,
+        0xbd553175, 0xb8cee3d8, 0xb5797014, 0xb36ec4ae, 0xb2bec333, 0xb36ec4ae, 0xb5797014, 0xb8cee3d8, 0xbd553175,
+        0xc2e92723, 0xc95f619a, 0xd0859d8b, 0xd8243e9f, 0xe0000000, 0xe7dbc161, 0xef7a6275, 0xf6a09e66, 0xfd16d8dd,
     },
 };
 
@@ -251,10 +218,8 @@ const int imdctWin[4][36] = {
  *     - and since S = 0 in the joint stereo region (above NZB right) then L = R
  * = M * 1.0
  */
-const int ISFMpeg1[2][7] = {{0x00000000, 0x0d8658ba, 0x176cf5d0, 0x20000000,
-                             0x28930a2f, 0x3279a745, 0x40000000},
-                            {0x00000000, 0x13207f5c, 0x2120fb83, 0x2d413ccc,
-                             0x39617e16, 0x4761fa3d, 0x5a827999}};
+const int ISFMpeg1[2][7] = {{0x00000000, 0x0d8658ba, 0x176cf5d0, 0x20000000, 0x28930a2f, 0x3279a745, 0x40000000},
+                            {0x00000000, 0x13207f5c, 0x2120fb83, 0x2d413ccc, 0x39617e16, 0x4761fa3d, 0x5a827999}};
 
 /* indexing = [intensity scale on/off][mid-side off/on][intensity scale factor]
  * format = Q30, range = [0.0, 1.414]
@@ -362,18 +327,15 @@ const int ISFIIP[2][2] = {
     {0x40000000, 0x40000000}, /* mid-side on */
 };
 
-const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f,
-                                      0x5f, 0x4a, 0x52, 0x5f};
+const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 0x5f};
 
 /* anti-alias coefficients - see spec Annex B, table 3-B.9
  *   csa[0][i] = CSi, csa[1][i] = CAi
  * format = Q31
  */
 const int csa[8][2] = {
-    {0x6dc253f0, 0xbe2500aa}, {0x70dcebe4, 0xc39e4949},
-    {0x798d6e73, 0xd7e33f4a}, {0x7ddd40a7, 0xe8b71176},
-    {0x7f6d20b7, 0xf3e4fe2f}, {0x7fe47e40, 0xfac1a3c7},
-    {0x7ffcb263, 0xfe2ebdc6}, {0x7fffc694, 0xff86c25d},
+    {0x6dc253f0, 0xbe2500aa}, {0x70dcebe4, 0xc39e4949}, {0x798d6e73, 0xd7e33f4a}, {0x7ddd40a7, 0xe8b71176},
+    {0x7f6d20b7, 0xf3e4fe2f}, {0x7fe47e40, 0xfac1a3c7}, {0x7ffcb263, 0xfe2ebdc6}, {0x7fffc694, 0xff86c25d},
 };
 
 /* format = Q30, range = [0.0981, 1.9976]
@@ -390,12 +352,10 @@ const int csa[8][2] = {
  * *** /
  */
 const int coef32[31] = {
-    0x7fd8878d, 0x7e9d55fc, 0x7c29fbee, 0x78848413, 0x73b5ebd0, 0x6dca0d14,
-    0x66cf811f, 0x5ed77c89, 0x55f5a4d2, 0x4c3fdff3, 0x41ce1e64, 0x36ba2013,
-    0x2b1f34eb, 0x1f19f97b, 0x12c8106e, 0x0647d97c, 0x7f62368f, 0x7a7d055b,
-    0x70e2cbc6, 0x62f201ac, 0x5133cc94, 0x3c56ba70, 0x25280c5d, 0x0c8bd35e,
-    0x7d8a5f3f, 0x6a6d98a4, 0x471cece6, 0x18f8b83c, 0x7641af3c, 0x30fbc54d,
-    0x2d413ccc,
+    0x7fd8878d, 0x7e9d55fc, 0x7c29fbee, 0x78848413, 0x73b5ebd0, 0x6dca0d14, 0x66cf811f, 0x5ed77c89,
+    0x55f5a4d2, 0x4c3fdff3, 0x41ce1e64, 0x36ba2013, 0x2b1f34eb, 0x1f19f97b, 0x12c8106e, 0x0647d97c,
+    0x7f62368f, 0x7a7d055b, 0x70e2cbc6, 0x62f201ac, 0x5133cc94, 0x3c56ba70, 0x25280c5d, 0x0c8bd35e,
+    0x7d8a5f3f, 0x6a6d98a4, 0x471cece6, 0x18f8b83c, 0x7641af3c, 0x30fbc54d, 0x2d413ccc,
 };
 
 /* format = Q30, right shifted by 12 (sign bits only in top 12 - undo this when
@@ -423,57 +383,42 @@ const int coef32[31] = {
  */
 const int polyCoef[264] = {
     /* shuffled vs. original from 0, 1, ... 15 to 0, 15, 2, 13, ... 14, 1 */
-    0x00000000, 0x00000074, 0x00000354, 0x0000072c, 0x00001fd4, 0x00005084,
-    0x000066b8, 0x000249c4, 0x00049478, 0xfffdb63c, 0x000066b8, 0xffffaf7c,
-    0x00001fd4, 0xfffff8d4, 0x00000354, 0xffffff8c, 0xfffffffc, 0x00000068,
-    0x00000368, 0x00000644, 0x00001f40, 0x00004ad0, 0x00005d1c, 0x00022ce0,
-    0x000493c0, 0xfffd9960, 0x00006f78, 0xffffa9cc, 0x0000203c, 0xfffff7e4,
-    0x00000340, 0xffffff84, 0xfffffffc, 0x00000060, 0x00000378, 0x0000056c,
-    0x00001e80, 0x00004524, 0x000052a0, 0x00020ffc, 0x000491a0, 0xfffd7ca0,
-    0x00007760, 0xffffa424, 0x00002080, 0xfffff6ec, 0x00000328, 0xffffff74,
-    0xfffffffc, 0x00000054, 0x00000384, 0x00000498, 0x00001d94, 0x00003f7c,
-    0x00004744, 0x0001f32c, 0x00048e18, 0xfffd6008, 0x00007e70, 0xffff9e8c,
-    0x0000209c, 0xfffff5ec, 0x00000310, 0xffffff68, 0xfffffffc, 0x0000004c,
-    0x0000038c, 0x000003d0, 0x00001c78, 0x000039e4, 0x00003b00, 0x0001d680,
-    0x00048924, 0xfffd43ac, 0x000084b0, 0xffff990c, 0x00002094, 0xfffff4e4,
-    0x000002f8, 0xffffff5c, 0xfffffffc, 0x00000044, 0x00000390, 0x00000314,
-    0x00001b2c, 0x0000345c, 0x00002ddc, 0x0001ba04, 0x000482d0, 0xfffd279c,
-    0x00008a20, 0xffff93a4, 0x0000206c, 0xfffff3d4, 0x000002dc, 0xffffff4c,
-    0xfffffffc, 0x00000040, 0x00000390, 0x00000264, 0x000019b0, 0x00002ef0,
-    0x00001fd4, 0x00019dc8, 0x00047b1c, 0xfffd0be8, 0x00008ecc, 0xffff8e64,
-    0x00002024, 0xfffff2c0, 0x000002c0, 0xffffff3c, 0xfffffff8, 0x00000038,
-    0x0000038c, 0x000001bc, 0x000017fc, 0x0000299c, 0x000010e8, 0x000181d8,
-    0x0004720c, 0xfffcf09c, 0x000092b4, 0xffff894c, 0x00001fc0, 0xfffff1a4,
-    0x000002a4, 0xffffff2c, 0xfffffff8, 0x00000034, 0x00000380, 0x00000120,
-    0x00001618, 0x00002468, 0x00000118, 0x00016644, 0x000467a4, 0xfffcd5cc,
-    0x000095e0, 0xffff8468, 0x00001f44, 0xfffff084, 0x00000284, 0xffffff18,
-    0xfffffff8, 0x0000002c, 0x00000374, 0x00000090, 0x00001400, 0x00001f58,
-    0xfffff068, 0x00014b14, 0x00045bf0, 0xfffcbb88, 0x00009858, 0xffff7fbc,
-    0x00001ea8, 0xffffef60, 0x00000268, 0xffffff04, 0xfffffff8, 0x00000028,
-    0x0000035c, 0x00000008, 0x000011ac, 0x00001a70, 0xffffded8, 0x00013058,
-    0x00044ef8, 0xfffca1d8, 0x00009a1c, 0xffff7b54, 0x00001dfc, 0xffffee3c,
-    0x0000024c, 0xfffffef0, 0xfffffff4, 0x00000024, 0x00000340, 0xffffff8c,
-    0x00000f28, 0x000015b0, 0xffffcc70, 0x0001161c, 0x000440bc, 0xfffc88d8,
-    0x00009b3c, 0xffff7734, 0x00001d38, 0xffffed18, 0x0000022c, 0xfffffedc,
-    0xfffffff4, 0x00000020, 0x00000320, 0xffffff1c, 0x00000c68, 0x0000111c,
-    0xffffb92c, 0x0000fc6c, 0x00043150, 0xfffc708c, 0x00009bb8, 0xffff7368,
-    0x00001c64, 0xffffebf4, 0x00000210, 0xfffffec4, 0xfffffff0, 0x0000001c,
-    0x000002f4, 0xfffffeb4, 0x00000974, 0x00000cb8, 0xffffa518, 0x0000e350,
-    0x000420b4, 0xfffc5908, 0x00009b9c, 0xffff6ff4, 0x00001b7c, 0xffffead0,
-    0x000001f4, 0xfffffeac, 0xfffffff0, 0x0000001c, 0x000002c4, 0xfffffe58,
-    0x00000648, 0x00000884, 0xffff9038, 0x0000cad0, 0x00040ef8, 0xfffc425c,
-    0x00009af0, 0xffff6ce0, 0x00001a88, 0xffffe9b0, 0x000001d4, 0xfffffe94,
-    0xffffffec, 0x00000018, 0x0000028c, 0xfffffe04, 0x000002e4, 0x00000480,
-    0xffff7a90, 0x0000b2fc, 0x0003fc28, 0xfffc2c90, 0x000099b8, 0xffff6a3c,
-    0x00001988, 0xffffe898, 0x000001bc, 0xfffffe7c, 0x000001a0, 0x0000187c,
-    0x000097fc, 0x0003e84c, 0xffff6424, 0xffffff4c, 0x00000248, 0xffffffec,
+    0x00000000, 0x00000074, 0x00000354, 0x0000072c, 0x00001fd4, 0x00005084, 0x000066b8, 0x000249c4, 0x00049478,
+    0xfffdb63c, 0x000066b8, 0xffffaf7c, 0x00001fd4, 0xfffff8d4, 0x00000354, 0xffffff8c, 0xfffffffc, 0x00000068,
+    0x00000368, 0x00000644, 0x00001f40, 0x00004ad0, 0x00005d1c, 0x00022ce0, 0x000493c0, 0xfffd9960, 0x00006f78,
+    0xffffa9cc, 0x0000203c, 0xfffff7e4, 0x00000340, 0xffffff84, 0xfffffffc, 0x00000060, 0x00000378, 0x0000056c,
+    0x00001e80, 0x00004524, 0x000052a0, 0x00020ffc, 0x000491a0, 0xfffd7ca0, 0x00007760, 0xffffa424, 0x00002080,
+    0xfffff6ec, 0x00000328, 0xffffff74, 0xfffffffc, 0x00000054, 0x00000384, 0x00000498, 0x00001d94, 0x00003f7c,
+    0x00004744, 0x0001f32c, 0x00048e18, 0xfffd6008, 0x00007e70, 0xffff9e8c, 0x0000209c, 0xfffff5ec, 0x00000310,
+    0xffffff68, 0xfffffffc, 0x0000004c, 0x0000038c, 0x000003d0, 0x00001c78, 0x000039e4, 0x00003b00, 0x0001d680,
+    0x00048924, 0xfffd43ac, 0x000084b0, 0xffff990c, 0x00002094, 0xfffff4e4, 0x000002f8, 0xffffff5c, 0xfffffffc,
+    0x00000044, 0x00000390, 0x00000314, 0x00001b2c, 0x0000345c, 0x00002ddc, 0x0001ba04, 0x000482d0, 0xfffd279c,
+    0x00008a20, 0xffff93a4, 0x0000206c, 0xfffff3d4, 0x000002dc, 0xffffff4c, 0xfffffffc, 0x00000040, 0x00000390,
+    0x00000264, 0x000019b0, 0x00002ef0, 0x00001fd4, 0x00019dc8, 0x00047b1c, 0xfffd0be8, 0x00008ecc, 0xffff8e64,
+    0x00002024, 0xfffff2c0, 0x000002c0, 0xffffff3c, 0xfffffff8, 0x00000038, 0x0000038c, 0x000001bc, 0x000017fc,
+    0x0000299c, 0x000010e8, 0x000181d8, 0x0004720c, 0xfffcf09c, 0x000092b4, 0xffff894c, 0x00001fc0, 0xfffff1a4,
+    0x000002a4, 0xffffff2c, 0xfffffff8, 0x00000034, 0x00000380, 0x00000120, 0x00001618, 0x00002468, 0x00000118,
+    0x00016644, 0x000467a4, 0xfffcd5cc, 0x000095e0, 0xffff8468, 0x00001f44, 0xfffff084, 0x00000284, 0xffffff18,
+    0xfffffff8, 0x0000002c, 0x00000374, 0x00000090, 0x00001400, 0x00001f58, 0xfffff068, 0x00014b14, 0x00045bf0,
+    0xfffcbb88, 0x00009858, 0xffff7fbc, 0x00001ea8, 0xffffef60, 0x00000268, 0xffffff04, 0xfffffff8, 0x00000028,
+    0x0000035c, 0x00000008, 0x000011ac, 0x00001a70, 0xffffded8, 0x00013058, 0x00044ef8, 0xfffca1d8, 0x00009a1c,
+    0xffff7b54, 0x00001dfc, 0xffffee3c, 0x0000024c, 0xfffffef0, 0xfffffff4, 0x00000024, 0x00000340, 0xffffff8c,
+    0x00000f28, 0x000015b0, 0xffffcc70, 0x0001161c, 0x000440bc, 0xfffc88d8, 0x00009b3c, 0xffff7734, 0x00001d38,
+    0xffffed18, 0x0000022c, 0xfffffedc, 0xfffffff4, 0x00000020, 0x00000320, 0xffffff1c, 0x00000c68, 0x0000111c,
+    0xffffb92c, 0x0000fc6c, 0x00043150, 0xfffc708c, 0x00009bb8, 0xffff7368, 0x00001c64, 0xffffebf4, 0x00000210,
+    0xfffffec4, 0xfffffff0, 0x0000001c, 0x000002f4, 0xfffffeb4, 0x00000974, 0x00000cb8, 0xffffa518, 0x0000e350,
+    0x000420b4, 0xfffc5908, 0x00009b9c, 0xffff6ff4, 0x00001b7c, 0xffffead0, 0x000001f4, 0xfffffeac, 0xfffffff0,
+    0x0000001c, 0x000002c4, 0xfffffe58, 0x00000648, 0x00000884, 0xffff9038, 0x0000cad0, 0x00040ef8, 0xfffc425c,
+    0x00009af0, 0xffff6ce0, 0x00001a88, 0xffffe9b0, 0x000001d4, 0xfffffe94, 0xffffffec, 0x00000018, 0x0000028c,
+    0xfffffe04, 0x000002e4, 0x00000480, 0xffff7a90, 0x0000b2fc, 0x0003fc28, 0xfffc2c90, 0x000099b8, 0xffff6a3c,
+    0x00001988, 0xffffe898, 0x000001bc, 0xfffffe7c, 0x000001a0, 0x0000187c, 0x000097fc, 0x0003e84c, 0xffff6424,
+    0xffffff4c, 0x00000248, 0xffffffec,
 };
 
 typedef int ARRAY3[3]; /* for short-block reordering */
 
 /* optional pre-emphasis for high-frequency scale factor bands */
-static const char preTab[22] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                1, 1, 1, 1, 2, 2, 3, 3, 3, 2, 0};
+static const char preTab[22] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 3, 3, 2, 0};
 
 /* pow(2,-i/4) for i=0..3, Q31 format */
 int pow14[4] = {0x7fffffff, 0x6ba27e65, 0x5a82799a, 0x4c1bf829};
@@ -559,14 +504,12 @@ int pow43_14[4][16] = {
 
 /* pow(j,4/3) for j=16..63, Q23 format */
 int pow43[] = {
-    0x1428a2fa, 0x15db1bd6, 0x1796302c, 0x19598d85, 0x1b24e8bb, 0x1cf7fcfa,
-    0x1ed28af2, 0x20b4582a, 0x229d2e6e, 0x248cdb55, 0x26832fda, 0x28800000,
-    0x2a832287, 0x2c8c70a8, 0x2e9bc5d8, 0x30b0ff99, 0x32cbfd4a, 0x34eca001,
-    0x3712ca62, 0x393e6088, 0x3b6f47e0, 0x3da56717, 0x3fe0a5fc, 0x4220ed72,
-    0x44662758, 0x46b03e7c, 0x48ff1e87, 0x4b52b3f3, 0x4daaebfd, 0x5007b497,
-    0x5268fc62, 0x54ceb29c, 0x5738c721, 0x59a72a59, 0x5c19cd35, 0x5e90a129,
-    0x610b9821, 0x638aa47f, 0x660db90f, 0x6894c90b, 0x6b1fc80c, 0x6daeaa0d,
-    0x70416360, 0x72d7e8b0, 0x75722ef9, 0x78102b85, 0x7ab1d3ec, 0x7d571e09,
+    0x1428a2fa, 0x15db1bd6, 0x1796302c, 0x19598d85, 0x1b24e8bb, 0x1cf7fcfa, 0x1ed28af2, 0x20b4582a,
+    0x229d2e6e, 0x248cdb55, 0x26832fda, 0x28800000, 0x2a832287, 0x2c8c70a8, 0x2e9bc5d8, 0x30b0ff99,
+    0x32cbfd4a, 0x34eca001, 0x3712ca62, 0x393e6088, 0x3b6f47e0, 0x3da56717, 0x3fe0a5fc, 0x4220ed72,
+    0x44662758, 0x46b03e7c, 0x48ff1e87, 0x4b52b3f3, 0x4daaebfd, 0x5007b497, 0x5268fc62, 0x54ceb29c,
+    0x5738c721, 0x59a72a59, 0x5c19cd35, 0x5e90a129, 0x610b9821, 0x638aa47f, 0x660db90f, 0x6894c90b,
+    0x6b1fc80c, 0x6daeaa0d, 0x70416360, 0x72d7e8b0, 0x75722ef9, 0x78102b85, 0x7ab1d3ec, 0x7d571e09,
 };
 
 /* sqrt(0.5) in Q31 format */
@@ -586,8 +529,7 @@ int poly43hi[5] = {0x10852163, 0xd333f6a4, 0x46e9408b, 0x27c2cef0, 0xfef577b4};
 /* pow(2, i*4/3) as exp and frac */
 int pow2exp[8] = {14, 13, 11, 10, 9, 7, 6, 5};
 
-int pow2frac[8] = {0x6597fa94, 0x50a28be6, 0x7fffffff, 0x6597fa94,
-                   0x50a28be6, 0x7fffffff, 0x6597fa94, 0x50a28be6};
+int pow2frac[8] = {0x6597fa94, 0x50a28be6, 0x7fffffff, 0x6597fa94, 0x50a28be6, 0x7fffffff, 0x6597fa94, 0x50a28be6};
 
 /**************************************************************************************
  * Function:    DequantBlock
@@ -612,8 +554,7 @@ static int DequantBlock(int *inbuf, int *outbuf, int num, int scale) {
 
   tab16 = pow43_14[scale & 0x3];
   scalef = pow14[scale & 0x3];
-  scalei = MIN(scale >> 2,
-               31); /* smallest input scale = -47, so smallest scalei = -12 */
+  scalei = MIN(scale >> 2, 31); /* smallest input scale = -47, so smallest scalei = -12 */
 
   /* cache first 4 values */
   shift = MIN(scalei + 3, 31);
@@ -624,23 +565,18 @@ static int DequantBlock(int *inbuf, int *outbuf, int num, int scale) {
   tab4[3] = tab16[3] >> shift;
 
   do {
-
     sx = *inbuf++;
     x = sx & 0x7fffffff; /* sx = sign|mag */
 
     if (x < 4) {
-
       y = tab4[x];
 
     } else if (x < 16) {
-
       y = tab16[x];
       y = (scalei < 0) ? y << -scalei : y >> scalei;
 
     } else {
-
       if (x < 64) {
-
         y = pow43[x - 16];
 
         /* fractional scale */
@@ -648,7 +584,6 @@ static int DequantBlock(int *inbuf, int *outbuf, int num, int scale) {
         shift = scalei - 3;
 
       } else {
-
         /* normalize to [0x40000000, 0x7fffffff] */
         x <<= 17;
         shift = 0;
@@ -716,9 +651,8 @@ static int DequantBlock(int *inbuf, int *outbuf, int num, int scale) {
  *
  * Notes:       dequantized samples in Q(DQ_FRACBITS_OUT) format
  **************************************************************************************/
-int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
-                   FrameHeader *fh, SideInfoSub *sis, ScaleFactorInfoSub *sfis,
-                   CriticalBandInfo *cbi) {
+int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound, FrameHeader *fh, SideInfoSub *sis,
+                   ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi) {
   int i, j, w, cb;
   int cbStartL, cbEndL, cbStartS, cbEndS;
   int nSamps, nonZero, sfactMultiplier, gbMask;
@@ -767,12 +701,9 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
 
   /* long blocks */
   for (cb = 0; cb < cbEndL; cb++) {
-
     nonZero = 0;
     nSamps = fh->sfBand->l[cb + 1] - fh->sfBand->l[cb];
-    gainI =
-        210 - globalGain +
-        sfactMultiplier * (sfis->l[cb] + (sis->preFlag ? (int)preTab[cb] : 0));
+    gainI = 210 - globalGain + sfactMultiplier * (sfis->l[cb] + (sis->preFlag ? (int) preTab[cb] : 0));
 
     nonZero |= DequantBlock(sampleBuf + i, sampleBuf + i, nSamps, gainI);
     i += nSamps;
@@ -800,15 +731,12 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
   /* short blocks */
   cbMax[2] = cbMax[1] = cbMax[0] = cbStartS;
   for (cb = cbStartS; cb < cbEndS; cb++) {
-
     nSamps = fh->sfBand->s[cb + 1] - fh->sfBand->s[cb];
     for (w = 0; w < 3; w++) {
       nonZero = 0;
-      gainI = 210 - globalGain + 8 * sis->subBlockGain[w] +
-              sfactMultiplier * (sfis->s[cb][w]);
+      gainI = 210 - globalGain + 8 * sis->subBlockGain[w] + sfactMultiplier * (sfis->s[cb][w]);
 
-      nonZero |= DequantBlock(sampleBuf + i + nSamps * w, workBuf + nSamps * w,
-                              nSamps, gainI);
+      nonZero |= DequantBlock(sampleBuf + i + nSamps * w, workBuf + nSamps * w, nSamps, gainI);
 
       /* update highest non-zero critical band */
       if (nonZero)
@@ -817,7 +745,7 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
     }
 
     /* reorder blocks */
-    buf = (ARRAY3 *)(sampleBuf + i);
+    buf = (ARRAY3 *) (sampleBuf + i);
     i += 3 * nSamps;
     for (j = 0; j < nSamps; j++) {
       buf[j][0] = workBuf[0 * nSamps + j];
@@ -841,8 +769,7 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
 
   ASSERT(*nonZeroBound <= MAX_NSAMP);
 
-  cbi->cbType =
-      (sis->mixedBlock ? 2 : 1); /* 2 = mixed short/long, 1 = short only */
+  cbi->cbType = (sis->mixedBlock ? 2 : 1); /* 2 = mixed short/long, 1 = short only */
 
   cbi->cbEndS[0] = cbMax[0];
   cbi->cbEndS[1] = cbMax[1];
@@ -861,8 +788,8 @@ int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
  *  (see comment on Dequantize() for more info)
  */
 #define DEF_NFRACBITS (DQ_FRACBITS_OUT - 2 - 2 - 15)
-#define CSHIFT                                                                 \
-  12 /* coefficients have 12 leading sign bits for early-terminating           \
+#define CSHIFT \
+  12 /* coefficients have 12 leading sign bits for early-terminating \
         mulitplies */
 
 static __inline short ClipToShort(int x, int fracBits) {
@@ -876,41 +803,41 @@ static __inline short ClipToShort(int x, int fracBits) {
   if (sign != (x >> 15))
     x = sign ^ ((1 << 15) - 1);
 
-  return (short)x;
+  return (short) x;
 }
 
-#define MC0M(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    c2 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    vHi = *(vb1 + (23 - (x)));                                                 \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
-    sum1L = MADD64(sum1L, vHi, -c2);                                           \
+#define MC0M(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    c2 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    vHi = *(vb1 + (23 - (x))); \
+    sum1L = MADD64(sum1L, vLo, c1); \
+    sum1L = MADD64(sum1L, vHi, -c2); \
   }
 
-#define MC1M(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
+#define MC1M(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    sum1L = MADD64(sum1L, vLo, c1); \
   }
 
-#define MC2M(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    c2 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    vHi = *(vb1 + (23 - (x)));                                                 \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
-    sum2L = MADD64(sum2L, vLo, c2);                                            \
-    sum1L = MADD64(sum1L, vHi, -c2);                                           \
-    sum2L = MADD64(sum2L, vHi, c1);                                            \
+#define MC2M(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    c2 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    vHi = *(vb1 + (23 - (x))); \
+    sum1L = MADD64(sum1L, vLo, c1); \
+    sum2L = MADD64(sum2L, vLo, c2); \
+    sum1L = MADD64(sum1L, vHi, -c2); \
+    sum2L = MADD64(sum2L, vHi, c1); \
   }
 
 /**************************************************************************************
@@ -940,7 +867,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase) {
   int vLo, vHi, c1, c2;
   Word64 sum1L, sum2L, rndVal;
 
-  rndVal = (Word64)(1 << (DEF_NFRACBITS - 1 + (32 - CSHIFT)));
+  rndVal = (Word64) (1 << (DEF_NFRACBITS - 1 + (32 - CSHIFT)));
 
   /* special case, output sample 0 */
   coef = coefBase;
@@ -956,7 +883,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase) {
   MC0M(6)
   MC0M(7)
 
-  *(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 0) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
 
   /* special case, output sample 16 */
   coef = coefBase + 256;
@@ -972,7 +899,7 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase) {
   MC1M(6)
   MC1M(7)
 
-  *(pcm + 16) = ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 16) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
 
   /* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples
    * 31, 30, ... 17 */
@@ -994,57 +921,56 @@ void PolyphaseMono(short *pcm, int *vbuf, const int *coefBase) {
     MC2M(7)
 
     vb1 += 64;
-    *(pcm) = ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
-    *(pcm + 2 * i) =
-        ClipToShort((int)SAR64(sum2L, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm + 2 * i) = ClipToShort((int) SAR64(sum2L, (32 - CSHIFT)), DEF_NFRACBITS);
     pcm++;
   }
 }
 
-#define MC0S(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    c2 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    vHi = *(vb1 + (23 - (x)));                                                 \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
-    sum1L = MADD64(sum1L, vHi, -c2);                                           \
-    vLo = *(vb1 + 32 + (x));                                                   \
-    vHi = *(vb1 + 32 + (23 - (x)));                                            \
-    sum1R = MADD64(sum1R, vLo, c1);                                            \
-    sum1R = MADD64(sum1R, vHi, -c2);                                           \
+#define MC0S(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    c2 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    vHi = *(vb1 + (23 - (x))); \
+    sum1L = MADD64(sum1L, vLo, c1); \
+    sum1L = MADD64(sum1L, vHi, -c2); \
+    vLo = *(vb1 + 32 + (x)); \
+    vHi = *(vb1 + 32 + (23 - (x))); \
+    sum1R = MADD64(sum1R, vLo, c1); \
+    sum1R = MADD64(sum1R, vHi, -c2); \
   }
 
-#define MC1S(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
-    vLo = *(vb1 + 32 + (x));                                                   \
-    sum1R = MADD64(sum1R, vLo, c1);                                            \
+#define MC1S(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    sum1L = MADD64(sum1L, vLo, c1); \
+    vLo = *(vb1 + 32 + (x)); \
+    sum1R = MADD64(sum1R, vLo, c1); \
   }
 
-#define MC2S(x)                                                                \
-  {                                                                            \
-    c1 = *coef;                                                                \
-    coef++;                                                                    \
-    c2 = *coef;                                                                \
-    coef++;                                                                    \
-    vLo = *(vb1 + (x));                                                        \
-    vHi = *(vb1 + (23 - (x)));                                                 \
-    sum1L = MADD64(sum1L, vLo, c1);                                            \
-    sum2L = MADD64(sum2L, vLo, c2);                                            \
-    sum1L = MADD64(sum1L, vHi, -c2);                                           \
-    sum2L = MADD64(sum2L, vHi, c1);                                            \
-    vLo = *(vb1 + 32 + (x));                                                   \
-    vHi = *(vb1 + 32 + (23 - (x)));                                            \
-    sum1R = MADD64(sum1R, vLo, c1);                                            \
-    sum2R = MADD64(sum2R, vLo, c2);                                            \
-    sum1R = MADD64(sum1R, vHi, -c2);                                           \
-    sum2R = MADD64(sum2R, vHi, c1);                                            \
+#define MC2S(x) \
+  { \
+    c1 = *coef; \
+    coef++; \
+    c2 = *coef; \
+    coef++; \
+    vLo = *(vb1 + (x)); \
+    vHi = *(vb1 + (23 - (x))); \
+    sum1L = MADD64(sum1L, vLo, c1); \
+    sum2L = MADD64(sum2L, vLo, c2); \
+    sum1L = MADD64(sum1L, vHi, -c2); \
+    sum2L = MADD64(sum2L, vHi, c1); \
+    vLo = *(vb1 + 32 + (x)); \
+    vHi = *(vb1 + 32 + (23 - (x))); \
+    sum1R = MADD64(sum1R, vLo, c1); \
+    sum2R = MADD64(sum2R, vLo, c2); \
+    sum1R = MADD64(sum1R, vHi, -c2); \
+    sum2R = MADD64(sum2R, vHi, c1); \
   }
 
 /**************************************************************************************
@@ -1076,7 +1002,7 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase) {
   int vLo, vHi, c1, c2;
   Word64 sum1L, sum2L, sum1R, sum2R, rndVal;
 
-  rndVal = (Word64)(1 << (DEF_NFRACBITS - 1 + (32 - CSHIFT)));
+  rndVal = (Word64) (1 << (DEF_NFRACBITS - 1 + (32 - CSHIFT)));
 
   /* special case, output sample 0 */
   coef = coefBase;
@@ -1092,8 +1018,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase) {
   MC0S(6)
   MC0S(7)
 
-  *(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
-  *(pcm + 1) = ClipToShort((int)SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 0) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 1) = ClipToShort((int) SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
 
   /* special case, output sample 16 */
   coef = coefBase + 256;
@@ -1109,10 +1035,8 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase) {
   MC1S(6)
   MC1S(7)
 
-  *(pcm + 2 * 16 + 0) =
-      ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
-  *(pcm + 2 * 16 + 1) =
-      ClipToShort((int)SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 2 * 16 + 0) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+  *(pcm + 2 * 16 + 1) = ClipToShort((int) SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
 
   /* main convolution loop: sum1L = samples 1, 2, 3, ... 15   sum2L = samples
    * 31, 30, ... 17 */
@@ -1135,12 +1059,10 @@ void PolyphaseStereo(short *pcm, int *vbuf, const int *coefBase) {
     MC2S(7)
 
     vb1 += 64;
-    *(pcm + 0) = ClipToShort((int)SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
-    *(pcm + 1) = ClipToShort((int)SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
-    *(pcm + 2 * 2 * i + 0) =
-        ClipToShort((int)SAR64(sum2L, (32 - CSHIFT)), DEF_NFRACBITS);
-    *(pcm + 2 * 2 * i + 1) =
-        ClipToShort((int)SAR64(sum2R, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm + 0) = ClipToShort((int) SAR64(sum1L, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm + 1) = ClipToShort((int) SAR64(sum1R, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm + 2 * 2 * i + 0) = ClipToShort((int) SAR64(sum2L, (32 - CSHIFT)), DEF_NFRACBITS);
+    *(pcm + 2 * 2 * i + 1) = ClipToShort((int) SAR64(sum2R, (32 - CSHIFT)), DEF_NFRACBITS);
     pcm += 2;
   }
 }
@@ -1165,33 +1087,27 @@ int Subband(MP3DecInfo *mp3DecInfo, short *pcmBuf) {
   SubbandInfo *sbi;
 
   /* validate pointers */
-  if (!mp3DecInfo || !mp3DecInfo->HuffmanInfoPS || !mp3DecInfo->IMDCTInfoPS ||
-      !mp3DecInfo->SubbandInfoPS)
+  if (!mp3DecInfo || !mp3DecInfo->HuffmanInfoPS || !mp3DecInfo->IMDCTInfoPS || !mp3DecInfo->SubbandInfoPS)
     return -1;
 
-  hi = (HuffmanInfo *)mp3DecInfo->HuffmanInfoPS;
-  mi = (IMDCTInfo *)(mp3DecInfo->IMDCTInfoPS);
-  sbi = (SubbandInfo *)(mp3DecInfo->SubbandInfoPS);
+  hi = (HuffmanInfo *) mp3DecInfo->HuffmanInfoPS;
+  mi = (IMDCTInfo *) (mp3DecInfo->IMDCTInfoPS);
+  sbi = (SubbandInfo *) (mp3DecInfo->SubbandInfoPS);
 
   if (mp3DecInfo->nChans == 2) {
     /* stereo */
     for (b = 0; b < BLOCK_SIZE; b++) {
-      FDCT32(mi->outBuf[0][b], sbi->vbuf + 0 * 32, sbi->vindex, (b & 0x01),
-             mi->gb[0]);
-      FDCT32(mi->outBuf[1][b], sbi->vbuf + 1 * 32, sbi->vindex, (b & 0x01),
-             mi->gb[1]);
-      PolyphaseStereo(
-          pcmBuf, sbi->vbuf + sbi->vindex + VBUF_LENGTH * (b & 0x01), polyCoef);
+      FDCT32(mi->outBuf[0][b], sbi->vbuf + 0 * 32, sbi->vindex, (b & 0x01), mi->gb[0]);
+      FDCT32(mi->outBuf[1][b], sbi->vbuf + 1 * 32, sbi->vindex, (b & 0x01), mi->gb[1]);
+      PolyphaseStereo(pcmBuf, sbi->vbuf + sbi->vindex + VBUF_LENGTH * (b & 0x01), polyCoef);
       sbi->vindex = (sbi->vindex - (b & 0x01)) & 7;
       pcmBuf += (2 * NBANDS);
     }
   } else {
     /* mono */
     for (b = 0; b < BLOCK_SIZE; b++) {
-      FDCT32(mi->outBuf[0][b], sbi->vbuf + 0 * 32, sbi->vindex, (b & 0x01),
-             mi->gb[0]);
-      PolyphaseMono(pcmBuf, sbi->vbuf + sbi->vindex + VBUF_LENGTH * (b & 0x01),
-                    polyCoef);
+      FDCT32(mi->outBuf[0][b], sbi->vbuf + 0 * 32, sbi->vindex, (b & 0x01), mi->gb[0]);
+      PolyphaseMono(pcmBuf, sbi->vbuf + sbi->vindex + VBUF_LENGTH * (b & 0x01), polyCoef);
       sbi->vindex = (sbi->vindex - (b & 0x01)) & 7;
       pcmBuf += NBANDS;
     }
@@ -1258,10 +1174,8 @@ void MidSideProc(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, int mOut[2]) {
  * TODO:        combine MPEG1/2 into one function (maybe)
  *              make sure all the mixed-block and IIP logic is right
  **************************************************************************************/
-void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
-                        FrameHeader *fh, ScaleFactorInfoSub *sfis,
-                        CriticalBandInfo *cbi, int midSideFlag, int mixFlag,
-                        int mOut[2]) {
+void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis,
+                        CriticalBandInfo *cbi, int midSideFlag, int mixFlag, int mOut[2]) {
   int i = 0, j = 0, n = 0, cb = 0, w = 0;
   int sampsLeft, isf, mOutL, mOutR, xl, xr;
   int fl, fr, fls[3], frs[3];
@@ -1290,7 +1204,7 @@ void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
   }
 
   sampsLeft = nSamps - i; /* process to length of left */
-  isfTab = (int *)ISFMpeg1[midSideFlag];
+  isfTab = (int *) ISFMpeg1[midSideFlag];
   mOutL = mOutR = 0;
 
   /* long blocks */
@@ -1382,10 +1296,8 @@ void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
  *              make sure all the mixed-block and IIP logic is right
  *                probably redo IIP logic to be simpler
  **************************************************************************************/
-void IntensityProcMPEG2(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
-                        FrameHeader *fh, ScaleFactorInfoSub *sfis,
-                        CriticalBandInfo *cbi, ScaleFactorJS *sfjs,
-                        int midSideFlag, int mixFlag, int mOut[2]) {
+void IntensityProcMPEG2(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis,
+                        CriticalBandInfo *cbi, ScaleFactorJS *sfjs, int midSideFlag, int mixFlag, int mOut[2]) {
   int i, j, k, n, r, cb, w;
   int fl, fr, mOutL, mOutR, xl, xr;
   int sampsLeft;
@@ -1393,7 +1305,7 @@ void IntensityProcMPEG2(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
   int *isfTab;
   int cbStartL, cbStartS, cbEndL, cbEndS;
 
-  isfTab = (int *)ISFMpeg2[sfjs->intensityScale][midSideFlag];
+  isfTab = (int *) ISFMpeg2[sfjs->intensityScale][midSideFlag];
   mOutL = mOutR = 0;
 
   /* fill buffer with illegal intensity positions (depending on slen) */
@@ -1506,23 +1418,22 @@ static const char SFLenTab[16][2] = {
  *unpacking (make sure dequantizer follows same convention) Illegal Intensity
  *Position = 7 (always) for MPEG1 scale factors
  **************************************************************************************/
-static void UnpackSFMPEG1(BitStreamInfo *bsi, SideInfoSub *sis,
-                          ScaleFactorInfoSub *sfis, int *scfsi, int gr,
+static void UnpackSFMPEG1(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoSub *sfis, int *scfsi, int gr,
                           ScaleFactorInfoSub *sfisGr0) {
   int sfb;
   int slen0, slen1;
 
   /* these can be 0, so make sure GetBits(bsi, 0) returns 0 (no >> 32 or
    * anything) */
-  slen0 = (int)SFLenTab[sis->sfCompress][0];
-  slen1 = (int)SFLenTab[sis->sfCompress][1];
+  slen0 = (int) SFLenTab[sis->sfCompress][0];
+  slen1 = (int) SFLenTab[sis->sfCompress][1];
 
   if (sis->blockType == 2) {
     /* short block, type 2 (implies winSwitchFlag == 1) */
     if (sis->mixedBlock) {
       /* do long block portion */
       for (sfb = 0; sfb < 8; sfb++)
-        sfis->l[sfb] = (char)GetBits(bsi, slen0);
+        sfis->l[sfb] = (char) GetBits(bsi, slen0);
       sfb = 3;
     } else {
       /* all short blocks */
@@ -1530,15 +1441,15 @@ static void UnpackSFMPEG1(BitStreamInfo *bsi, SideInfoSub *sis,
     }
 
     for (; sfb < 6; sfb++) {
-      sfis->s[sfb][0] = (char)GetBits(bsi, slen0);
-      sfis->s[sfb][1] = (char)GetBits(bsi, slen0);
-      sfis->s[sfb][2] = (char)GetBits(bsi, slen0);
+      sfis->s[sfb][0] = (char) GetBits(bsi, slen0);
+      sfis->s[sfb][1] = (char) GetBits(bsi, slen0);
+      sfis->s[sfb][2] = (char) GetBits(bsi, slen0);
     }
 
     for (; sfb < 12; sfb++) {
-      sfis->s[sfb][0] = (char)GetBits(bsi, slen1);
-      sfis->s[sfb][1] = (char)GetBits(bsi, slen1);
-      sfis->s[sfb][2] = (char)GetBits(bsi, slen1);
+      sfis->s[sfb][0] = (char) GetBits(bsi, slen1);
+      sfis->s[sfb][1] = (char) GetBits(bsi, slen1);
+      sfis->s[sfb][2] = (char) GetBits(bsi, slen1);
     }
 
     /* last sf band not transmitted */
@@ -1548,9 +1459,9 @@ static void UnpackSFMPEG1(BitStreamInfo *bsi, SideInfoSub *sis,
     if (gr == 0) {
       /* first granule */
       for (sfb = 0; sfb < 11; sfb++)
-        sfis->l[sfb] = (char)GetBits(bsi, slen0);
+        sfis->l[sfb] = (char) GetBits(bsi, slen0);
       for (sfb = 11; sfb < 21; sfb++)
-        sfis->l[sfb] = (char)GetBits(bsi, slen1);
+        sfis->l[sfb] = (char) GetBits(bsi, slen1);
       return;
     } else {
       /* second granule
@@ -1563,25 +1474,25 @@ static void UnpackSFMPEG1(BitStreamInfo *bsi, SideInfoSub *sis,
           sfis->l[sfb] = sfisGr0->l[sfb];
       else
         for (; sfb < 6; sfb++)
-          sfis->l[sfb] = (char)GetBits(bsi, slen0);
+          sfis->l[sfb] = (char) GetBits(bsi, slen0);
       if (scfsi[1])
         for (; sfb < 11; sfb++)
           sfis->l[sfb] = sfisGr0->l[sfb];
       else
         for (; sfb < 11; sfb++)
-          sfis->l[sfb] = (char)GetBits(bsi, slen0);
+          sfis->l[sfb] = (char) GetBits(bsi, slen0);
       if (scfsi[2])
         for (; sfb < 16; sfb++)
           sfis->l[sfb] = sfisGr0->l[sfb];
       else
         for (; sfb < 16; sfb++)
-          sfis->l[sfb] = (char)GetBits(bsi, slen1);
+          sfis->l[sfb] = (char) GetBits(bsi, slen1);
       if (scfsi[3])
         for (; sfb < 21; sfb++)
           sfis->l[sfb] = sfisGr0->l[sfb];
       else
         for (; sfb < 21; sfb++)
-          sfis->l[sfb] = (char)GetBits(bsi, slen1);
+          sfis->l[sfb] = (char) GetBits(bsi, slen1);
     }
     /* last sf band not transmitted */
     sfis->l[21] = 0;
@@ -1613,11 +1524,8 @@ static const char NRTab[6][3][4] = {
         {6, 3, 4, 2},
     },
     {
-        {11, 10, 0, 0},
-        {6, 6, 0, 0},
-        {6, 3, 6,
-         0}, /* spec = [15,18,0,0], but 15 = 6L + 9S, so move 9/3=3 into col 1,
-                18/3=6 into col 2 and adj. slen[1,2] below */
+        {11, 10, 0, 0}, {6, 6, 0, 0}, {6, 3, 6, 0}, /* spec = [15,18,0,0], but 15 = 6L + 9S, so move 9/3=3 into col 1,
+                                                       18/3=6 into col 2 and adj. slen[1,2] below */
     },
     /* intensity stereo, right chan */
     {
@@ -1660,10 +1568,8 @@ static const char NRTab[6][3][4] = {
  * TODO:        optimize the / and % stuff (only do one divide, get modulo x
  *                with (x / m) * m, etc.)
  **************************************************************************************/
-static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
-                          ScaleFactorInfoSub *sfis, int gr, int ch, int modeExt,
+static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis, ScaleFactorInfoSub *sfis, int gr, int ch, int modeExt,
                           ScaleFactorJS *sfjs) {
-
   int i, sfb, sfcIdx, btIdx, nrIdx, iipTest;
   int slen[4], nr[4];
   int sfCompress, preFlag, intensityScale;
@@ -1741,7 +1647,7 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
   if (sis->blockType == 2)
     btIdx = (sis->mixedBlock ? 2 : 1);
   for (i = 0; i < 4; i++)
-    nr[i] = (int)NRTab[sfcIdx][btIdx][i];
+    nr[i] = (int) NRTab[sfcIdx][btIdx][i];
 
   /* save intensity stereo scale factor info */
   if ((modeExt & 0x01) && (ch == 1)) {
@@ -1759,7 +1665,7 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
       /* do long block portion */
       iipTest = (1 << slen[0]) - 1;
       for (sfb = 0; sfb < 6; sfb++) {
-        sfis->l[sfb] = (char)GetBits(bsi, slen[0]);
+        sfis->l[sfb] = (char) GetBits(bsi, slen[0]);
       }
       sfb = 3; /* start sfb for short */
       nrIdx = 1;
@@ -1773,9 +1679,9 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
     for (; nrIdx <= 3; nrIdx++) {
       iipTest = (1 << slen[nrIdx]) - 1;
       for (i = 0; i < nr[nrIdx]; i++, sfb++) {
-        sfis->s[sfb][0] = (char)GetBits(bsi, slen[nrIdx]);
-        sfis->s[sfb][1] = (char)GetBits(bsi, slen[nrIdx]);
-        sfis->s[sfb][2] = (char)GetBits(bsi, slen[nrIdx]);
+        sfis->s[sfb][0] = (char) GetBits(bsi, slen[nrIdx]);
+        sfis->s[sfb][1] = (char) GetBits(bsi, slen[nrIdx]);
+        sfis->s[sfb][2] = (char) GetBits(bsi, slen[nrIdx]);
       }
     }
     /* last sf band not transmitted */
@@ -1786,7 +1692,7 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
     for (nrIdx = 0; nrIdx <= 3; nrIdx++) {
       iipTest = (1 << slen[nrIdx]) - 1;
       for (i = 0; i < nr[nrIdx]; i++, sfb++) {
-        sfis->l[sfb] = (char)GetBits(bsi, slen[nrIdx]);
+        sfis->l[sfb] = (char) GetBits(bsi, slen[nrIdx]);
       }
     }
     /* last sf band not transmitted */
@@ -1810,8 +1716,7 @@ static void UnpackSFMPEG2(BitStreamInfo *bsi, SideInfoSub *sis,
  * Return:      length (in bytes) of scale factor data, -1 if null input
  *pointers
  **************************************************************************************/
-int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf,
-                       int *bitOffset, int bitsAvail, int gr, int ch) {
+int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, int bitsAvail, int gr, int ch) {
   int bitsUsed;
   unsigned char *startBuf;
   BitStreamInfo bitStreamInfo, *bsi;
@@ -1820,12 +1725,11 @@ int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf,
   ScaleFactorInfo *sfi;
 
   /* validate pointers */
-  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS ||
-      !mp3DecInfo->ScaleFactorInfoPS)
+  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS || !mp3DecInfo->ScaleFactorInfoPS)
     return -1;
-  fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
-  si = ((SideInfo *)(mp3DecInfo->SideInfoPS));
-  sfi = ((ScaleFactorInfo *)(mp3DecInfo->ScaleFactorInfoPS));
+  fh = ((FrameHeader *) (mp3DecInfo->FrameHeaderPS));
+  si = ((SideInfo *) (mp3DecInfo->SideInfoPS));
+  sfi = ((ScaleFactorInfo *) (mp3DecInfo->ScaleFactorInfoPS));
 
   /* init GetBits reader */
   startBuf = buf;
@@ -1835,11 +1739,9 @@ int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf,
     GetBits(bsi, *bitOffset);
 
   if (fh->ver == MPEG1)
-    UnpackSFMPEG1(bsi, &si->sis[gr][ch], &sfi->sfis[gr][ch], si->scfsi[ch], gr,
-                  &sfi->sfis[0][ch]);
+    UnpackSFMPEG1(bsi, &si->sis[gr][ch], &sfi->sfis[gr][ch], si->scfsi[ch], gr, &sfi->sfis[0][ch]);
   else
-    UnpackSFMPEG2(bsi, &si->sis[gr][ch], &sfi->sfis[gr][ch], gr, ch,
-                  fh->modeExt, &sfi->sfjs);
+    UnpackSFMPEG2(bsi, &si->sis[gr][ch], &sfi->sfis[gr][ch], gr, ch, fh->modeExt, &sfi->sfjs);
 
   mp3DecInfo->part23Length[gr][ch] = si->sis[gr][ch].part23Length;
 
@@ -1988,18 +1890,15 @@ static void WinPrevious(int *xPrev, int *xPrevWin, int btPrev) {
     xPrevWin[1] = MULSHIFT32(wpLo[7], xPrev[1]) + MULSHIFT32(wpLo[1], xPrev[7]);
     xPrevWin[2] = MULSHIFT32(wpLo[8], xPrev[0]) + MULSHIFT32(wpLo[2], xPrev[8]);
     xPrevWin[3] = MULSHIFT32(wpLo[9], xPrev[0]) + MULSHIFT32(wpLo[3], xPrev[8]);
-    xPrevWin[4] =
-        MULSHIFT32(wpLo[10], xPrev[1]) + MULSHIFT32(wpLo[4], xPrev[7]);
-    xPrevWin[5] =
-        MULSHIFT32(wpLo[11], xPrev[2]) + MULSHIFT32(wpLo[5], xPrev[6]);
+    xPrevWin[4] = MULSHIFT32(wpLo[10], xPrev[1]) + MULSHIFT32(wpLo[4], xPrev[7]);
+    xPrevWin[5] = MULSHIFT32(wpLo[11], xPrev[2]) + MULSHIFT32(wpLo[5], xPrev[6]);
     xPrevWin[6] = MULSHIFT32(wpLo[6], xPrev[5]);
     xPrevWin[7] = MULSHIFT32(wpLo[7], xPrev[4]);
     xPrevWin[8] = MULSHIFT32(wpLo[8], xPrev[3]);
     xPrevWin[9] = MULSHIFT32(wpLo[9], xPrev[3]);
     xPrevWin[10] = MULSHIFT32(wpLo[10], xPrev[4]);
     xPrevWin[11] = MULSHIFT32(wpLo[11], xPrev[5]);
-    xPrevWin[12] = xPrevWin[13] = xPrevWin[14] = xPrevWin[15] = xPrevWin[16] =
-        xPrevWin[17] = 0;
+    xPrevWin[12] = xPrevWin[13] = xPrevWin[14] = xPrevWin[15] = xPrevWin[16] = xPrevWin[17] = 0;
   } else {
     /* use ARM-style pointers (*ptr++) so that ADS compiles well */
     wpLo = imdctWin[btPrev] + 18;
@@ -2142,8 +2041,7 @@ static const int c9_4 = 0x7e0e2e32;
  * cos(((0:8) + 0.5) * (pi/18))
  */
 static const int c18[9] = {
-    0x7f834ed0, 0x7ba3751d, 0x7401e4c1, 0x68d9f964, 0x5a82799a,
-    0x496af3e2, 0x36185aee, 0x2120fb83, 0x0b27eb5c,
+    0x7f834ed0, 0x7ba3751d, 0x7401e4c1, 0x68d9f964, 0x5a82799a, 0x496af3e2, 0x36185aee, 0x2120fb83, 0x0b27eb5c,
 };
 
 /* require at least 3 guard bits in x[] to ensure no overflow */
@@ -2234,9 +2132,8 @@ static __inline void idct9(int *x) {
  * format = Q30
  */
 int fastWin36[18] = {
-    0x42aace8b, 0xc2e92724, 0x47311c28, 0xc95f619a, 0x4a868feb, 0xd0859d8c,
-    0x4c913b51, 0xd8243ea0, 0x4d413ccc, 0xe0000000, 0x4c913b51, 0xe7dbc161,
-    0x4a868feb, 0xef7a6275, 0x47311c28, 0xf6a09e67, 0x42aace8b, 0xfd16d8dd,
+    0x42aace8b, 0xc2e92724, 0x47311c28, 0xc95f619a, 0x4a868feb, 0xd0859d8c, 0x4c913b51, 0xd8243ea0, 0x4d413ccc,
+    0xe0000000, 0x4c913b51, 0xe7dbc161, 0x4a868feb, 0xef7a6275, 0x47311c28, 0xf6a09e67, 0x42aace8b, 0xfd16d8dd,
 };
 
 /**************************************************************************************
@@ -2271,8 +2168,7 @@ int fastWin36[18] = {
  *                inline asm may or may not be helpful)
  **************************************************************************************/
 // barely faster in RAM
-static int IMDCT36(int *xCurr, int *xPrev, int *y, int btCurr, int btPrev,
-                   int blockIdx, int gb) {
+static int IMDCT36(int *xCurr, int *xPrev, int *y, int btCurr, int btPrev, int blockIdx, int gb) {
   int i, es, xBuf[18], xPrevWin[18];
   int acc1, acc2, s, d, t, mOut;
   int xo, xe, c, *xp, yLo, yHi;
@@ -2330,16 +2226,15 @@ static int IMDCT36(int *xCurr, int *xPrev, int *y, int btCurr, int btPrev,
       xo = MULSHIFT32(c, xo); /* 2*c18*xOdd (mul by 2 implicit in scaling)  */
       xe >>= 2;
 
-      s = -(*xPrev);  /* sum from last block (always at least 2 guard bits) */
-      d = -(xe - xo); /* gain 2 int bits, don't shift xo (effective << 1 to eat
-                         sign bit, << 1 for mul by 2) */
-      (*xPrev++) =
-          xe + xo; /* symmetry - xPrev[i] = xPrev[17-i] for long blocks */
+      s = -(*xPrev);        /* sum from last block (always at least 2 guard bits) */
+      d = -(xe - xo);       /* gain 2 int bits, don't shift xo (effective << 1 to eat
+                               sign bit, << 1 for mul by 2) */
+      (*xPrev++) = xe + xo; /* symmetry - xPrev[i] = xPrev[17-i] for long blocks */
       t = s - d;
 
       yLo = (d + (MULSHIFT32(t, *wp++) << 2));
       yHi = (s + (MULSHIFT32(t, *wp++) << 2));
-      y[(i)*NBANDS] = yLo;
+      y[(i) *NBANDS] = yLo;
       y[(17 - i) * NBANDS] = yHi;
       mOut |= FASTABS(yLo);
       mOut |= FASTABS(yHi);
@@ -2361,12 +2256,11 @@ static int IMDCT36(int *xCurr, int *xPrev, int *y, int btCurr, int btPrev,
       xe >>= 2;
 
       d = xe - xo;
-      (*xPrev++) =
-          xe + xo; /* symmetry - xPrev[i] = xPrev[17-i] for long blocks */
+      (*xPrev++) = xe + xo; /* symmetry - xPrev[i] = xPrev[17-i] for long blocks */
 
       yLo = (xPrevWin[i] + MULSHIFT32(d, wp[i])) << 2;
       yHi = (xPrevWin[17 - i] + MULSHIFT32(d, wp[17 - i])) << 2;
-      y[(i)*NBANDS] = yLo;
+      y[(i) *NBANDS] = yLo;
       y[(17 - i) * NBANDS] = yHi;
       mOut |= FASTABS(yLo);
       mOut |= FASTABS(yHi);
@@ -2379,9 +2273,8 @@ static int IMDCT36(int *xCurr, int *xPrev, int *y, int btCurr, int btPrev,
   return mOut;
 }
 
-static int c3_0 = 0x6ed9eba1; /* format = Q31, cos(pi/6) */
-static int c6[3] = {0x7ba3751d, 0x5a82799a,
-                    0x2120fb83}; /* format = Q31, cos(((0:2) + 0.5) * (pi/6)) */
+static int c3_0 = 0x6ed9eba1;                            /* format = Q31, cos(pi/6) */
+static int c6[3] = {0x7ba3751d, 0x5a82799a, 0x2120fb83}; /* format = Q31, cos(((0:2) + 0.5) * (pi/6)) */
 
 /* 12-point inverse DCT, used in IMDCT12x3()
  * 4 input guard bits will ensure no overflow
@@ -2465,10 +2358,8 @@ static __inline void imdct12(int *x, int *out) {
  * TODO:        optimize for ARM
  **************************************************************************************/
 // barely faster in RAM
-static int IMDCT12x3(int *xCurr, int *xPrev, int *y, int btPrev, int blockIdx,
-                     int gb) {
-  int i, es, mOut, yLo, xBuf[18],
-      xPrevWin[18]; /* need temp buffer for reordering short blocks */
+static int IMDCT12x3(int *xCurr, int *xPrev, int *y, int btPrev, int blockIdx, int gb) {
+  int i, es, mOut, yLo, xBuf[18], xPrevWin[18]; /* need temp buffer for reordering short blocks */
   const int *wp;
 
   es = 0;
@@ -2511,12 +2402,10 @@ static int IMDCT12x3(int *xCurr, int *xPrev, int *y, int btPrev, int blockIdx,
     yLo = (xPrevWin[9 + i] << 2) + (MULSHIFT32(wp[3 + i], xBuf[5 - i]));
     mOut |= FASTABS(yLo);
     y[(9 + i) * NBANDS] = yLo;
-    yLo = (xPrevWin[12 + i] << 2) + (MULSHIFT32(wp[6 + i], xBuf[2 - i]) +
-                                     MULSHIFT32(wp[0 + i], xBuf[(6 + 3) + i]));
+    yLo = (xPrevWin[12 + i] << 2) + (MULSHIFT32(wp[6 + i], xBuf[2 - i]) + MULSHIFT32(wp[0 + i], xBuf[(6 + 3) + i]));
     mOut |= FASTABS(yLo);
     y[(12 + i) * NBANDS] = yLo;
-    yLo = (xPrevWin[15 + i] << 2) + (MULSHIFT32(wp[9 + i], xBuf[0 + i]) +
-                                     MULSHIFT32(wp[3 + i], xBuf[(6 + 5) - i]));
+    yLo = (xPrevWin[15 + i] << 2) + (MULSHIFT32(wp[9 + i], xBuf[0 + i]) + MULSHIFT32(wp[3 + i], xBuf[(6 + 5) - i]));
     mOut |= FASTABS(yLo);
     y[(15 + i) * NBANDS] = yLo;
   }
@@ -2555,8 +2444,7 @@ static int IMDCT12x3(int *xCurr, int *xPrev, int *y, int btPrev, int blockIdx,
  *
  * TODO:        examine mixedBlock/winSwitch logic carefully (test he_mode.bit)
  **************************************************************************************/
-static int HybridTransform(int *xCurr, int *xPrev, int y[BLOCK_SIZE][NBANDS],
-                           SideInfoSub *sis, BlockCount *bc) {
+static int HybridTransform(int *xCurr, int *xPrev, int y[BLOCK_SIZE][NBANDS], SideInfoSub *sis, BlockCount *bc) {
   int xPrevWin[18], currWinIdx, prevWinIdx;
   int i, j, nBlocksOut, nonZero, mOut;
   int fiBit, xp;
@@ -2580,8 +2468,7 @@ static int HybridTransform(int *xCurr, int *xPrev, int y[BLOCK_SIZE][NBANDS],
       prevWinIdx = 0;
 
     /* do 36-point IMDCT, including windowing and overlap-add */
-    mOut |=
-        IMDCT36(xCurr, xPrev, &(y[0][i]), currWinIdx, prevWinIdx, i, bc->gbIn);
+    mOut |= IMDCT36(xCurr, xPrev, &(y[0][i]), currWinIdx, prevWinIdx, i, bc->gbIn);
     xCurr += 18;
     xPrev += 9;
   }
@@ -2668,16 +2555,16 @@ int IMDCT(MP3DecInfo *mp3DecInfo, int gr, int ch) {
   BlockCount bc;
 
   /* validate pointers */
-  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS ||
-      !mp3DecInfo->HuffmanInfoPS || !mp3DecInfo->IMDCTInfoPS)
+  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS || !mp3DecInfo->HuffmanInfoPS ||
+      !mp3DecInfo->IMDCTInfoPS)
     return -1;
 
   /* si is an array of up to 4 structs, stored as gr0ch0, gr0ch1, gr1ch0, gr1ch1
    */
-  fh = (FrameHeader *)(mp3DecInfo->FrameHeaderPS);
-  si = (SideInfo *)(mp3DecInfo->SideInfoPS);
-  hi = (HuffmanInfo *)(mp3DecInfo->HuffmanInfoPS);
-  mi = (IMDCTInfo *)(mp3DecInfo->IMDCTInfoPS);
+  fh = (FrameHeader *) (mp3DecInfo->FrameHeaderPS);
+  si = (SideInfo *) (mp3DecInfo->SideInfoPS);
+  hi = (HuffmanInfo *) (mp3DecInfo->HuffmanInfoPS);
+  mi = (IMDCTInfo *) (mp3DecInfo->IMDCTInfoPS);
 
   /* anti-aliasing done on whole long blocks only
    * for mixed blocks, nBfly always 1, except 3 for 8 kHz MPEG 2.5 (see
@@ -2685,8 +2572,7 @@ int IMDCT(MP3DecInfo *mp3DecInfo, int gr, int ch) {
    *   nBfly = number of butterflies to do (nLongBlocks - 1, unless no long
    * blocks)
    */
-  blockCutoff = fh->sfBand->l[(fh->ver == MPEG1 ? 8 : 6)] /
-                18; /* same as 3* num short sfb's in spec */
+  blockCutoff = fh->sfBand->l[(fh->ver == MPEG1 ? 8 : 6)] / 18; /* same as 3* num short sfb's in spec */
   if (si->sis[gr][ch].blockType != 2) {
     /* all long transforms */
     bc.nBlocksLong = MIN((hi->nonZeroBound[ch] + 7) / 18 + 1, 32);
@@ -2712,13 +2598,10 @@ int IMDCT(MP3DecInfo *mp3DecInfo, int gr, int ch) {
   bc.nBlocksPrev = mi->numPrevIMDCT[ch];
   bc.prevType = mi->prevType[ch];
   bc.prevWinSwitch = mi->prevWinSwitch[ch];
-  bc.currWinSwitch = (si->sis[gr][ch].mixedBlock
-                          ? blockCutoff
-                          : 0); /* where WINDOW switches (not nec. transform) */
+  bc.currWinSwitch = (si->sis[gr][ch].mixedBlock ? blockCutoff : 0); /* where WINDOW switches (not nec. transform) */
   bc.gbIn = hi->gb[ch];
 
-  mi->numPrevIMDCT[ch] = HybridTransform(hi->huffDecBuf[ch], mi->overBuf[ch],
-                                         mi->outBuf[ch], &si->sis[gr][ch], &bc);
+  mi->numPrevIMDCT[ch] = HybridTransform(hi->huffDecBuf[ch], mi->overBuf[ch], mi->outBuf[ch], &si->sis[gr][ch], &bc);
   mi->prevType[ch] = si->sis[gr][ch].blockType;
   mi->prevWinSwitch[ch] = bc.currWinSwitch; /* 0 means not a mixed block (either
                                                all short or all long) */
@@ -7088,16 +6971,12 @@ const int huffTabOffset[HUFF_PAIRTABS] = {
 };
 
 const HuffTabLookup huffTabLookup[HUFF_PAIRTABS] = {
-    {0, noBits},        {0, oneShot},       {0, oneShot},
-    {0, oneShot},       {0, invalidTab},    {0, oneShot},
-    {0, oneShot},       {0, loopNoLinbits}, {0, loopNoLinbits},
-    {0, loopNoLinbits}, {0, loopNoLinbits}, {0, loopNoLinbits},
-    {0, loopNoLinbits}, {0, loopNoLinbits}, {0, invalidTab},
-    {0, loopNoLinbits}, {1, loopLinbits},   {2, loopLinbits},
-    {3, loopLinbits},   {4, loopLinbits},   {6, loopLinbits},
-    {8, loopLinbits},   {10, loopLinbits},  {13, loopLinbits},
-    {4, loopLinbits},   {5, loopLinbits},   {6, loopLinbits},
-    {7, loopLinbits},   {8, loopLinbits},   {9, loopLinbits},
+    {0, noBits},        {0, oneShot},       {0, oneShot},       {0, oneShot},       {0, invalidTab},
+    {0, oneShot},       {0, oneShot},       {0, loopNoLinbits}, {0, loopNoLinbits}, {0, loopNoLinbits},
+    {0, loopNoLinbits}, {0, loopNoLinbits}, {0, loopNoLinbits}, {0, loopNoLinbits}, {0, invalidTab},
+    {0, loopNoLinbits}, {1, loopLinbits},   {2, loopLinbits},   {3, loopLinbits},   {4, loopLinbits},
+    {6, loopLinbits},   {8, loopLinbits},   {10, loopLinbits},  {13, loopLinbits},  {4, loopLinbits},
+    {5, loopLinbits},   {6, loopLinbits},   {7, loopLinbits},   {8, loopLinbits},   {9, loopLinbits},
     {11, loopLinbits},  {13, loopLinbits},
 };
 
@@ -7196,22 +7075,22 @@ const int quadTabMaxBits[2] = {6, 4};
 
 /* helper macros - see comments in hufftabs.c about the format of the huffman
  * tables */
-#define GetMaxbits(x) ((int)((((unsigned short)(x)) >> 0) & 0x000f))
-#define GetHLen(x) ((int)((((unsigned short)(x)) >> 12) & 0x000f))
-#define GetCWY(x) ((int)((((unsigned short)(x)) >> 8) & 0x000f))
-#define GetCWX(x) ((int)((((unsigned short)(x)) >> 4) & 0x000f))
-#define GetSignBits(x) ((int)((((unsigned short)(x)) >> 0) & 0x000f))
+#define GetMaxbits(x) ((int) ((((unsigned short) (x)) >> 0) & 0x000f))
+#define GetHLen(x) ((int) ((((unsigned short) (x)) >> 12) & 0x000f))
+#define GetCWY(x) ((int) ((((unsigned short) (x)) >> 8) & 0x000f))
+#define GetCWX(x) ((int) ((((unsigned short) (x)) >> 4) & 0x000f))
+#define GetSignBits(x) ((int) ((((unsigned short) (x)) >> 0) & 0x000f))
 
-#define GetHLenQ(x) ((int)((((unsigned char)(x)) >> 4) & 0x0f))
-#define GetCWVQ(x) ((int)((((unsigned char)(x)) >> 3) & 0x01))
-#define GetCWWQ(x) ((int)((((unsigned char)(x)) >> 2) & 0x01))
-#define GetCWXQ(x) ((int)((((unsigned char)(x)) >> 1) & 0x01))
-#define GetCWYQ(x) ((int)((((unsigned char)(x)) >> 0) & 0x01))
+#define GetHLenQ(x) ((int) ((((unsigned char) (x)) >> 4) & 0x0f))
+#define GetCWVQ(x) ((int) ((((unsigned char) (x)) >> 3) & 0x01))
+#define GetCWWQ(x) ((int) ((((unsigned char) (x)) >> 2) & 0x01))
+#define GetCWXQ(x) ((int) ((((unsigned char) (x)) >> 1) & 0x01))
+#define GetCWYQ(x) ((int) ((((unsigned char) (x)) >> 0) & 0x01))
 
 /* apply sign of s to the positive number x (save in MSB, will do two's
  * complement in dequant) */
-#define ApplySign(x, s)                                                        \
-  { (x) |= ((s)&0x80000000); }
+#define ApplySign(x, s) \
+  { (x) |= ((s) & 0x80000000); }
 
 /**************************************************************************************
  * Function:    DecodeHuffmanPairs
@@ -7235,8 +7114,7 @@ const int quadTabMaxBits[2] = {6, 4};
  *not necessarily all linBits outputs for x,y > 15)
  **************************************************************************************/
 // no improvement with section=data
-static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
-                              unsigned char *buf, int bitOffset) {
+static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft, unsigned char *buf, int bitOffset) {
   int i, x, y;
   int cachedBits, padBits, len, startBits, linBits, maxBits, minBits;
   HuffTabType tabType;
@@ -7250,7 +7128,7 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
     return -1;
   startBits = bitsLeft;
 
-  tBase = (unsigned short *)(huffTable + huffTabOffset[tabIdx]);
+  tBase = (unsigned short *) (huffTable + huffTabOffset[tabIdx]);
   linBits = huffTabLookup[tabIdx].linBits;
   tabType = huffTabLookup[tabIdx].tabType;
 
@@ -7263,7 +7141,7 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
   cache = 0;
   cachedBits = (8 - bitOffset) & 0x07;
   if (cachedBits)
-    cache = (unsigned int)(*buf++) << (32 - cachedBits);
+    cache = (unsigned int) (*buf++) << (32 - cachedBits);
   bitsLeft -= cachedBits;
 
   if (tabType == noBits) {
@@ -7282,8 +7160,8 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
       /* refill cache - assumes cachedBits <= 16 */
       if (bitsLeft >= 16) {
         /* load 2 new bytes into left-justified cache */
-        cache |= (unsigned int)(*buf++) << (24 - cachedBits);
-        cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (24 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (16 - cachedBits);
         cachedBits += 16;
         bitsLeft -= 16;
       } else {
@@ -7291,13 +7169,13 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
         if (cachedBits + bitsLeft <= 0)
           return -1;
         if (bitsLeft > 0)
-          cache |= (unsigned int)(*buf++) << (24 - cachedBits);
+          cache |= (unsigned int) (*buf++) << (24 - cachedBits);
         if (bitsLeft > 8)
-          cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+          cache |= (unsigned int) (*buf++) << (16 - cachedBits);
         cachedBits += bitsLeft;
         bitsLeft = 0;
 
-        cache &= (signed int)0x80000000 >> (cachedBits - 1);
+        cache &= (signed int) 0x80000000 >> (cachedBits - 1);
         padBits = 11;
         cachedBits += padBits; /* okay if this is > 32 (0's automatically
                                   shifted in from right) */
@@ -7342,8 +7220,8 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
       /* refill cache - assumes cachedBits <= 16 */
       if (bitsLeft >= 16) {
         /* load 2 new bytes into left-justified cache */
-        cache |= (unsigned int)(*buf++) << (24 - cachedBits);
-        cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (24 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (16 - cachedBits);
         cachedBits += 16;
         bitsLeft -= 16;
       } else {
@@ -7351,13 +7229,13 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
         if (cachedBits + bitsLeft <= 0)
           return -1;
         if (bitsLeft > 0)
-          cache |= (unsigned int)(*buf++) << (24 - cachedBits);
+          cache |= (unsigned int) (*buf++) << (24 - cachedBits);
         if (bitsLeft > 8)
-          cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+          cache |= (unsigned int) (*buf++) << (16 - cachedBits);
         cachedBits += bitsLeft;
         bitsLeft = 0;
 
-        cache &= (signed int)0x80000000 >> (cachedBits - 1);
+        cache &= (signed int) 0x80000000 >> (cachedBits - 1);
         padBits = 11;
         cachedBits += padBits; /* okay if this is > 32 (0's automatically
                                   shifted in from right) */
@@ -7386,16 +7264,16 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
           if (cachedBits + bitsLeft < minBits)
             return -1;
           while (cachedBits < minBits) {
-            cache |= (unsigned int)(*buf++) << (24 - cachedBits);
+            cache |= (unsigned int) (*buf++) << (24 - cachedBits);
             cachedBits += 8;
             bitsLeft -= 8;
           }
           if (bitsLeft < 0) {
             cachedBits += bitsLeft;
             bitsLeft = 0;
-            cache &= (signed int)0x80000000 >> (cachedBits - 1);
+            cache &= (signed int) 0x80000000 >> (cachedBits - 1);
           }
-          x += (int)(cache >> (32 - linBits));
+          x += (int) (cache >> (32 - linBits));
           cachedBits -= linBits;
           cache <<= linBits;
         }
@@ -7410,16 +7288,16 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
           if (cachedBits + bitsLeft < minBits)
             return -1;
           while (cachedBits < minBits) {
-            cache |= (unsigned int)(*buf++) << (24 - cachedBits);
+            cache |= (unsigned int) (*buf++) << (24 - cachedBits);
             cachedBits += 8;
             bitsLeft -= 8;
           }
           if (bitsLeft < 0) {
             cachedBits += bitsLeft;
             bitsLeft = 0;
-            cache &= (signed int)0x80000000 >> (cachedBits - 1);
+            cache &= (signed int) 0x80000000 >> (cachedBits - 1);
           }
-          y += (int)(cache >> (32 - linBits));
+          y += (int) (cache >> (32 - linBits));
           cachedBits -= linBits;
           cache <<= linBits;
         }
@@ -7468,8 +7346,7 @@ static int DecodeHuffmanPairs(int *xy, int nVals, int tabIdx, int bitsLeft,
  * Notes:        si_huff.bit tests every vwxy output in both quad tables
  **************************************************************************************/
 // no improvement with section=data
-static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft,
-                              unsigned char *buf, int bitOffset) {
+static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft, unsigned char *buf, int bitOffset) {
   int i, v, w, x, y;
   int len, maxBits, cachedBits, padBits;
   unsigned int cache;
@@ -7478,14 +7355,14 @@ static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft,
   if (bitsLeft <= 0)
     return 0;
 
-  tBase = (unsigned char *)quadTable + quadTabOffset[tabIdx];
+  tBase = (unsigned char *) quadTable + quadTabOffset[tabIdx];
   maxBits = quadTabMaxBits[tabIdx];
 
   /* initially fill cache with any partial byte */
   cache = 0;
   cachedBits = (8 - bitOffset) & 0x07;
   if (cachedBits)
-    cache = (unsigned int)(*buf++) << (32 - cachedBits);
+    cache = (unsigned int) (*buf++) << (32 - cachedBits);
   bitsLeft -= cachedBits;
 
   i = padBits = 0;
@@ -7493,8 +7370,8 @@ static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft,
     /* refill cache - assumes cachedBits <= 16 */
     if (bitsLeft >= 16) {
       /* load 2 new bytes into left-justified cache */
-      cache |= (unsigned int)(*buf++) << (24 - cachedBits);
-      cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+      cache |= (unsigned int) (*buf++) << (24 - cachedBits);
+      cache |= (unsigned int) (*buf++) << (16 - cachedBits);
       cachedBits += 16;
       bitsLeft -= 16;
     } else {
@@ -7502,13 +7379,13 @@ static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft,
       if (cachedBits + bitsLeft <= 0)
         return i;
       if (bitsLeft > 0)
-        cache |= (unsigned int)(*buf++) << (24 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (24 - cachedBits);
       if (bitsLeft > 8)
-        cache |= (unsigned int)(*buf++) << (16 - cachedBits);
+        cache |= (unsigned int) (*buf++) << (16 - cachedBits);
       cachedBits += bitsLeft;
       bitsLeft = 0;
 
-      cache &= (signed int)0x80000000 >> (cachedBits - 1);
+      cache &= (signed int) 0x80000000 >> (cachedBits - 1);
       padBits = 10;
       cachedBits += padBits; /* okay if this is > 32 (0's automatically shifted
                                 in from right) */
@@ -7585,8 +7462,7 @@ static int DecodeHuffmanQuads(int *vwxy, int nVals, int tabIdx, int bitsLeft,
  *                out of bits prematurely (invalid bitstream)
  **************************************************************************************/
 // .data about 1ms faster per frame
-int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset,
-                  int huffBlockBits, int gr, int ch) {
+int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, int huffBlockBits, int gr, int ch) {
   int r1Start, r2Start, rEnd[4]; /* region boundaries */
   int i, w, bitsUsed, bitsLeft;
   unsigned char *startBuf = buf;
@@ -7598,15 +7474,15 @@ int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset,
   HuffmanInfo *hi;
 
   /* validate pointers */
-  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS ||
-      !mp3DecInfo->ScaleFactorInfoPS || !mp3DecInfo->HuffmanInfoPS)
+  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS || !mp3DecInfo->ScaleFactorInfoPS ||
+      !mp3DecInfo->HuffmanInfoPS)
     return -1;
 
-  fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
-  si = ((SideInfo *)(mp3DecInfo->SideInfoPS));
+  fh = ((FrameHeader *) (mp3DecInfo->FrameHeaderPS));
+  si = ((SideInfo *) (mp3DecInfo->SideInfoPS));
   sis = &si->sis[gr][ch];
-  sfi = ((ScaleFactorInfo *)(mp3DecInfo->ScaleFactorInfoPS));
-  hi = (HuffmanInfo *)(mp3DecInfo->HuffmanInfoPS);
+  sfi = ((ScaleFactorInfo *) (mp3DecInfo->ScaleFactorInfoPS));
+  hi = (HuffmanInfo *) (mp3DecInfo->HuffmanInfoPS);
 
   if (huffBlockBits < 0)
     return -1;
@@ -7644,11 +7520,9 @@ int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset,
   /* decode Huffman pairs (rEnd[i] are always even numbers) */
   bitsLeft = huffBlockBits;
   for (i = 0; i < 3; i++) {
-    bitsUsed =
-        DecodeHuffmanPairs(hi->huffDecBuf[ch] + rEnd[i], rEnd[i + 1] - rEnd[i],
-                           sis->tableSelect[i], bitsLeft, buf, *bitOffset);
-    if (bitsUsed < 0 ||
-        bitsUsed > bitsLeft) /* error - overran end of bitstream */
+    bitsUsed = DecodeHuffmanPairs(hi->huffDecBuf[ch] + rEnd[i], rEnd[i + 1] - rEnd[i], sis->tableSelect[i], bitsLeft,
+                                  buf, *bitOffset);
+    if (bitsUsed < 0 || bitsUsed > bitsLeft) /* error - overran end of bitstream */
       return -1;
 
     /* update bitstream position */
@@ -7658,9 +7532,8 @@ int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset,
   }
 
   /* decode Huffman quads (if any) */
-  hi->nonZeroBound[ch] +=
-      DecodeHuffmanQuads(hi->huffDecBuf[ch] + rEnd[3], MAX_NSAMP - rEnd[3],
-                         sis->count1TableSelect, bitsLeft, buf, *bitOffset);
+  hi->nonZeroBound[ch] += DecodeHuffmanQuads(hi->huffDecBuf[ch] + rEnd[3], MAX_NSAMP - rEnd[3], sis->count1TableSelect,
+                                             bitsLeft, buf, *bitOffset);
 
   ASSERT(hi->nonZeroBound[ch] <= MAX_NSAMP);
   for (i = hi->nonZeroBound[ch]; i < MAX_NSAMP; i++)
@@ -7711,27 +7584,25 @@ int Dequantize(MP3DecInfo *mp3DecInfo, int gr) {
   CriticalBandInfo *cbi;
 
   /* validate pointers */
-  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS ||
-      !mp3DecInfo->ScaleFactorInfoPS || !mp3DecInfo->HuffmanInfoPS ||
-      !mp3DecInfo->DequantInfoPS)
+  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS || !mp3DecInfo->ScaleFactorInfoPS ||
+      !mp3DecInfo->HuffmanInfoPS || !mp3DecInfo->DequantInfoPS)
     return -1;
 
-  fh = (FrameHeader *)(mp3DecInfo->FrameHeaderPS);
+  fh = (FrameHeader *) (mp3DecInfo->FrameHeaderPS);
 
   /* si is an array of up to 4 structs, stored as gr0ch0, gr0ch1, gr1ch0, gr1ch1
    */
-  si = (SideInfo *)(mp3DecInfo->SideInfoPS);
-  sfi = (ScaleFactorInfo *)(mp3DecInfo->ScaleFactorInfoPS);
-  hi = (HuffmanInfo *)mp3DecInfo->HuffmanInfoPS;
-  di = (DequantInfo *)mp3DecInfo->DequantInfoPS;
+  si = (SideInfo *) (mp3DecInfo->SideInfoPS);
+  sfi = (ScaleFactorInfo *) (mp3DecInfo->ScaleFactorInfoPS);
+  hi = (HuffmanInfo *) mp3DecInfo->HuffmanInfoPS;
+  di = (DequantInfo *) mp3DecInfo->DequantInfoPS;
   cbi = di->cbi;
   mOut[0] = mOut[1] = 0;
 
   /* dequantize all the samples in each channel */
   for (ch = 0; ch < mp3DecInfo->nChans; ch++) {
-    hi->gb[ch] =
-        DequantChannel(hi->huffDecBuf[ch], di->workBuf, &hi->nonZeroBound[ch],
-                       fh, &si->sis[gr][ch], &sfi->sfis[gr][ch], &cbi[ch]);
+    hi->gb[ch] = DequantChannel(hi->huffDecBuf[ch], di->workBuf, &hi->nonZeroBound[ch], fh, &si->sis[gr][ch],
+                                &sfi->sfis[gr][ch], &cbi[ch]);
   }
 
   /* joint stereo processing assumes one guard bit in input samples
@@ -7774,11 +7645,10 @@ int Dequantize(MP3DecInfo *mp3DecInfo, int gr) {
   if (fh->modeExt & 0x01) {
     nSamps = hi->nonZeroBound[0];
     if (fh->ver == MPEG1) {
-      IntensityProcMPEG1(hi->huffDecBuf, nSamps, fh, &sfi->sfis[gr][1], di->cbi,
-                         fh->modeExt >> 1, si->sis[gr][1].mixedBlock, mOut);
+      IntensityProcMPEG1(hi->huffDecBuf, nSamps, fh, &sfi->sfis[gr][1], di->cbi, fh->modeExt >> 1,
+                         si->sis[gr][1].mixedBlock, mOut);
     } else {
-      IntensityProcMPEG2(hi->huffDecBuf, nSamps, fh, &sfi->sfis[gr][1], di->cbi,
-                         &sfi->sfjs, fh->modeExt >> 1,
+      IntensityProcMPEG2(hi->huffDecBuf, nSamps, fh, &sfi->sfis[gr][1], di->cbi, &sfi->sfjs, fh->modeExt >> 1,
                          si->sis[gr][1].mixedBlock, mOut);
     }
   }
@@ -7854,20 +7724,20 @@ static const int dcttab[48] = {
     -COS2_1, -COS2_2, COS3_1, /* 31, 31, 30 */
 };
 
-#define D32FP(i, s0, s1, s2)                                                   \
-  {                                                                            \
-    a0 = buf[i];                                                               \
-    a3 = buf[31 - i];                                                          \
-    a1 = buf[15 - i];                                                          \
-    a2 = buf[16 + i];                                                          \
-    b0 = a0 + a3;                                                              \
-    b3 = MULSHIFT32(*cptr++, a0 - a3) << (s0);                                 \
-    b1 = a1 + a2;                                                              \
-    b2 = MULSHIFT32(*cptr++, a1 - a2) << (s1);                                 \
-    buf[i] = b0 + b1;                                                          \
-    buf[15 - i] = MULSHIFT32(*cptr, b0 - b1) << (s2);                          \
-    buf[16 + i] = b2 + b3;                                                     \
-    buf[31 - i] = MULSHIFT32(*cptr++, b3 - b2) << (s2);                        \
+#define D32FP(i, s0, s1, s2) \
+  { \
+    a0 = buf[i]; \
+    a3 = buf[31 - i]; \
+    a1 = buf[15 - i]; \
+    a2 = buf[16 + i]; \
+    b0 = a0 + a3; \
+    b3 = MULSHIFT32(*cptr++, a0 - a3) << (s0); \
+    b1 = a1 + a2; \
+    b2 = MULSHIFT32(*cptr++, a1 - a2) << (s1); \
+    buf[i] = b0 + b1; \
+    buf[15 - i] = MULSHIFT32(*cptr, b0 - b1) << (s2); \
+    buf[16 + i] = b2 + b3; \
+    buf[31 - i] = MULSHIFT32(*cptr++, b3 - b2) << (s2); \
   }
 
 /**************************************************************************************
@@ -8106,8 +7976,7 @@ void FDCT32(int *buf, int *dest, int offset, int oddBlock, int gb) {
    * that es != 0
    */
   if (es) {
-    d = dest + 64 * 16 + ((offset - oddBlock) & 7) +
-        (oddBlock ? 0 : VBUF_LENGTH);
+    d = dest + 64 * 16 + ((offset - oddBlock) & 7) + (oddBlock ? 0 : VBUF_LENGTH);
     s = d[0];
     CLIP_2N(s, 31 - es);
     d[0] = d[8] = (s << es);
@@ -8146,7 +8015,7 @@ void FDCT32(int *buf, int *dest, int offset, int oddBlock, int gb) {
  **************************************************************************************/
 static void ClearBuffer(void *buf, int nBytes) {
   int i;
-  unsigned char *cbuf = (unsigned char *)buf;
+  unsigned char *cbuf = (unsigned char *) buf;
 
   for (i = 0; i < nBytes; i++)
     cbuf[i] = 0;
@@ -8183,7 +8052,8 @@ MP3DecInfo *AllocateBuffers(void) {
   esphome::ExternalRAMAllocator<MP3DecInfo> mp3di_allocator(esphome::ExternalRAMAllocator<MP3DecInfo>::ALLOW_FAILURE);
   esphome::ExternalRAMAllocator<FrameHeader> fh_allocator(esphome::ExternalRAMAllocator<FrameHeader>::ALLOW_FAILURE);
   esphome::ExternalRAMAllocator<SideInfo> si_allocator(esphome::ExternalRAMAllocator<SideInfo>::ALLOW_FAILURE);
-  esphome::ExternalRAMAllocator<ScaleFactorInfo> sfi_allocator(esphome::ExternalRAMAllocator<ScaleFactorInfo>::ALLOW_FAILURE);
+  esphome::ExternalRAMAllocator<ScaleFactorInfo> sfi_allocator(
+      esphome::ExternalRAMAllocator<ScaleFactorInfo>::ALLOW_FAILURE);
   esphome::ExternalRAMAllocator<HuffmanInfo> hi_allocator(esphome::ExternalRAMAllocator<HuffmanInfo>::ALLOW_FAILURE);
   esphome::ExternalRAMAllocator<DequantInfo> di_allocator(esphome::ExternalRAMAllocator<DequantInfo>::ALLOW_FAILURE);
   esphome::ExternalRAMAllocator<IMDCTInfo> mi_allocator(esphome::ExternalRAMAllocator<IMDCTInfo>::ALLOW_FAILURE);
@@ -8194,8 +8064,6 @@ MP3DecInfo *AllocateBuffers(void) {
   if (!mp3DecInfo)
     return 0;
   ClearBuffer(mp3DecInfo, sizeof(MP3DecInfo));
-
-
 
   // fh = (FrameHeader *)malloc(sizeof(FrameHeader));
   // si = (SideInfo *)malloc(sizeof(SideInfo));
@@ -8212,13 +8080,13 @@ MP3DecInfo *AllocateBuffers(void) {
   mi = mi_allocator.allocate(1);
   sbi = sbi_allocator.allocate(1);
 
-  mp3DecInfo->FrameHeaderPS = (void *)fh;
-  mp3DecInfo->SideInfoPS = (void *)si;
-  mp3DecInfo->ScaleFactorInfoPS = (void *)sfi;
-  mp3DecInfo->HuffmanInfoPS = (void *)hi;
-  mp3DecInfo->DequantInfoPS = (void *)di;
-  mp3DecInfo->IMDCTInfoPS = (void *)mi;
-  mp3DecInfo->SubbandInfoPS = (void *)sbi;
+  mp3DecInfo->FrameHeaderPS = (void *) fh;
+  mp3DecInfo->SideInfoPS = (void *) si;
+  mp3DecInfo->ScaleFactorInfoPS = (void *) sfi;
+  mp3DecInfo->HuffmanInfoPS = (void *) hi;
+  mp3DecInfo->DequantInfoPS = (void *) di;
+  mp3DecInfo->IMDCTInfoPS = (void *) mi;
+  mp3DecInfo->SubbandInfoPS = (void *) sbi;
 
   if (!fh || !si || !sfi || !hi || !di || !mi || !sbi) {
     FreeBuffers(mp3DecInfo); /* safe to call - only frees memory that was
@@ -8239,11 +8107,11 @@ MP3DecInfo *AllocateBuffers(void) {
   return mp3DecInfo;
 }
 
-#define SAFE_FREE(x)                                                           \
-  {                                                                            \
-    if (x)                                                                     \
-      free(x);                                                                 \
-    (x) = 0;                                                                   \
+#define SAFE_FREE(x) \
+  { \
+    if (x) \
+      free(x); \
+    (x) = 0; \
   } /* helper macro */
 
 /**************************************************************************************
@@ -8358,13 +8226,12 @@ static __inline void RefillBitstreamCache(BitStreamInfo *bsi) {
 unsigned int GetBits(BitStreamInfo *bsi, int nBits) {
   unsigned int data, lowBits;
 
-  nBits &= 0x1f; /* nBits mod 32 to avoid unpredictable results like >> by
-                    negative amount */
+  nBits &= 0x1f;                      /* nBits mod 32 to avoid unpredictable results like >> by
+                                         negative amount */
   data = bsi->iCache >> (31 - nBits); /* unsigned >> so zero-extend */
-  data >>= 1; /* do as >> 31, >> 1 so that nBits = 0 works okay (returns 0) */
-  bsi->iCache <<= nBits; /* left-justify cache */
-  bsi->cachedBits -=
-      nBits; /* how many bits have we drawn from the cache so far */
+  data >>= 1;                         /* do as >> 31, >> 1 so that nBits = 0 works okay (returns 0) */
+  bsi->iCache <<= nBits;              /* left-justify cache */
+  bsi->cachedBits -= nBits;           /* how many bits have we drawn from the cache so far */
 
   /* if we cross an int boundary, refill the cache */
   if (bsi->cachedBits < 0) {
@@ -8372,9 +8239,8 @@ unsigned int GetBits(BitStreamInfo *bsi, int nBits) {
     RefillBitstreamCache(bsi);
     data |= bsi->iCache >> (32 - lowBits); /* get the low-order bits */
 
-    bsi->cachedBits -=
-        lowBits; /* how many bits have we drawn from the cache so far */
-    bsi->iCache <<= lowBits; /* left-justify cache */
+    bsi->cachedBits -= lowBits; /* how many bits have we drawn from the cache so far */
+    bsi->iCache <<= lowBits;    /* left-justify cache */
   }
 
   return data;
@@ -8423,7 +8289,7 @@ int CheckPadBit(MP3DecInfo *mp3DecInfo) {
   if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS)
     return -1;
 
-  fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
+  fh = ((FrameHeader *) (mp3DecInfo->FrameHeaderPS));
 
   return (fh->paddingBit ? 1 : 0);
 }
@@ -8447,31 +8313,27 @@ int CheckPadBit(MP3DecInfo *mp3DecInfo) {
  *              test CRC on actual stream (verify no endian problems)
  **************************************************************************************/
 int UnpackFrameHeader(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
-
   int verIdx;
   FrameHeader *fh;
 
   /* validate pointers and sync word */
-  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS ||
-      (buf[0] & SYNCWORDH) != SYNCWORDH || (buf[1] & SYNCWORDL) != SYNCWORDL)
+  if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || (buf[0] & SYNCWORDH) != SYNCWORDH ||
+      (buf[1] & SYNCWORDL) != SYNCWORDL)
     return -1;
 
-  fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
+  fh = ((FrameHeader *) (mp3DecInfo->FrameHeaderPS));
 
   /* read header fields - use bitmasks instead of GetBits() for speed, since
    * format never varies */
   verIdx = (buf[1] >> 3) & 0x03;
-  fh->ver =
-      (MPEGVersion)(verIdx == 0 ? MPEG25 : ((verIdx & 0x01) ? MPEG1 : MPEG2));
-  fh->layer = 4 - ((buf[1] >> 1) &
-                   0x03); /* easy mapping of index to layer number, 4 = error */
+  fh->ver = (MPEGVersion) (verIdx == 0 ? MPEG25 : ((verIdx & 0x01) ? MPEG1 : MPEG2));
+  fh->layer = 4 - ((buf[1] >> 1) & 0x03); /* easy mapping of index to layer number, 4 = error */
   fh->crc = 1 - ((buf[1] >> 0) & 0x01);
   fh->brIdx = (buf[2] >> 4) & 0x0f;
   fh->srIdx = (buf[2] >> 2) & 0x03;
   fh->paddingBit = (buf[2] >> 1) & 0x01;
   fh->privateBit = (buf[2] >> 0) & 0x01;
-  fh->sMode = (StereoMode)((buf[3] >> 6) &
-                           0x03); /* maps to correct enum (see definition) */
+  fh->sMode = (StereoMode) ((buf[3] >> 6) & 0x03); /* maps to correct enum (see definition) */
   fh->modeExt = (buf[3] >> 4) & 0x03;
   fh->copyFlag = (buf[3] >> 3) & 0x01;
   fh->origFlag = (buf[3] >> 2) & 0x01;
@@ -8481,19 +8343,16 @@ int UnpackFrameHeader(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
   if (fh->srIdx == 3 || fh->layer == 4 || fh->brIdx == 15)
     return -1;
 
-  fh->sfBand =
-      &sfBandTable[fh->ver][fh->srIdx]; /* for readability (we reference
-                                           sfBandTable many times in decoder) */
-  if (fh->sMode !=
-      Joint) /* just to be safe (dequant, stproc check fh->modeExt) */
+  fh->sfBand = &sfBandTable[fh->ver][fh->srIdx]; /* for readability (we reference
+                                                    sfBandTable many times in decoder) */
+  if (fh->sMode != Joint)                        /* just to be safe (dequant, stproc check fh->modeExt) */
     fh->modeExt = 0;
 
   /* init user-accessible data */
   mp3DecInfo->nChans = (fh->sMode == Mono ? 1 : 2);
   mp3DecInfo->samprate = samplerateTab[fh->ver][fh->srIdx];
   mp3DecInfo->nGrans = (fh->ver == MPEG1 ? NGRANS_MPEG1 : NGRANS_MPEG2);
-  mp3DecInfo->nGranSamps =
-      ((int)samplesPerFrameTab[fh->ver][fh->layer - 1]) / mp3DecInfo->nGrans;
+  mp3DecInfo->nGranSamps = ((int) samplesPerFrameTab[fh->ver][fh->layer - 1]) / mp3DecInfo->nGrans;
   mp3DecInfo->layer = fh->layer;
   mp3DecInfo->version = fh->ver;
 
@@ -8505,20 +8364,18 @@ int UnpackFrameHeader(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
    * free or none free)
    */
   if (fh->brIdx) {
-    mp3DecInfo->bitrate =
-        ((int)bitrateTab[fh->ver][fh->layer - 1][fh->brIdx]) * 1000;
+    mp3DecInfo->bitrate = ((int) bitrateTab[fh->ver][fh->layer - 1][fh->brIdx]) * 1000;
 
     /* nSlots = total frame bytes (from table) - sideInfo bytes - header - CRC
      * (if present) + pad (if present) */
-    mp3DecInfo->nSlots =
-        (int)slotTab[fh->ver][fh->srIdx][fh->brIdx] -
-        (int)sideBytesTab[fh->ver][(fh->sMode == Mono ? 0 : 1)] - 4 -
-        (fh->crc ? 2 : 0) + (fh->paddingBit ? 1 : 0);
+    mp3DecInfo->nSlots = (int) slotTab[fh->ver][fh->srIdx][fh->brIdx] -
+                         (int) sideBytesTab[fh->ver][(fh->sMode == Mono ? 0 : 1)] - 4 - (fh->crc ? 2 : 0) +
+                         (fh->paddingBit ? 1 : 0);
   }
 
   /* load crc word, if enabled, and return length of frame header (in bytes) */
   if (fh->crc) {
-    fh->CRCWord = ((int)buf[4] << 8 | (int)buf[5] << 0);
+    fh->CRCWord = ((int) buf[4] << 8 | (int) buf[5] << 0);
     return 6;
   } else {
     fh->CRCWord = 0;
@@ -8551,8 +8408,8 @@ int UnpackSideInfo(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
   if (!mp3DecInfo || !mp3DecInfo->FrameHeaderPS || !mp3DecInfo->SideInfoPS)
     return -1;
 
-  fh = ((FrameHeader *)(mp3DecInfo->FrameHeaderPS));
-  si = ((SideInfo *)(mp3DecInfo->SideInfoPS));
+  fh = ((FrameHeader *) (mp3DecInfo->FrameHeaderPS));
+  si = ((SideInfo *) (mp3DecInfo->SideInfoPS));
 
   bsi = &bitStreamInfo;
   if (fh->ver == MPEG1) {
@@ -8585,8 +8442,7 @@ int UnpackSideInfo(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
 
       if (sis->winSwitchFlag) {
         /* this is a start, stop, short, or mixed block */
-        sis->blockType =
-            GetBits(bsi, 2); /* 0 = normal, 1 = start, 2 = short, 3 = stop */
+        sis->blockType = GetBits(bsi, 2);  /* 0 = normal, 1 = start, 2 = short, 3 = stop */
         sis->mixedBlock = GetBits(bsi, 1); /* 0 = not mixed, 1 = mixed */
         sis->tableSelect[0] = GetBits(bsi, 5);
         sis->tableSelect[1] = GetBits(bsi, 5);
@@ -8624,8 +8480,7 @@ int UnpackSideInfo(MP3DecInfo *mp3DecInfo, unsigned char *buf) {
       sis->count1TableSelect = GetBits(bsi, 1);
     }
   }
-  mp3DecInfo->mainDataBegin =
-      si->mainDataBegin; /* needed by main decode loop */
+  mp3DecInfo->mainDataBegin = si->mainDataBegin; /* needed by main decode loop */
 
   ASSERT(nBytes == CalcBitsUsed(bsi, buf, 0) >> 3);
 
@@ -8649,7 +8504,7 @@ HMP3Decoder MP3InitDecoder(void) {
 
   mp3DecInfo = AllocateBuffers();
 
-  return (HMP3Decoder)mp3DecInfo;
+  return (HMP3Decoder) mp3DecInfo;
 }
 
 /**************************************************************************************
@@ -8665,7 +8520,7 @@ HMP3Decoder MP3InitDecoder(void) {
  * Return:      none
  **************************************************************************************/
 void MP3FreeDecoder(HMP3Decoder hMP3Decoder) {
-  MP3DecInfo *mp3DecInfo = (MP3DecInfo *)hMP3Decoder;
+  MP3DecInfo *mp3DecInfo = (MP3DecInfo *) hMP3Decoder;
 
   if (!mp3DecInfo)
     return;
@@ -8692,8 +8547,7 @@ int MP3FindSyncWord(unsigned char *buf, int nBytes) {
   /* find byte-aligned syncword - need 12 (MPEG 1,2) or 11 (MPEG 2.5) matching
    * bits */
   for (i = 0; i < nBytes - 1; i++) {
-    if ((buf[i + 0] & SYNCWORDH) == SYNCWORDH &&
-        (buf[i + 1] & SYNCWORDL) == SYNCWORDL)
+    if ((buf[i + 0] & SYNCWORDH) == SYNCWORDH && (buf[i + 1] & SYNCWORDL) == SYNCWORDL)
       return i;
   }
 
@@ -8724,8 +8578,7 @@ int MP3FindSyncWord(unsigned char *buf, int nBytes) {
  *function once (first frame) then store the result (nSlots) and just use it
  *from then on
  **************************************************************************************/
-static int MP3FindFreeSync(unsigned char *buf, unsigned char firstFH[4],
-                           int nBytes) {
+static int MP3FindFreeSync(unsigned char *buf, unsigned char firstFH[4], int nBytes) {
   int offset = 0;
   unsigned char *bufPtr = buf;
 
@@ -8739,8 +8592,7 @@ static int MP3FindFreeSync(unsigned char *buf, unsigned char firstFH[4],
     bufPtr += offset;
     if (offset < 0) {
       return -1;
-    } else if ((bufPtr[0] == firstFH[0]) && (bufPtr[1] == firstFH[1]) &&
-               ((bufPtr[2] & 0xfc) == (firstFH[2] & 0xfc))) {
+    } else if ((bufPtr[0] == firstFH[0]) && (bufPtr[1] == firstFH[1]) && ((bufPtr[2] & 0xfc) == (firstFH[2] & 0xfc))) {
       /* want to return number of bytes per frame, NOT counting the padding
        * byte, so subtract one if padFlag == 1 */
       if ((firstFH[2] >> 1) & 0x01)
@@ -8770,7 +8622,7 @@ static int MP3FindFreeSync(unsigned char *buf, unsigned char firstFH[4],
  * Notes:       call this right after calling MP3Decode
  **************************************************************************************/
 void MP3GetLastFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo) {
-  MP3DecInfo *mp3DecInfo = (MP3DecInfo *)hMP3Decoder;
+  MP3DecInfo *mp3DecInfo = (MP3DecInfo *) hMP3Decoder;
 
   if (!mp3DecInfo || mp3DecInfo->layer != 3) {
     mp3FrameInfo->bitrate = 0;
@@ -8786,8 +8638,7 @@ void MP3GetLastFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo) {
     mp3FrameInfo->samprate = mp3DecInfo->samprate;
     mp3FrameInfo->bitsPerSample = 16;
     mp3FrameInfo->outputSamps =
-        mp3DecInfo->nChans *
-        (int)samplesPerFrameTab[mp3DecInfo->version][mp3DecInfo->layer - 1];
+        mp3DecInfo->nChans * (int) samplesPerFrameTab[mp3DecInfo->version][mp3DecInfo->layer - 1];
     mp3FrameInfo->layer = mp3DecInfo->layer;
     mp3FrameInfo->version = mp3DecInfo->version;
   }
@@ -8808,9 +8659,8 @@ void MP3GetLastFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo) {
  * Return:      error code, defined in mp3dec.h (0 means no error, < 0 means
  *error)
  **************************************************************************************/
-int MP3GetNextFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo,
-                        unsigned char *buf) {
-  MP3DecInfo *mp3DecInfo = (MP3DecInfo *)hMP3Decoder;
+int MP3GetNextFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo, unsigned char *buf) {
+  MP3DecInfo *mp3DecInfo = (MP3DecInfo *) hMP3Decoder;
 
   if (!mp3DecInfo)
     return ERR_MP3_NULL_POINTER;
@@ -8841,9 +8691,7 @@ static void MP3ClearBadFrame(MP3DecInfo *mp3DecInfo, short *outbuf) {
   if (!mp3DecInfo)
     return;
 
-  for (i = 0;
-       i < mp3DecInfo->nGrans * mp3DecInfo->nGranSamps * mp3DecInfo->nChans;
-       i++)
+  for (i = 0; i < mp3DecInfo->nGrans * mp3DecInfo->nGranSamps * mp3DecInfo->nChans; i++)
     outbuf[i] = 0;
 }
 
@@ -8870,12 +8718,11 @@ static void MP3ClearBadFrame(MP3DecInfo *mp3DecInfo, short *outbuf) {
  *                is not supported (bit reservoir is not maintained if useSize
  *on)
  **************************************************************************************/
-int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
-              short *outbuf, int useSize) {
+int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft, short *outbuf, int useSize) {
   int offset, bitOffset, mainBits, gr, ch, fhBytes, siBytes, freeFrameBytes;
   int prevBitOffset, sfBlockBits, huffBlockBits;
   unsigned char *mainPtr;
-  MP3DecInfo *mp3DecInfo = (MP3DecInfo *)hMP3Decoder;
+  MP3DecInfo *mp3DecInfo = (MP3DecInfo *) hMP3Decoder;
 
   if (!mp3DecInfo)
     return ERR_MP3_NULL_POINTER;
@@ -8903,19 +8750,15 @@ int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
       /* first time through, need to scan for next sync word and figure out
        * frame size */
       mp3DecInfo->freeBitrateFlag = 1;
-      mp3DecInfo->freeBitrateSlots =
-          MP3FindFreeSync(*inbuf, *inbuf - fhBytes - siBytes, *bytesLeft);
+      mp3DecInfo->freeBitrateSlots = MP3FindFreeSync(*inbuf, *inbuf - fhBytes - siBytes, *bytesLeft);
       if (mp3DecInfo->freeBitrateSlots < 0) {
         MP3ClearBadFrame(mp3DecInfo, outbuf);
         return ERR_MP3_FREE_BITRATE_SYNC;
       }
       freeFrameBytes = mp3DecInfo->freeBitrateSlots + fhBytes + siBytes;
-      mp3DecInfo->bitrate = (freeFrameBytes * mp3DecInfo->samprate * 8) /
-                            (mp3DecInfo->nGrans * mp3DecInfo->nGranSamps);
+      mp3DecInfo->bitrate = (freeFrameBytes * mp3DecInfo->samprate * 8) / (mp3DecInfo->nGrans * mp3DecInfo->nGranSamps);
     }
-    mp3DecInfo->nSlots =
-        mp3DecInfo->freeBitrateSlots +
-        CheckPadBit(mp3DecInfo); /* add pad byte, if required */
+    mp3DecInfo->nSlots = mp3DecInfo->freeBitrateSlots + CheckPadBit(mp3DecInfo); /* add pad byte, if required */
   }
 
   /* useSize != 0 means we're getting reformatted (RTP) packets (see RFC 3119)
@@ -8949,23 +8792,18 @@ int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
     /* fill main data buffer with enough new data for this frame */
     if (mp3DecInfo->mainDataBytes >= mp3DecInfo->mainDataBegin) {
       /* adequate "old" main data available (i.e. bit reservoir) */
-      memmove(mp3DecInfo->mainBuf,
-              mp3DecInfo->mainBuf + mp3DecInfo->mainDataBytes -
-                  mp3DecInfo->mainDataBegin,
+      memmove(mp3DecInfo->mainBuf, mp3DecInfo->mainBuf + mp3DecInfo->mainDataBytes - mp3DecInfo->mainDataBegin,
               mp3DecInfo->mainDataBegin);
-      memcpy(mp3DecInfo->mainBuf + mp3DecInfo->mainDataBegin, *inbuf,
-             mp3DecInfo->nSlots);
+      memcpy(mp3DecInfo->mainBuf + mp3DecInfo->mainDataBegin, *inbuf, mp3DecInfo->nSlots);
 
-      mp3DecInfo->mainDataBytes =
-          mp3DecInfo->mainDataBegin + mp3DecInfo->nSlots;
+      mp3DecInfo->mainDataBytes = mp3DecInfo->mainDataBegin + mp3DecInfo->nSlots;
       *inbuf += mp3DecInfo->nSlots;
       *bytesLeft -= (mp3DecInfo->nSlots);
       mainPtr = mp3DecInfo->mainBuf;
     } else {
       /* not enough data in bit reservoir from previous frames (perhaps starting
        * in middle of file) */
-      memcpy(mp3DecInfo->mainBuf + mp3DecInfo->mainDataBytes, *inbuf,
-             mp3DecInfo->nSlots);
+      memcpy(mp3DecInfo->mainBuf + mp3DecInfo->mainDataBytes, *inbuf, mp3DecInfo->nSlots);
       mp3DecInfo->mainDataBytes += mp3DecInfo->nSlots;
       *inbuf += mp3DecInfo->nSlots;
       *bytesLeft -= (mp3DecInfo->nSlots);
@@ -8979,11 +8817,9 @@ int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
   /* decode one complete frame */
   for (gr = 0; gr < mp3DecInfo->nGrans; gr++) {
     for (ch = 0; ch < mp3DecInfo->nChans; ch++) {
-
       /* unpack scale factors and compute size of scale factor block */
       prevBitOffset = bitOffset;
-      offset =
-          UnpackScaleFactors(mp3DecInfo, mainPtr, &bitOffset, mainBits, gr, ch);
+      offset = UnpackScaleFactors(mp3DecInfo, mainPtr, &bitOffset, mainBits, gr, ch);
 
       sfBlockBits = 8 * offset - prevBitOffset + bitOffset;
       huffBlockBits = mp3DecInfo->part23Length[gr][ch] - sfBlockBits;
@@ -8997,8 +8833,7 @@ int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
 
       /* decode Huffman code words */
       prevBitOffset = bitOffset;
-      offset =
-          DecodeHuffman(mp3DecInfo, mainPtr, &bitOffset, huffBlockBits, gr, ch);
+      offset = DecodeHuffman(mp3DecInfo, mainPtr, &bitOffset, huffBlockBits, gr, ch);
       if (offset < 0) {
         MP3ClearBadFrame(mp3DecInfo, outbuf);
         return ERR_MP3_INVALID_HUFFCODES;
@@ -9023,11 +8858,11 @@ int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
     }
 
     /* subband transform - if stereo, interleaves pcm LRLRLR */
-    if (Subband(mp3DecInfo, outbuf + gr * mp3DecInfo->nGranSamps *
-                                         mp3DecInfo->nChans) < 0) {
+    if (Subband(mp3DecInfo, outbuf + gr * mp3DecInfo->nGranSamps * mp3DecInfo->nChans) < 0) {
       MP3ClearBadFrame(mp3DecInfo, outbuf);
       return ERR_MP3_INVALID_SUBBAND;
     }
   }
   return ERR_MP3_NONE;
 }
+#endif

--- a/esphome/components/nabu/mp3_decoder.h
+++ b/esphome/components/nabu/mp3_decoder.h
@@ -1,3 +1,5 @@
+#ifdef USE_ESP_IDF
+
 #ifndef MP3_DECODER_H_
 #define MP3_DECODER_H_
 
@@ -45,9 +47,7 @@ typedef enum { MPEG1 = 0, MPEG2 = 1, MPEG25 = 2 } MPEGVersion;
 
 typedef long long Word64;
 
-static __inline Word64 MADD64(Word64 sum64, int x, int y) {
-  return (sum64 + ((long long)x * y));
-}
+static __inline Word64 MADD64(Word64 sum64, int x, int y) { return (sum64 + ((long long) x * y)); }
 
 static __inline int MULSHIFT32(int x, int y) {
   /* important rules for smull RdLo, RdHi, Rm, Rs:
@@ -76,12 +76,12 @@ static __inline Word64 SAR64(Word64 x, int n) { return x >> n; }
 static __inline int CLZ(int x) { return __builtin_clz(x); }
 
 /* clip to range [-2^n, 2^n - 1] */
-#define CLIP_2N(y, n)                                                          \
-  {                                                                            \
-    int sign = (y) >> 31;                                                      \
-    if (sign != (y) >> (n)) {                                                  \
-      (y) = sign ^ ((1 << (n)) - 1);                                           \
-    }                                                                          \
+#define CLIP_2N(y, n) \
+  { \
+    int sign = (y) >> 31; \
+    if (sign != (y) >> (n)) { \
+      (y) = sign ^ ((1 << (n)) - 1); \
+    } \
   }
 
 #define SIBYTES_MPEG1_MONO 17
@@ -94,15 +94,13 @@ static __inline int CLZ(int x) { return __builtin_clz(x); }
 #define POW43_FRACBITS_HIGH 12
 
 #define DQ_FRACBITS_OUT 25 /* number of fraction bits in output of dequant */
-#define IMDCT_SCALE 2 /* additional scaling (by sqrt(2)) for fast IMDCT36 */
+#define IMDCT_SCALE 2      /* additional scaling (by sqrt(2)) for fast IMDCT36 */
 
 #define HUFF_PAIRTABS 32
 #define BLOCK_SIZE 18
 #define NBANDS 32
-#define MAX_REORDER_SAMPS                                                      \
-  ((192 - 126) *                                                               \
-   3) /* largest critical band for short blocks (see sfBandTable) */
-#define VBUF_LENGTH (17 * 2 * NBANDS) /* for double-sized vbuf FIFO */
+#define MAX_REORDER_SAMPS ((192 - 126) * 3) /* largest critical band for short blocks (see sfBandTable) */
+#define VBUF_LENGTH (17 * 2 * NBANDS)       /* for double-sized vbuf FIFO */
 
 /* map these to the corresponding 2-bit values in the frame header */
 typedef enum {
@@ -110,9 +108,9 @@ typedef enum {
                     different # of bits */
   Joint = 0x01,  /* coupled channels - layer III: mix of M-S and intensity,
                     Layers I/II: intensity and direct coding only */
-  Dual = 0x02, /* two independent channels, L and R always have exactly 1/2 the
-                  total bitrate */
-  Mono = 0x03  /* one channel */
+  Dual = 0x02,   /* two independent channels, L and R always have exactly 1/2 the
+                    total bitrate */
+  Mono = 0x03    /* one channel */
 } StereoMode;
 
 typedef struct _SFBandTable {
@@ -146,22 +144,22 @@ typedef struct _FrameHeader {
 } FrameHeader;
 
 typedef struct _SideInfoSub {
-  int part23Length; /* number of bits in main data */
-  int nBigvals; /* 2x this = first set of Huffman cw's (maximum amplitude can be
-                   > 1) */
-  int globalGain; /* overall gain for dequantizer */
-  int sfCompress; /* unpacked to figure out number of bits in scale factors */
-  int winSwitchFlag; /* window switching flag */
-  int blockType;     /* block type */
-  int mixedBlock; /* 0 = regular block (all short or long), 1 = mixed block */
-  int tableSelect[3];  /* index of Huffman tables for the big values regions */
-  int subBlockGain[3]; /* subblock gain offset, relative to global gain */
-  int region0Count; /* 1+region0Count = num scale factor bands in first region
-                       of bigvals */
-  int region1Count; /* 1+region1Count = num scale factor bands in second region
-                       of bigvals */
-  int preFlag;      /* for optional high frequency boost */
-  int sfactScale;   /* scaling of the scalefactors */
+  int part23Length;      /* number of bits in main data */
+  int nBigvals;          /* 2x this = first set of Huffman cw's (maximum amplitude can be
+                            > 1) */
+  int globalGain;        /* overall gain for dequantizer */
+  int sfCompress;        /* unpacked to figure out number of bits in scale factors */
+  int winSwitchFlag;     /* window switching flag */
+  int blockType;         /* block type */
+  int mixedBlock;        /* 0 = regular block (all short or long), 1 = mixed block */
+  int tableSelect[3];    /* index of Huffman tables for the big values regions */
+  int subBlockGain[3];   /* subblock gain offset, relative to global gain */
+  int region0Count;      /* 1+region0Count = num scale factor bands in first region
+                            of bigvals */
+  int region1Count;      /* 1+region1Count = num scale factor bands in second region
+                            of bigvals */
+  int preFlag;           /* for optional high frequency boost */
+  int sfactScale;        /* scaling of the scalefactors */
   int count1TableSelect; /* index of Huffman table for quad codewords */
 } SideInfoSub;
 
@@ -189,20 +187,12 @@ typedef struct _DequantInfo {
 typedef struct _HuffmanInfo {
   int huffDecBuf[MAX_NCHAN][MAX_NSAMP]; /* used both for decoded Huffman values
                                            and dequantized coefficients */
-  int nonZeroBound[MAX_NCHAN]; /* number of coeffs in huffDecBuf[ch] which can
-                                  be > 0 */
-  int gb[MAX_NCHAN]; /* minimum number of guard bits in huffDecBuf[ch] */
+  int nonZeroBound[MAX_NCHAN];          /* number of coeffs in huffDecBuf[ch] which can
+                                           be > 0 */
+  int gb[MAX_NCHAN];                    /* minimum number of guard bits in huffDecBuf[ch] */
 } HuffmanInfo;
 
-typedef enum _HuffTabType {
-  noBits,
-  oneShot,
-  loopNoLinbits,
-  loopLinbits,
-  quadA,
-  quadB,
-  invalidTab
-} HuffTabType;
+typedef enum _HuffTabType { noBits, oneShot, loopNoLinbits, loopLinbits, quadA, quadB, invalidTab } HuffTabType;
 
 typedef struct _HuffTabLookup {
   int linBits;
@@ -213,8 +203,8 @@ typedef struct _IMDCTInfo {
   int outBuf[MAX_NCHAN][BLOCK_SIZE][NBANDS]; /* output of IMDCT */
   int overBuf[MAX_NCHAN][MAX_NSAMP / 2];     /* overlap-add buffer (by symmetry,
                                                 only need 1/2 size) */
-  int numPrevIMDCT[MAX_NCHAN]; /* how many IMDCT's calculated in this channel on
-                                  prev. granule */
+  int numPrevIMDCT[MAX_NCHAN];               /* how many IMDCT's calculated in this channel on
+                                                prev. granule */
   int prevType[MAX_NCHAN];
   int prevWinSwitch[MAX_NCHAN];
   int gb[MAX_NCHAN];
@@ -254,10 +244,9 @@ typedef struct _ScaleFactorInfo {
  * memmove on the last 15 blocks to shift them down one, a hardware style FIFO)
  */
 typedef struct _SubbandInfo {
-  int vbuf[MAX_NCHAN *
-           VBUF_LENGTH]; /* vbuf for fast DCT-based synthesis PQMF - double size
-                            for speed (no modulo indexing) */
-  int vindex;            /* internal index for tracking position in vbuf */
+  int vbuf[MAX_NCHAN * VBUF_LENGTH]; /* vbuf for fast DCT-based synthesis PQMF - double size
+                                        for speed (no modulo indexing) */
+  int vindex;                        /* internal index for tracking position in vbuf */
 } SubbandInfo;
 
 /* bitstream.c */
@@ -266,23 +255,18 @@ unsigned int GetBits(BitStreamInfo *bsi, int nBits);
 int CalcBitsUsed(BitStreamInfo *bsi, unsigned char *startBuf, int startOffset);
 
 /* dequant.c, dqchan.c, stproc.c */
-int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound,
-                   FrameHeader *fh, SideInfoSub *sis, ScaleFactorInfoSub *sfis,
-                   CriticalBandInfo *cbi);
+int DequantChannel(int *sampleBuf, int *workBuf, int *nonZeroBound, FrameHeader *fh, SideInfoSub *sis,
+                   ScaleFactorInfoSub *sfis, CriticalBandInfo *cbi);
 void MidSideProc(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, int mOut[2]);
-void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
-                        FrameHeader *fh, ScaleFactorInfoSub *sfis,
-                        CriticalBandInfo *cbi, int midSideFlag, int mixFlag,
-                        int mOut[2]);
-void IntensityProcMPEG2(int x[MAX_NCHAN][MAX_NSAMP], int nSamps,
-                        FrameHeader *fh, ScaleFactorInfoSub *sfis,
-                        CriticalBandInfo *cbi, ScaleFactorJS *sfjs,
-                        int midSideFlag, int mixFlag, int mOut[2]);
+void IntensityProcMPEG1(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis,
+                        CriticalBandInfo *cbi, int midSideFlag, int mixFlag, int mOut[2]);
+void IntensityProcMPEG2(int x[MAX_NCHAN][MAX_NSAMP], int nSamps, FrameHeader *fh, ScaleFactorInfoSub *sfis,
+                        CriticalBandInfo *cbi, ScaleFactorJS *sfjs, int midSideFlag, int mixFlag, int mOut[2]);
 
 /* dct32.c */
 // about 1 ms faster in RAM, but very large
 void FDCT32(int *x, int *d, int offset, int oddBlock,
-            int gb); // __attribute__ ((section (".data")));
+            int gb);  // __attribute__ ((section (".data")));
 
 /* hufftabs.c */
 extern const HuffTabLookup huffTabLookup[HUFF_PAIRTABS];
@@ -344,12 +328,10 @@ void FreeBuffers(MP3DecInfo *mp3DecInfo);
 int CheckPadBit(MP3DecInfo *mp3DecInfo);
 int UnpackFrameHeader(MP3DecInfo *mp3DecInfo, unsigned char *buf);
 int UnpackSideInfo(MP3DecInfo *mp3DecInfo, unsigned char *buf);
-int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset,
-                  int huffBlockBits, int gr, int ch);
+int DecodeHuffman(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, int huffBlockBits, int gr, int ch);
 int Dequantize(MP3DecInfo *mp3DecInfo, int gr);
 int IMDCT(MP3DecInfo *mp3DecInfo, int gr, int ch);
-int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf,
-                       int *bitOffset, int bitsAvail, int gr, int ch);
+int UnpackScaleFactors(MP3DecInfo *mp3DecInfo, unsigned char *buf, int *bitOffset, int bitsAvail, int gr, int ch);
 int Subband(MP3DecInfo *mp3DecInfo, short *pcmBuf);
 
 extern const int samplerateTab[3][3];
@@ -393,12 +375,11 @@ typedef struct _MP3FrameInfo {
 /* public API */
 HMP3Decoder MP3InitDecoder(void);
 void MP3FreeDecoder(HMP3Decoder hMP3Decoder);
-int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft,
-              short *outbuf, int useSize);
+int MP3Decode(HMP3Decoder hMP3Decoder, unsigned char **inbuf, int *bytesLeft, short *outbuf, int useSize);
 
 void MP3GetLastFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo);
-int MP3GetNextFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo,
-                        unsigned char *buf);
+int MP3GetNextFrameInfo(HMP3Decoder hMP3Decoder, MP3FrameInfo *mp3FrameInfo, unsigned char *buf);
 int MP3FindSyncWord(unsigned char *buf, int nBytes);
 
-#endif // MP3_DECODER_H_
+#endif  // MP3_DECODER_H_
+#endif

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -17,10 +17,7 @@ namespace nabu {
 //  - Cleanup AudioResampler code (remove or refactor the esp_dsp fir filter)
 //  - Idle muting can cut off parts of the audio. Replace commnented code with eventual XMOS command to cut power to
 //    speaker amp
-//  - Block media commands until the bluetooth stack is disabled (will run out of memory otherwise)
 //  - Tune task memory requirements and potentially buffer sizes if issues appear
-//  - Ducking improvements
-//    - Add a YAML action for setting the ducking level instead of requiring a lambda
 //  - Clean up process around playing back local media files
 //    - Create a registry of media files in Python
 //    - What do I need to give them an ESPHome id?
@@ -609,13 +606,14 @@ void NabuMediaPlayer::loop() {
   }
 }
 
-void NabuMediaPlayer::set_ducking_reduction(uint8_t decibel_reduction, float transition_duration) {
+void NabuMediaPlayer::set_ducking_reduction(uint8_t decibel_reduction, float duration) {
   if (this->audio_mixer_ != nullptr) {
     CommandEvent command_event;
     command_event.command = CommandEventType::DUCK;
     command_event.decibel_reduction = decibel_reduction;
-    command_event.transition_samples =
-        static_cast<size_t>(transition_duration * this->sample_rate_ * NUMBER_OF_CHANNELS);
+
+    // Convert the duration in seconds to number of samples, accounting for the sample rate and number of channels
+    command_event.transition_samples = static_cast<size_t>(duration * this->sample_rate_ * NUMBER_OF_CHANNELS);
     this->audio_mixer_->send_command(&command_event);
   }
 }

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -14,9 +14,7 @@ namespace esphome {
 namespace nabu {
 
 // TODO:
-//  - Have better logging outputs
-//    - Output file type and stream information + any resampling processes
-//    - Remove printf
+//  - Cleanup AudioResampler code (remove or refactor the esp_dsp fir filter)
 //  - Block media commands until the bluetooth stack is disabled (will run out of memory otherwise)
 //  - Tune task memory requirements and potentially buffer sizes if issues appear
 //  - Ducking improvements
@@ -572,28 +570,8 @@ void NabuMediaPlayer::loop() {
   if (this->announcement_pipeline_ != nullptr)
     this->announcement_pipeline_state_ = this->announcement_pipeline_->get_state();
 
-  if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_READING) {
-    ESP_LOGE(TAG, "Encountered an error reading the announcement file");
-  }
-  if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_DECODING) {
-    ESP_LOGE(TAG, "Encountered an error decoding the announcement file");
-  }
-  if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_RESAMPLING) {
-    ESP_LOGE(TAG, "Encountered an error resampling the announcement file");
-  }
-
   if (this->media_pipeline_ != nullptr)
     this->media_pipeline_state_ = this->media_pipeline_->get_state();
-
-  if (this->media_pipeline_state_ == AudioPipelineState::ERROR_READING) {
-    ESP_LOGE(TAG, "Encountered an error reading the media file");
-  }
-  if (this->media_pipeline_state_ == AudioPipelineState::ERROR_DECODING) {
-    ESP_LOGE(TAG, "Encountered an error decoding the media file");
-  }
-  if (this->media_pipeline_state_ == AudioPipelineState::ERROR_RESAMPLING) {
-    ESP_LOGE(TAG, "Encountered an error resampling the media file");
-  }
 
   if (this->announcement_pipeline_state_ != AudioPipelineState::STOPPED) {
     this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -608,11 +608,12 @@ void NabuMediaPlayer::loop() {
   }
 }
 
-void NabuMediaPlayer::set_ducking_ratio(float ducking_ratio) {
+void NabuMediaPlayer::set_ducking_ratio(float ducking_ratio, float duration) {
   if (this->audio_mixer_ != nullptr) {
     CommandEvent command_event;
     command_event.command = CommandEventType::DUCK;
     command_event.ducking_ratio = ducking_ratio;
+    command_event.samples = 48000*2;
     this->audio_mixer_->send_command(&command_event);
   }
 }

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -484,11 +484,11 @@ void NabuMediaPlayer::watch_media_commands_() {
           this->publish_state();
           break;
         case media_player::MEDIA_PLAYER_COMMAND_VOLUME_UP:
-          this->set_volume_(std::min(1.0f, this->volume + 0.05f));
+          this->set_volume_(std::min(1.0f, this->volume + this->volume_increment_));
           this->publish_state();
           break;
         case media_player::MEDIA_PLAYER_COMMAND_VOLUME_DOWN:
-          this->set_volume_(std::max(0.0f, this->volume - 0.05f));
+          this->set_volume_(std::max(0.0f, this->volume - this->volume_increment_));
           this->publish_state();
           break;
         default:

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -334,7 +334,7 @@ void NabuMediaPlayer::speaker_task(void *params) {
 
       if (bytes_written != bytes_read) {
         event.type = EventType::WARNING;
-        event.err = ESP_ERR_TIMEOUT;  // TODO: not the correct error...
+        event.err = ESP_ERR_INVALID_SIZE;
         xQueueSend(this_speaker->speaker_event_queue_, &event, portMAX_DELAY);
       } else {
         event.type = EventType::RUNNING;

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -2,20 +2,21 @@
 
 #ifdef USE_ESP_IDF
 
-#include "esphome/components/media_player/media_player.h"
-#include "esphome/components/i2s_audio/i2s_audio.h"
-#include "esphome/core/component.h"
-#include "esphome/core/ring_buffer.h"
-
 #include "audio_mixer.h"
 #include "audio_pipeline.h"
+
+#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/i2s_audio/i2s_audio.h"
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/ring_buffer.h"
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 
 #include <esp_http_client.h>
-
-#include "esphome/components/i2c/i2c.h"
 
 namespace esphome {
 namespace nabu {
@@ -125,6 +126,14 @@ class NabuMediaPlayer : public Component,
 
   // The amount to change the volume on volume up/down commands
   float volume_increment_;
+};
+
+template<typename... Ts> class DuckingSetAction : public Action<Ts...>, public Parented<NabuMediaPlayer> {
+  TEMPLATABLE_VALUE(uint8_t, decibel_reduction)
+  TEMPLATABLE_VALUE(float, transition_duration)
+  void play(Ts... x) override {
+    this->parent_->set_ducking_reduction(this->decibel_reduction_.value(x...), this->transition_duration_.value(x...));
+  }
 };
 
 }  // namespace nabu

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -53,7 +53,7 @@ class NabuMediaPlayer : public Component,
   media_player::MediaPlayerTraits get_traits() override;
   bool is_muted() const override { return this->is_muted_; }
 
-  void set_ducking_ratio(float ducking_ratio) override;
+  void set_ducking_ratio(float ducking_ratio, float duration = 1.0f);
 
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -59,6 +59,8 @@ class NabuMediaPlayer : public Component,
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
 
+  void set_volume_increment(float volume_increment) { this->volume_increment_ = volume_increment; }
+
  protected:
   // Receives commands from HA or from the voice assistant component
   // Sends commands to the media_control_commanda_queue_
@@ -117,6 +119,9 @@ class NabuMediaPlayer : public Component,
 
   // We mute the DAC whenever there is no audio playback to avoid speaker hiss
   bool is_idle_muted_{false};
+
+  // The amount to change the volume on volume up/down commands
+  float volume_increment_;
 };
 
 }  // namespace nabu

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -56,8 +56,8 @@ class NabuMediaPlayer : public Component,
 
   /// @brief Sets the ducking level for the media stream in the mixer
   /// @param decibel_reduction (uint8_t) The dB reduction level. For example, 0 is no change, 10 is a reduction by 10 dB
-  /// @param transition_duration (float) The duration (in seconds) for transitioning to the new ducking level
-  void set_ducking_reduction(uint8_t decibel_reduction, float transition_duration = 0.0f);
+  /// @param duration (float) The duration (in seconds) for transitioning to the new ducking level
+  void set_ducking_reduction(uint8_t decibel_reduction, float duration);
 
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
@@ -130,9 +130,9 @@ class NabuMediaPlayer : public Component,
 
 template<typename... Ts> class DuckingSetAction : public Action<Ts...>, public Parented<NabuMediaPlayer> {
   TEMPLATABLE_VALUE(uint8_t, decibel_reduction)
-  TEMPLATABLE_VALUE(float, transition_duration)
+  TEMPLATABLE_VALUE(float, duration)
   void play(Ts... x) override {
-    this->parent_->set_ducking_reduction(this->decibel_reduction_.value(x...), this->transition_duration_.value(x...));
+    this->parent_->set_ducking_reduction(this->decibel_reduction_.value(x...), this->duration_.value(x...));
   }
 };
 

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -99,7 +99,7 @@ class NabuMediaPlayer : public Component,
 
   // Starts the ``type`` pipeline with a ``url`` or file. Starts the mixer, pipeline, and speaker tasks if necessary.
   // Unpauses if starting media in paused state
-  void start_pipeline_(AudioPipelineType type, bool url);
+  esp_err_t start_pipeline_(AudioPipelineType type, bool url);
 
   AudioPipelineState media_pipeline_state_{AudioPipelineState::STOPPED};
   AudioPipelineState announcement_pipeline_state_{AudioPipelineState::STOPPED};

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -99,7 +99,7 @@ class NabuMediaPlayer : public Component,
   std::unique_ptr<AudioMixer> audio_mixer_;
 
   // Monitors the mixer task
-  void watch_();
+  void watch_mixer_();
 
   // Starts the ``type`` pipeline with a ``url`` or file. Starts the mixer, pipeline, and speaker tasks if necessary.
   // Unpauses if starting media in paused state

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -53,7 +53,10 @@ class NabuMediaPlayer : public Component,
   media_player::MediaPlayerTraits get_traits() override;
   bool is_muted() const override { return this->is_muted_; }
 
-  void set_ducking_ratio(float ducking_ratio, float duration = 1.0f);
+  /// @brief Sets the ducking level for the media stream in the mixer
+  /// @param decibel_reduction (uint8_t) The dB reduction level. For example, 0 is no change, 10 is a reduction by 10 dB
+  /// @param transition_duration (float) The duration (in seconds) for transitioning to the new ducking level
+  void set_ducking_reduction(uint8_t decibel_reduction, float transition_duration = 0.0f);
 
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -95,6 +95,10 @@ class NabuMediaPlayer : public Component,
   // Monitors the mixer task
   void watch_();
 
+  // Starts the ``type`` pipeline with a ``url`` or file. Starts the mixer, pipeline, and speaker tasks if necessary.
+  // Unpauses if starting media in paused state
+  void start_pipeline_(AudioPipelineType type, bool url);
+
   AudioPipelineState media_pipeline_state_{AudioPipelineState::STOPPED};
   AudioPipelineState announcement_pipeline_state_{AudioPipelineState::STOPPED};
 

--- a/esphome/components/nabu/resampler.cpp
+++ b/esphome/components/nabu/resampler.cpp
@@ -8,11 +8,12 @@
 
 // resampler.c
 
+#ifdef USE_ESP_IDF
+
 #include "resampler.h"
 
 #include "esphome/core/helpers.h"
 #include "esp_dsp.h"
-
 
 static void init_filter(Resample *cxt, float *filter, float fraction, float lowpass_ratio);
 static float subsample(Resample *cxt, float *source, float offset);
@@ -377,7 +378,7 @@ void resampleFree(Resample *cxt) {
 static float apply_filter(float *A, float *B, int num_taps) {
   float sum;
   dsps_dotprod_f32_aes3(A, B, &sum, num_taps);
-//   dsps_dotprod_f32_ansi(A, B, &sum, num_taps);
+  //   dsps_dotprod_f32_ansi(A, B, &sum, num_taps);
   return sum;
 }
 #endif
@@ -511,3 +512,5 @@ static float subsample(Resample *cxt, float *source, float offset) {
   else
     return subsample_no_interpolate(cxt, source, offset);
 }
+
+#endif

--- a/esphome/components/nabu/resampler.h
+++ b/esphome/components/nabu/resampler.h
@@ -9,6 +9,8 @@
 // resampler.h
 #pragma once
 
+#ifdef USE_ESP_IDF
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -18,34 +20,38 @@
 
 #include "esphome/core/helpers.h"
 
-#define SUBSAMPLE_INTERPOLATE   0x1
-#define BLACKMAN_HARRIS         0x2
-#define INCLUDE_LOWPASS         0x4
+#define SUBSAMPLE_INTERPOLATE 0x1
+#define BLACKMAN_HARRIS 0x2
+#define INCLUDE_LOWPASS 0x4
 
 typedef struct {
-    int numChannels, numSamples, numFilters, numTaps, inputIndex, flags;
-    float *tempFilter, outputOffset;
-    float **buffers, **filters;
+  int numChannels, numSamples, numFilters, numTaps, inputIndex, flags;
+  float *tempFilter, outputOffset;
+  float **buffers, **filters;
 } Resample;
 
 typedef struct {
-    unsigned int input_used, output_generated;
+  unsigned int input_used, output_generated;
 } ResampleResult;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-Resample *resampleInit (int numChannels, int numTaps, int numFilters, float lowpassRatio, int flags);
-ResampleResult resampleProcess (Resample *cxt, const float *const *input, int numInputFrames, float *const *output, int numOutputFrames, float ratio);
-ResampleResult resampleProcessInterleaved (Resample *cxt, const float *input, int numInputFrames, float *output, int numOutputFrames, float ratio);
-unsigned int resampleGetRequiredSamples (Resample *cxt, int numOutputFrames, float ratio);
-unsigned int resampleGetExpectedOutput (Resample *cxt, int numInputFrames, float ratio);
-void resampleAdvancePosition (Resample *cxt, float delta);
-float resampleGetPosition (Resample *cxt);
-void resampleReset (Resample *cxt);
-void resampleFree (Resample *cxt);
+Resample *resampleInit(int numChannels, int numTaps, int numFilters, float lowpassRatio, int flags);
+ResampleResult resampleProcess(Resample *cxt, const float *const *input, int numInputFrames, float *const *output,
+                               int numOutputFrames, float ratio);
+ResampleResult resampleProcessInterleaved(Resample *cxt, const float *input, int numInputFrames, float *output,
+                                          int numOutputFrames, float ratio);
+unsigned int resampleGetRequiredSamples(Resample *cxt, int numOutputFrames, float ratio);
+unsigned int resampleGetExpectedOutput(Resample *cxt, int numInputFrames, float ratio);
+void resampleAdvancePosition(Resample *cxt, float delta);
+float resampleGetPosition(Resample *cxt);
+void resampleReset(Resample *cxt);
+void resampleFree(Resample *cxt);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/esphome/components/nabu/wav_decoder.cpp
+++ b/esphome/components/nabu/wav_decoder.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_ESP_IDF
 #include "wav_decoder.h"
 
 namespace wav_decoder {
@@ -6,120 +7,121 @@ WAVDecoderResult WAVDecoder::next() {
   this->bytes_to_skip_ = 0;
 
   switch (this->state_) {
-  case WAV_DECODER_BEFORE_RIFF: {
-    this->chunk_name_ = std::string((const char *)*this->buffer_, 4);
-    if (this->chunk_name_ != "RIFF") {
-      return WAV_DECODER_ERROR_NO_RIFF;
+    case WAV_DECODER_BEFORE_RIFF: {
+      this->chunk_name_ = std::string((const char *) *this->buffer_, 4);
+      if (this->chunk_name_ != "RIFF") {
+        return WAV_DECODER_ERROR_NO_RIFF;
+      }
+
+      this->chunk_bytes_left_ = *((uint32_t *) (*this->buffer_ + 4));
+      if ((this->chunk_bytes_left_ % 2) != 0) {
+        // Pad byte
+        this->chunk_bytes_left_++;
+      }
+
+      // WAVE sub-chunk header should follow
+      this->state_ = WAV_DECODER_BEFORE_WAVE;
+      this->bytes_needed_ = 4;  // WAVE
+      break;
     }
 
-    this->chunk_bytes_left_ = *((uint32_t *)(*this->buffer_ + 4));
-    if ((this->chunk_bytes_left_ % 2) != 0) {
-      // Pad byte
-      this->chunk_bytes_left_++;
+    case WAV_DECODER_BEFORE_WAVE: {
+      this->chunk_name_ = std::string((const char *) *this->buffer_, 4);
+      if (this->chunk_name_ != "WAVE") {
+        return WAV_DECODER_ERROR_NO_WAVE;
+      }
+
+      // Next chunk header
+      this->state_ = WAV_DECODER_BEFORE_FMT;
+      this->bytes_needed_ = 8;  // chunk name + size
+      break;
     }
 
-    // WAVE sub-chunk header should follow
-    this->state_ = WAV_DECODER_BEFORE_WAVE;
-    this->bytes_needed_ = 4; // WAVE
-    break;
-  }
+    case WAV_DECODER_BEFORE_FMT: {
+      this->chunk_name_ = std::string((const char *) *this->buffer_, 4);
+      this->chunk_bytes_left_ = *((uint32_t *) (*this->buffer_ + 4));
+      if ((this->chunk_bytes_left_ % 2) != 0) {
+        // Pad byte
+        this->chunk_bytes_left_++;
+      }
 
-  case WAV_DECODER_BEFORE_WAVE: {
-    this->chunk_name_ = std::string((const char *)*this->buffer_, 4);
-    if (this->chunk_name_ != "WAVE") {
-      return WAV_DECODER_ERROR_NO_WAVE;
+      if (this->chunk_name_ == "fmt ") {
+        // Read rest of fmt chunk
+        this->state_ = WAV_DECODER_IN_FMT;
+        this->bytes_needed_ = this->chunk_bytes_left_;
+      } else {
+        // Skip over chunk
+        // this->state_ = WAV_DECODER_BEFORE_FMT_SKIP_CHUNK;
+        this->bytes_to_skip_ = this->chunk_bytes_left_;
+        this->bytes_needed_ = 8;
+      }
+      break;
     }
 
-    // Next chunk header
-    this->state_ = WAV_DECODER_BEFORE_FMT;
-    this->bytes_needed_ = 8; // chunk name + size
-    break;
-  }
+      // case WAV_DECODER_BEFORE_FMT_SKIP_CHUNK: {
+      //   // Next chunk header
+      //   this->state_ = WAV_DECODER_BEFORE_FMT;
+      //   this->bytes_needed_ = 8; // chunk name + size
+      //   break;
+      // }
 
-  case WAV_DECODER_BEFORE_FMT: {
-    this->chunk_name_ = std::string((const char *)*this->buffer_, 4);
-    this->chunk_bytes_left_ = *((uint32_t *)(*this->buffer_ + 4));
-    if ((this->chunk_bytes_left_ % 2) != 0) {
-      // Pad byte
-      this->chunk_bytes_left_++;
+    case WAV_DECODER_IN_FMT: {
+      /**
+       * audio format (uint16_t)
+       * number of channels (uint16_t)
+       * sample rate (uint32_t)
+       * bytes per second (uint32_t)
+       * block align (uint16_t)
+       * bits per sample (uint16_t)
+       * [rest of format chunk]
+       */
+      this->num_channels_ = *((uint16_t *) (*this->buffer_ + 2));
+      this->sample_rate_ = *((uint32_t *) (*this->buffer_ + 4));
+      this->bits_per_sample_ = *((uint16_t *) (*this->buffer_ + 14));
+
+      // Next chunk
+      this->state_ = WAV_DECODER_BEFORE_DATA;
+      this->bytes_needed_ = 8;  // chunk name + size
+      break;
     }
 
-    if (this->chunk_name_ == "fmt ") {
-      // Read rest of fmt chunk
-      this->state_ = WAV_DECODER_IN_FMT;
-      this->bytes_needed_ = this->chunk_bytes_left_;
-    } else {
+    case WAV_DECODER_BEFORE_DATA: {
+      this->chunk_name_ = std::string((const char *) *this->buffer_, 4);
+      this->chunk_bytes_left_ = *((uint32_t *) (*this->buffer_ + 4));
+      if ((this->chunk_bytes_left_ % 2) != 0) {
+        // Pad byte
+        this->chunk_bytes_left_++;
+      }
+
+      if (this->chunk_name_ == "data") {
+        // Complete
+        this->state_ = WAV_DECODER_IN_DATA;
+        this->bytes_needed_ = 0;
+        return WAV_DECODER_SUCCESS_IN_DATA;
+      }
+
       // Skip over chunk
-      // this->state_ = WAV_DECODER_BEFORE_FMT_SKIP_CHUNK;
+      // this->state_ = WAV_DECODER_BEFORE_DATA_SKIP_CHUNK;
       this->bytes_to_skip_ = this->chunk_bytes_left_;
       this->bytes_needed_ = 8;
-    }
-    break;
-  }
-
-    // case WAV_DECODER_BEFORE_FMT_SKIP_CHUNK: {
-    //   // Next chunk header
-    //   this->state_ = WAV_DECODER_BEFORE_FMT;
-    //   this->bytes_needed_ = 8; // chunk name + size
-    //   break;
-    // }
-
-  case WAV_DECODER_IN_FMT: {
-    /**
-     * audio format (uint16_t)
-     * number of channels (uint16_t)
-     * sample rate (uint32_t)
-     * bytes per second (uint32_t)
-     * block align (uint16_t)
-     * bits per sample (uint16_t)
-     * [rest of format chunk]
-     */
-    this->num_channels_ = *((uint16_t *)(*this->buffer_ + 2));
-    this->sample_rate_ = *((uint32_t *)(*this->buffer_ + 4));
-    this->bits_per_sample_ = *((uint16_t *)(*this->buffer_ + 14));
-
-    // Next chunk
-    this->state_ = WAV_DECODER_BEFORE_DATA;
-    this->bytes_needed_ = 8; // chunk name + size
-    break;
-  }
-
-  case WAV_DECODER_BEFORE_DATA: {
-    this->chunk_name_ = std::string((const char *)*this->buffer_, 4);
-    this->chunk_bytes_left_ = *((uint32_t *)(*this->buffer_ + 4));
-    if ((this->chunk_bytes_left_ % 2) != 0) {
-      // Pad byte
-      this->chunk_bytes_left_++;
+      break;
     }
 
-    if (this->chunk_name_ == "data") {
-      // Complete
-      this->state_ = WAV_DECODER_IN_DATA;
-      this->bytes_needed_ = 0;
+      // case WAV_DECODER_BEFORE_DATA_SKIP_CHUNK: {
+      //   // Next chunk header
+      //   this->state_ = WAV_DECODER_BEFORE_DATA;
+      //   this->bytes_needed_ = 8; // chunk name + size
+      //   break;
+      // }
+
+    case WAV_DECODER_IN_DATA: {
       return WAV_DECODER_SUCCESS_IN_DATA;
+      break;
     }
-
-    // Skip over chunk
-    // this->state_ = WAV_DECODER_BEFORE_DATA_SKIP_CHUNK;
-    this->bytes_to_skip_ = this->chunk_bytes_left_;
-    this->bytes_needed_ = 8;
-    break;
-  }
-
-    // case WAV_DECODER_BEFORE_DATA_SKIP_CHUNK: {
-    //   // Next chunk header
-    //   this->state_ = WAV_DECODER_BEFORE_DATA;
-    //   this->bytes_needed_ = 8; // chunk name + size
-    //   break;
-    // }
-
-  case WAV_DECODER_IN_DATA: {
-    return WAV_DECODER_SUCCESS_IN_DATA;
-    break;
-  }
   }
 
   return WAV_DECODER_SUCCESS_NEXT;
 }
 
-} // namespace wav_decoder
+}  // namespace wav_decoder
+#endif

--- a/esphome/components/nabu/wav_decoder.h
+++ b/esphome/components/nabu/wav_decoder.h
@@ -1,3 +1,5 @@
+#ifdef USE_ESP_IDF
+
 // Very basic WAV file decoder that parses format information and gets to the
 // data portion of the file.
 // Skips over extraneous chunks like LIST and INFO.
@@ -52,10 +54,9 @@ enum WAVDecoderResult {
 };
 
 class WAVDecoder {
-
-public:
-  WAVDecoder(uint8_t **buffer) : buffer_(buffer){};
-  ~WAVDecoder(){};
+ public:
+  WAVDecoder(uint8_t **buffer) : buffer_(buffer) {};
+  ~WAVDecoder() {};
 
   WAVDecoderState state() { return this->state_; }
   std::size_t bytes_to_skip() { return this->bytes_to_skip_; }
@@ -85,10 +86,10 @@ public:
     this->bits_per_sample_ = 0;
   }
 
-protected:
+ protected:
   uint8_t **buffer_;
   WAVDecoderState state_ = WAV_DECODER_BEFORE_RIFF;
-  std::size_t bytes_needed_ = 8; // chunk name + size
+  std::size_t bytes_needed_ = 8;  // chunk name + size
   std::size_t bytes_to_skip_ = 0;
   std::string chunk_name_;
   std::size_t chunk_bytes_left_ = 0;
@@ -97,6 +98,7 @@ protected:
   uint16_t num_channels_ = 0;
   uint16_t bits_per_sample_ = 0;
 };
-} // namespace wav_decoder
+}  // namespace wav_decoder
 
-#endif // WAV_DECODER_H_
+#endif  // WAV_DECODER_H_
+#endif

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -177,10 +177,13 @@ switch:
     restore_mode: ALWAYS_OFF
     on_turn_off:
       - delay: 200ms
-      - lambda: id(nabu_media_player).set_ducking_ratio(1);
+      - nabu.set_ducking:
+          decibel_reduction: 0
+          duration: 1.0s
       - script.execute: control_leds
     on_turn_on:
-      - lambda: id(nabu_media_player).set_ducking_ratio(0.25);
+      - nabu.set_ducking:
+          decibel_reduction: 20
       - script.execute: ring_timer
       - script.execute: control_leds
       - delay: 15min
@@ -1117,7 +1120,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: dev
+      ref: kahrendt-20240810-media-player-cleanup
     components: [i2s_audio, microphone, nabu_microphone, nabu, voice_assistant, media_player, micro_wake_word]
     refresh: 0s
 
@@ -1236,7 +1239,9 @@ voice_assistant:
           - script.execute: control_leds
   # When the voice assistant starts: Play a wake up sound, duck audio.
   on_start:
-    - lambda: id(nabu_media_player).set_ducking_ratio(0.25);
+    - nabu.set_ducking:
+        decibel_reduction: 20   # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s          # The duration of the transition (default is 0)
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_waiting_for_command_phase_id};
     - script.execute: control_leds
@@ -1254,7 +1259,9 @@ voice_assistant:
     - wait_until:
         not:
           voice_assistant.is_running:
-    - lambda: id(nabu_media_player).set_ducking_ratio(1.0);
+    - nabu.set_ducking:
+        decibel_reduction: 0   # 0 dB means no reduction
+        duration: 1.0s
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
     - script.execute: control_leds
   on_timer_finished:


### PR DESCRIPTION
This PR is mainly for cleaning up and better organizing the nabu media player code. Most of the changes make error handling better in the media playback process and better logging of the pipeline details. Besides under-the-hood improvements, there are two notable changes:

New Feature: ``set_ducking`` yaml action. The ducking level is now set by specifying the number of decibels to reduce the media stream by. This is a more natural measurement for the sound reduction versus the raw ratio. Additionally, you can optionally set the duration, so it will gradually increase or decrease the media volume until it reaches the desired level. If not specified, it changes to the specified level immediately.

Bugfix: The media player would go into an invalid state if you stopped the media (say, via Music Assistant). This case is properly handled, and, in general, makes it more stable after encountering an error.

Due to changes to how the ducking level is set, the config has breaking changes. I will follow up with another PR to point the external component reference back to dev.