### PR TITLE
Add MediaPlayerSupportedFormat

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -1,0 +1,286 @@
+import base64
+
+from esphome import automation
+from esphome.automation import Condition
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ACTION,
+    CONF_ACTIONS,
+    CONF_DATA,
+    CONF_DATA_TEMPLATE,
+    CONF_EVENT,
+    CONF_ID,
+    CONF_KEY,
+    CONF_ON_CLIENT_CONNECTED,
+    CONF_ON_CLIENT_DISCONNECTED,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_REBOOT_TIMEOUT,
+    CONF_SERVICE,
+    CONF_SERVICES,
+    CONF_TAG,
+    CONF_TRIGGER_ID,
+    CONF_VARIABLES,
+)
+from esphome.core import coroutine_with_priority
+
+DEPENDENCIES = ["network"]
+AUTO_LOAD = ["socket"]
+CODEOWNERS = ["@OttoWinter"]
+
+api_ns = cg.esphome_ns.namespace("api")
+APIServer = api_ns.class_("APIServer", cg.Component, cg.Controller)
+HomeAssistantServiceCallAction = api_ns.class_(
+    "HomeAssistantServiceCallAction", automation.Action
+)
+APIConnectedCondition = api_ns.class_("APIConnectedCondition", Condition)
+
+UserServiceTrigger = api_ns.class_("UserServiceTrigger", automation.Trigger)
+ListEntitiesServicesArgument = api_ns.class_("ListEntitiesServicesArgument")
+SERVICE_ARG_NATIVE_TYPES = {
+    "bool": bool,
+    "int": cg.int32,
+    "float": float,
+    "string": cg.std_string,
+    "bool[]": cg.std_vector.template(bool),
+    "int[]": cg.std_vector.template(cg.int32),
+    "float[]": cg.std_vector.template(float),
+    "string[]": cg.std_vector.template(cg.std_string),
+}
+CONF_ENCRYPTION = "encryption"
+
+
+def validate_encryption_key(value):
+    value = cv.string_strict(value)
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except ValueError as err:
+        raise cv.Invalid("Invalid key format, please check it's using base64") from err
+
+    if len(decoded) != 32:
+        raise cv.Invalid("Encryption key must be base64 and 32 bytes long")
+
+    # Return original data for roundtrip conversion
+    return value
+
+
+ACTIONS_SCHEMA = automation.validate_automation(
+    {
+        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(UserServiceTrigger),
+        cv.Exclusive(CONF_SERVICE, group_of_exclusion=CONF_ACTION): cv.valid_name,
+        cv.Exclusive(CONF_ACTION, group_of_exclusion=CONF_ACTION): cv.valid_name,
+        cv.Optional(CONF_VARIABLES, default={}): cv.Schema(
+            {
+                cv.validate_id_name: cv.one_of(*SERVICE_ARG_NATIVE_TYPES, lower=True),
+            }
+        ),
+    },
+    cv.All(
+        cv.has_exactly_one_key(CONF_SERVICE, CONF_ACTION),
+        cv.rename_key(CONF_SERVICE, CONF_ACTION),
+    ),
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(APIServer),
+            cv.Optional(CONF_PORT, default=6053): cv.port,
+            cv.Optional(CONF_PASSWORD, default=""): cv.string_strict,
+            cv.Optional(
+                CONF_REBOOT_TIMEOUT, default="15min"
+            ): cv.positive_time_period_milliseconds,
+            cv.Exclusive(
+                CONF_SERVICES, group_of_exclusion=CONF_ACTIONS
+            ): ACTIONS_SCHEMA,
+            cv.Exclusive(CONF_ACTIONS, group_of_exclusion=CONF_ACTIONS): ACTIONS_SCHEMA,
+            cv.Optional(CONF_ENCRYPTION): cv.Schema(
+                {
+                    cv.Required(CONF_KEY): validate_encryption_key,
+                }
+            ),
+            cv.Optional(CONF_ON_CLIENT_CONNECTED): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_CLIENT_DISCONNECTED): automation.validate_automation(
+                single=True
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.rename_key(CONF_SERVICES, CONF_ACTIONS),
+)
+
+
+@coroutine_with_priority(40.0)
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add(var.set_port(config[CONF_PORT]))
+    cg.add(var.set_password(config[CONF_PASSWORD]))
+    cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
+
+    for conf in config.get(CONF_ACTIONS, []):
+        template_args = []
+        func_args = []
+        service_arg_names = []
+        for name, var_ in conf[CONF_VARIABLES].items():
+            native = SERVICE_ARG_NATIVE_TYPES[var_]
+            template_args.append(native)
+            func_args.append((native, name))
+            service_arg_names.append(name)
+        templ = cg.TemplateArguments(*template_args)
+        trigger = cg.new_Pvariable(
+            conf[CONF_TRIGGER_ID], templ, conf[CONF_ACTION], service_arg_names
+        )
+        cg.add(var.register_user_service(trigger))
+        await automation.build_automation(trigger, func_args, conf)
+
+    if CONF_ON_CLIENT_CONNECTED in config:
+        await automation.build_automation(
+            var.get_client_connected_trigger(),
+            [(cg.std_string, "client_info"), (cg.std_string, "client_address")],
+            config[CONF_ON_CLIENT_CONNECTED],
+        )
+
+    if CONF_ON_CLIENT_DISCONNECTED in config:
+        await automation.build_automation(
+            var.get_client_disconnected_trigger(),
+            [(cg.std_string, "client_info"), (cg.std_string, "client_address")],
+            config[CONF_ON_CLIENT_DISCONNECTED],
+        )
+
+    if encryption_config := config.get(CONF_ENCRYPTION):
+        decoded = base64.b64decode(encryption_config[CONF_KEY])
+        cg.add(var.set_noise_psk(list(decoded)))
+        cg.add_define("USE_API_NOISE")
+        cg.add_library("esphome/noise-c", "0.1.4")
+    else:
+        cg.add_define("USE_API_PLAINTEXT")
+
+    cg.add_define("USE_API")
+    cg.add_global(api_ns.using)
+
+
+KEY_VALUE_SCHEMA = cv.Schema({cv.string: cv.templatable(cv.string_strict)})
+
+
+HOMEASSISTANT_ACTION_ACTION_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(APIServer),
+            cv.Exclusive(CONF_SERVICE, group_of_exclusion=CONF_ACTION): cv.templatable(
+                cv.string
+            ),
+            cv.Exclusive(CONF_ACTION, group_of_exclusion=CONF_ACTION): cv.templatable(
+                cv.string
+            ),
+            cv.Optional(CONF_DATA, default={}): KEY_VALUE_SCHEMA,
+            cv.Optional(CONF_DATA_TEMPLATE, default={}): KEY_VALUE_SCHEMA,
+            cv.Optional(CONF_VARIABLES, default={}): cv.Schema(
+                {cv.string: cv.returning_lambda}
+            ),
+        }
+    ),
+    cv.has_exactly_one_key(CONF_SERVICE, CONF_ACTION),
+    cv.rename_key(CONF_SERVICE, CONF_ACTION),
+)
+
+
+@automation.register_action(
+    "homeassistant.action",
+    HomeAssistantServiceCallAction,
+    HOMEASSISTANT_ACTION_ACTION_SCHEMA,
+)
+@automation.register_action(
+    "homeassistant.service",
+    HomeAssistantServiceCallAction,
+    HOMEASSISTANT_ACTION_ACTION_SCHEMA,
+)
+async def homeassistant_service_to_code(config, action_id, template_arg, args):
+    serv = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, serv, False)
+    templ = await cg.templatable(config[CONF_ACTION], args, None)
+    cg.add(var.set_service(templ))
+    for key, value in config[CONF_DATA].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_data(key, templ))
+    for key, value in config[CONF_DATA_TEMPLATE].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_data_template(key, templ))
+    for key, value in config[CONF_VARIABLES].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_variable(key, templ))
+    return var
+
+
+def validate_homeassistant_event(value):
+    value = cv.string(value)
+    if not value.startswith("esphome."):
+        raise cv.Invalid(
+            "ESPHome can only generate Home Assistant events that begin with "
+            "esphome. For example 'esphome.xyz'"
+        )
+    return value
+
+
+HOMEASSISTANT_EVENT_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(APIServer),
+        cv.Required(CONF_EVENT): validate_homeassistant_event,
+        cv.Optional(CONF_DATA, default={}): KEY_VALUE_SCHEMA,
+        cv.Optional(CONF_DATA_TEMPLATE, default={}): KEY_VALUE_SCHEMA,
+        cv.Optional(CONF_VARIABLES, default={}): KEY_VALUE_SCHEMA,
+    }
+)
+
+
+@automation.register_action(
+    "homeassistant.event",
+    HomeAssistantServiceCallAction,
+    HOMEASSISTANT_EVENT_ACTION_SCHEMA,
+)
+async def homeassistant_event_to_code(config, action_id, template_arg, args):
+    serv = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, serv, True)
+    templ = await cg.templatable(config[CONF_EVENT], args, None)
+    cg.add(var.set_service(templ))
+    for key, value in config[CONF_DATA].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_data(key, templ))
+    for key, value in config[CONF_DATA_TEMPLATE].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_data_template(key, templ))
+    for key, value in config[CONF_VARIABLES].items():
+        templ = await cg.templatable(value, args, None)
+        cg.add(var.add_variable(key, templ))
+    return var
+
+
+HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(): cv.use_id(APIServer),
+        cv.Required(CONF_TAG): cv.templatable(cv.string_strict),
+    },
+    key=CONF_TAG,
+)
+
+
+@automation.register_action(
+    "homeassistant.tag_scanned",
+    HomeAssistantServiceCallAction,
+    HOMEASSISTANT_TAG_SCANNED_ACTION_SCHEMA,
+)
+async def homeassistant_tag_scanned_to_code(config, action_id, template_arg, args):
+    serv = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, serv, True)
+    cg.add(var.set_service("esphome.tag_scanned"))
+    templ = await cg.templatable(config[CONF_TAG], args, cg.std_string)
+    cg.add(var.add_data("tag_id", templ))
+    return var
+
+
+@automation.register_condition("api.connected", APIConnectedCondition, {})
+async def api_connected_to_code(config, condition_id, template_arg, args):
+    return cg.new_Pvariable(condition_id, template_arg)

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1,0 +1,1904 @@
+syntax = "proto3";
+
+import "api_options.proto";
+
+service APIConnection {
+  rpc hello (HelloRequest) returns (HelloResponse) {
+    option (needs_setup_connection) = false;
+    option (needs_authentication) = false;
+  }
+  rpc connect (ConnectRequest) returns (ConnectResponse) {
+    option (needs_setup_connection) = false;
+    option (needs_authentication) = false;
+  }
+  rpc disconnect (DisconnectRequest) returns (DisconnectResponse) {
+    option (needs_setup_connection) = false;
+    option (needs_authentication) = false;
+  }
+  rpc ping (PingRequest) returns (PingResponse) {
+    option (needs_setup_connection) = false;
+    option (needs_authentication) = false;
+  }
+  rpc device_info (DeviceInfoRequest) returns (DeviceInfoResponse) {
+    option (needs_authentication) = false;
+  }
+  rpc list_entities (ListEntitiesRequest) returns (void) {}
+  rpc subscribe_states (SubscribeStatesRequest) returns (void) {}
+  rpc subscribe_logs (SubscribeLogsRequest) returns (void) {}
+  rpc subscribe_homeassistant_services (SubscribeHomeassistantServicesRequest) returns (void) {}
+  rpc subscribe_home_assistant_states (SubscribeHomeAssistantStatesRequest) returns (void) {}
+  rpc get_time (GetTimeRequest) returns (GetTimeResponse) {
+    option (needs_authentication) = false;
+  }
+  rpc execute_service (ExecuteServiceRequest) returns (void) {}
+
+  rpc cover_command (CoverCommandRequest) returns (void) {}
+  rpc fan_command (FanCommandRequest) returns (void) {}
+  rpc light_command (LightCommandRequest) returns (void) {}
+  rpc switch_command (SwitchCommandRequest) returns (void) {}
+  rpc camera_image (CameraImageRequest) returns (void) {}
+  rpc climate_command (ClimateCommandRequest) returns (void) {}
+  rpc number_command (NumberCommandRequest) returns (void) {}
+  rpc text_command (TextCommandRequest) returns (void) {}
+  rpc select_command (SelectCommandRequest) returns (void) {}
+  rpc button_command (ButtonCommandRequest) returns (void) {}
+  rpc lock_command (LockCommandRequest) returns (void) {}
+  rpc valve_command (ValveCommandRequest) returns (void) {}
+  rpc media_player_command (MediaPlayerCommandRequest) returns (void) {}
+  rpc date_command (DateCommandRequest) returns (void) {}
+  rpc time_command (TimeCommandRequest) returns (void) {}
+  rpc datetime_command (DateTimeCommandRequest) returns (void) {}
+  rpc update_command (UpdateCommandRequest) returns (void) {}
+
+  rpc subscribe_bluetooth_le_advertisements(SubscribeBluetoothLEAdvertisementsRequest) returns (void) {}
+  rpc bluetooth_device_request(BluetoothDeviceRequest) returns (void) {}
+  rpc bluetooth_gatt_get_services(BluetoothGATTGetServicesRequest) returns (void) {}
+  rpc bluetooth_gatt_read(BluetoothGATTReadRequest) returns (void) {}
+  rpc bluetooth_gatt_write(BluetoothGATTWriteRequest) returns (void) {}
+  rpc bluetooth_gatt_read_descriptor(BluetoothGATTReadDescriptorRequest) returns (void) {}
+  rpc bluetooth_gatt_write_descriptor(BluetoothGATTWriteDescriptorRequest) returns (void) {}
+  rpc bluetooth_gatt_notify(BluetoothGATTNotifyRequest) returns (void) {}
+  rpc subscribe_bluetooth_connections_free(SubscribeBluetoothConnectionsFreeRequest) returns (BluetoothConnectionsFreeResponse) {}
+  rpc unsubscribe_bluetooth_le_advertisements(UnsubscribeBluetoothLEAdvertisementsRequest) returns (void) {}
+
+  rpc subscribe_voice_assistant(SubscribeVoiceAssistantRequest) returns (void) {}
+
+  rpc alarm_control_panel_command (AlarmControlPanelCommandRequest) returns (void) {}
+}
+
+
+// ==================== BASE PACKETS ====================
+
+// The Home Assistant protocol is structured as a simple
+// TCP socket with short binary messages encoded in the protocol buffers format
+// First, a message in this protocol has a specific format:
+//  * A zero byte.
+//  * VarInt denoting the size of the message object. (type is not part of this)
+//  * VarInt denoting the type of message.
+//  * The message object encoded as a ProtoBuf message
+
+// The connection is established in 4 steps:
+//  * First, the client connects to the server and sends a "Hello Request" identifying itself
+//  * The server responds with a "Hello Response" and selects the protocol version
+//  * After receiving this message, the client attempts to authenticate itself using
+//    the password and a "Connect Request"
+//  * The server responds with a "Connect Response" and notifies of invalid password.
+// If anything in this initial process fails, the connection must immediately closed
+// by both sides and _no_ disconnection message is to be sent.
+
+// Message sent at the beginning of each connection
+// Can only be sent by the client and only at the beginning of the connection
+message HelloRequest {
+  option (id) = 1;
+  option (source) = SOURCE_CLIENT;
+  option (no_delay) = true;
+
+  // Description of client (like User Agent)
+  // For example "Home Assistant"
+  // Not strictly necessary to send but nice for debugging
+  // purposes.
+  string client_info = 1;
+  uint32 api_version_major = 2;
+  uint32 api_version_minor = 3;
+}
+
+// Confirmation of successful connection request.
+// Can only be sent by the server and only at the beginning of the connection
+message HelloResponse {
+  option (id) = 2;
+  option (source) = SOURCE_SERVER;
+  option (no_delay) = true;
+
+  // The version of the API to use. The _client_ (for example Home Assistant) needs to check
+  // for compatibility and if necessary adopt to an older API.
+  // Major is for breaking changes in the base protocol - a mismatch will lead to immediate disconnect_client_
+  // Minor is for breaking changes in individual messages - a mismatch will lead to a warning message
+  uint32 api_version_major = 1;
+  uint32 api_version_minor = 2;
+
+  // A string identifying the server (ESP); like client info this may be empty
+  // and only exists for debugging/logging purposes.
+  // For example "ESPHome v1.10.0 on ESP8266"
+  string server_info = 3;
+
+  // The name of the server (App.get_name())
+  string name = 4;
+}
+
+// Message sent at the beginning of each connection to authenticate the client
+// Can only be sent by the client and only at the beginning of the connection
+message ConnectRequest {
+  option (id) = 3;
+  option (source) = SOURCE_CLIENT;
+  option (no_delay) = true;
+
+  // The password to log in with
+  string password = 1;
+}
+
+// Confirmation of successful connection. After this the connection is available for all traffic.
+// Can only be sent by the server and only at the beginning of the connection
+message ConnectResponse {
+  option (id) = 4;
+  option (source) = SOURCE_SERVER;
+  option (no_delay) = true;
+
+  bool invalid_password = 1;
+}
+
+// Request to close the connection.
+// Can be sent by both the client and server
+message DisconnectRequest {
+  option (id) = 5;
+  option (source) = SOURCE_BOTH;
+  option (no_delay) = true;
+
+  // Do not close the connection before the acknowledgement arrives
+}
+
+message DisconnectResponse {
+  option (id) = 6;
+  option (source) = SOURCE_BOTH;
+  option (no_delay) = true;
+
+  // Empty - Both parties are required to close the connection after this
+  // message has been received.
+}
+
+message PingRequest {
+  option (id) = 7;
+  option (source) = SOURCE_BOTH;
+  // Empty
+}
+
+message PingResponse {
+  option (id) = 8;
+  option (source) = SOURCE_BOTH;
+  // Empty
+}
+
+message DeviceInfoRequest {
+  option (id) = 9;
+  option (source) = SOURCE_CLIENT;
+  // Empty
+}
+
+message DeviceInfoResponse {
+  option (id) = 10;
+  option (source) = SOURCE_SERVER;
+
+  bool uses_password = 1;
+
+  // The name of the node, given by "App.set_name()"
+  string name = 2;
+
+  // The mac address of the device. For example "AC:BC:32:89:0E:A9"
+  string mac_address = 3;
+
+  // A string describing the ESPHome version. For example "1.10.0"
+  string esphome_version = 4;
+
+  // A string describing the date of compilation, this is generated by the compiler
+  // and therefore may not be in the same format all the time.
+  // If the user isn't using ESPHome, this will also not be set.
+  string compilation_time = 5;
+
+  // The model of the board. For example NodeMCU
+  string model = 6;
+
+  bool has_deep_sleep = 7;
+
+  // The esphome project details if set
+  string project_name = 8;
+  string project_version = 9;
+
+  uint32 webserver_port = 10;
+
+  uint32 legacy_bluetooth_proxy_version = 11;
+  uint32 bluetooth_proxy_feature_flags = 15;
+
+  string manufacturer = 12;
+
+  string friendly_name = 13;
+
+  uint32 legacy_voice_assistant_version = 14;
+  uint32 voice_assistant_feature_flags = 17;
+
+  string suggested_area = 16;
+}
+
+message ListEntitiesRequest {
+  option (id) = 11;
+  option (source) = SOURCE_CLIENT;
+  // Empty
+}
+message ListEntitiesDoneResponse {
+  option (id) = 19;
+  option (source) = SOURCE_SERVER;
+  option (no_delay) = true;
+  // Empty
+}
+message SubscribeStatesRequest {
+  option (id) = 20;
+  option (source) = SOURCE_CLIENT;
+  // Empty
+}
+
+// ==================== COMMON =====================
+
+enum EntityCategory {
+  ENTITY_CATEGORY_NONE = 0;
+  ENTITY_CATEGORY_CONFIG = 1;
+  ENTITY_CATEGORY_DIAGNOSTIC = 2;
+}
+
+// ==================== BINARY SENSOR ====================
+message ListEntitiesBinarySensorResponse {
+  option (id) = 12;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BINARY_SENSOR";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string device_class = 5;
+  bool is_status_binary_sensor = 6;
+  bool disabled_by_default = 7;
+  string icon = 8;
+  EntityCategory entity_category = 9;
+}
+message BinarySensorStateResponse {
+  option (id) = 21;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BINARY_SENSOR";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool state = 2;
+  // If the binary sensor does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+
+// ==================== COVER ====================
+message ListEntitiesCoverResponse {
+  option (id) = 13;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_COVER";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  bool assumed_state = 5;
+  bool supports_position = 6;
+  bool supports_tilt = 7;
+  string device_class = 8;
+  bool disabled_by_default = 9;
+  string icon = 10;
+  EntityCategory entity_category = 11;
+  bool supports_stop = 12;
+}
+
+enum LegacyCoverState {
+  LEGACY_COVER_STATE_OPEN = 0;
+  LEGACY_COVER_STATE_CLOSED = 1;
+}
+enum CoverOperation {
+  COVER_OPERATION_IDLE = 0;
+  COVER_OPERATION_IS_OPENING = 1;
+  COVER_OPERATION_IS_CLOSING = 2;
+}
+message CoverStateResponse {
+  option (id) = 22;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_COVER";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  // legacy: state has been removed in 1.13
+  // clients/servers must still send/accept it until the next protocol change
+  LegacyCoverState legacy_state = 2;
+
+  float position = 3;
+  float tilt = 4;
+  CoverOperation current_operation = 5;
+}
+
+enum LegacyCoverCommand {
+  LEGACY_COVER_COMMAND_OPEN = 0;
+  LEGACY_COVER_COMMAND_CLOSE = 1;
+  LEGACY_COVER_COMMAND_STOP = 2;
+}
+message CoverCommandRequest {
+  option (id) = 30;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_COVER";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+
+  // legacy: command has been removed in 1.13
+  // clients/servers must still send/accept it until the next protocol change
+  bool has_legacy_command = 2;
+  LegacyCoverCommand legacy_command = 3;
+
+  bool has_position = 4;
+  float position = 5;
+  bool has_tilt = 6;
+  float tilt = 7;
+  bool stop = 8;
+}
+
+// ==================== FAN ====================
+message ListEntitiesFanResponse {
+  option (id) = 14;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_FAN";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  bool supports_oscillation = 5;
+  bool supports_speed = 6;
+  bool supports_direction = 7;
+  int32 supported_speed_count = 8;
+  bool disabled_by_default = 9;
+  string icon = 10;
+  EntityCategory entity_category = 11;
+  repeated string supported_preset_modes = 12;
+}
+enum FanSpeed {
+  FAN_SPEED_LOW = 0;
+  FAN_SPEED_MEDIUM = 1;
+  FAN_SPEED_HIGH = 2;
+}
+enum FanDirection {
+  FAN_DIRECTION_FORWARD = 0;
+  FAN_DIRECTION_REVERSE = 1;
+}
+message FanStateResponse {
+  option (id) = 23;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_FAN";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool state = 2;
+  bool oscillating = 3;
+  FanSpeed speed = 4 [deprecated = true];
+  FanDirection direction = 5;
+  int32 speed_level = 6;
+  string preset_mode = 7;
+}
+message FanCommandRequest {
+  option (id) = 31;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_FAN";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool has_state = 2;
+  bool state = 3;
+  bool has_speed = 4 [deprecated = true];
+  FanSpeed speed = 5 [deprecated = true];
+  bool has_oscillating = 6;
+  bool oscillating = 7;
+  bool has_direction = 8;
+  FanDirection direction = 9;
+  bool has_speed_level = 10;
+  int32 speed_level = 11;
+  bool has_preset_mode = 12;
+  string preset_mode = 13;
+}
+
+// ==================== LIGHT ====================
+enum ColorMode {
+  COLOR_MODE_UNKNOWN = 0;
+  COLOR_MODE_ON_OFF = 1;
+  COLOR_MODE_BRIGHTNESS = 2;
+  COLOR_MODE_WHITE = 7;
+  COLOR_MODE_COLOR_TEMPERATURE = 11;
+  COLOR_MODE_COLD_WARM_WHITE = 19;
+  COLOR_MODE_RGB = 35;
+  COLOR_MODE_RGB_WHITE = 39;
+  COLOR_MODE_RGB_COLOR_TEMPERATURE = 47;
+  COLOR_MODE_RGB_COLD_WARM_WHITE = 51;
+}
+message ListEntitiesLightResponse {
+  option (id) = 15;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_LIGHT";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  repeated ColorMode supported_color_modes = 12;
+  // next four supports_* are for legacy clients, newer clients should use color modes
+  bool legacy_supports_brightness = 5 [deprecated=true];
+  bool legacy_supports_rgb = 6 [deprecated=true];
+  bool legacy_supports_white_value = 7 [deprecated=true];
+  bool legacy_supports_color_temperature = 8 [deprecated=true];
+  float min_mireds = 9;
+  float max_mireds = 10;
+  repeated string effects = 11;
+  bool disabled_by_default = 13;
+  string icon = 14;
+  EntityCategory entity_category = 15;
+}
+message LightStateResponse {
+  option (id) = 24;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_LIGHT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool state = 2;
+  float brightness = 3;
+  ColorMode color_mode = 11;
+  float color_brightness = 10;
+  float red = 4;
+  float green = 5;
+  float blue = 6;
+  float white = 7;
+  float color_temperature = 8;
+  float cold_white = 12;
+  float warm_white = 13;
+  string effect = 9;
+}
+message LightCommandRequest {
+  option (id) = 32;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_LIGHT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool has_state = 2;
+  bool state = 3;
+  bool has_brightness = 4;
+  float brightness = 5;
+  bool has_color_mode = 22;
+  ColorMode color_mode = 23;
+  bool has_color_brightness = 20;
+  float color_brightness = 21;
+  bool has_rgb = 6;
+  float red = 7;
+  float green = 8;
+  float blue = 9;
+  bool has_white = 10;
+  float white = 11;
+  bool has_color_temperature = 12;
+  float color_temperature = 13;
+  bool has_cold_white = 24;
+  float cold_white = 25;
+  bool has_warm_white = 26;
+  float warm_white = 27;
+  bool has_transition_length = 14;
+  uint32 transition_length = 15;
+  bool has_flash_length = 16;
+  uint32 flash_length = 17;
+  bool has_effect = 18;
+  string effect = 19;
+}
+
+// ==================== SENSOR ====================
+enum SensorStateClass {
+  STATE_CLASS_NONE = 0;
+  STATE_CLASS_MEASUREMENT = 1;
+  STATE_CLASS_TOTAL_INCREASING = 2;
+  STATE_CLASS_TOTAL = 3;
+}
+
+enum SensorLastResetType {
+  LAST_RESET_NONE = 0;
+  LAST_RESET_NEVER = 1;
+  LAST_RESET_AUTO = 2;
+}
+
+message ListEntitiesSensorResponse {
+  option (id) = 16;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SENSOR";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  string unit_of_measurement = 6;
+  int32 accuracy_decimals = 7;
+  bool force_update = 8;
+  string device_class = 9;
+  SensorStateClass state_class = 10;
+  // Last reset type removed in 2021.9.0
+  SensorLastResetType legacy_last_reset_type = 11;
+  bool disabled_by_default = 12;
+  EntityCategory entity_category = 13;
+}
+message SensorStateResponse {
+  option (id) = 25;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SENSOR";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  float state = 2;
+  // If the sensor does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+
+// ==================== SWITCH ====================
+message ListEntitiesSwitchResponse {
+  option (id) = 17;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SWITCH";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool assumed_state = 6;
+  bool disabled_by_default = 7;
+  EntityCategory entity_category = 8;
+  string device_class = 9;
+}
+message SwitchStateResponse {
+  option (id) = 26;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SWITCH";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool state = 2;
+}
+message SwitchCommandRequest {
+  option (id) = 33;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SWITCH";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool state = 2;
+}
+
+// ==================== TEXT SENSOR ====================
+message ListEntitiesTextSensorResponse {
+  option (id) = 18;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_TEXT_SENSOR";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  string device_class = 8;
+}
+message TextSensorStateResponse {
+  option (id) = 27;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_TEXT_SENSOR";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
+  // If the text sensor does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+
+// ==================== SUBSCRIBE LOGS ====================
+enum LogLevel {
+  LOG_LEVEL_NONE = 0;
+  LOG_LEVEL_ERROR = 1;
+  LOG_LEVEL_WARN = 2;
+  LOG_LEVEL_INFO = 3;
+  LOG_LEVEL_CONFIG = 4;
+  LOG_LEVEL_DEBUG = 5;
+  LOG_LEVEL_VERBOSE = 6;
+  LOG_LEVEL_VERY_VERBOSE = 7;
+}
+message SubscribeLogsRequest {
+  option (id) = 28;
+  option (source) = SOURCE_CLIENT;
+  LogLevel level = 1;
+  bool dump_config = 2;
+}
+message SubscribeLogsResponse {
+  option (id) = 29;
+  option (source) = SOURCE_SERVER;
+  option (log) = false;
+  option (no_delay) = false;
+
+  LogLevel level = 1;
+  string message = 3;
+  bool send_failed = 4;
+}
+
+// ==================== HOMEASSISTANT.SERVICE ====================
+message SubscribeHomeassistantServicesRequest {
+  option (id) = 34;
+  option (source) = SOURCE_CLIENT;
+}
+
+message HomeassistantServiceMap {
+  string key = 1;
+  string value = 2;
+}
+
+message HomeassistantServiceResponse {
+  option (id) = 35;
+  option (source) = SOURCE_SERVER;
+  option (no_delay) = true;
+
+  string service = 1;
+  repeated HomeassistantServiceMap data = 2;
+  repeated HomeassistantServiceMap data_template = 3;
+  repeated HomeassistantServiceMap variables = 4;
+  bool is_event = 5;
+}
+
+// ==================== IMPORT HOME ASSISTANT STATES ====================
+// 1. Client sends SubscribeHomeAssistantStatesRequest
+// 2. Server responds with zero or more SubscribeHomeAssistantStateResponse (async)
+// 3. Client sends HomeAssistantStateResponse for state changes.
+message SubscribeHomeAssistantStatesRequest {
+  option (id) = 38;
+  option (source) = SOURCE_CLIENT;
+}
+
+message SubscribeHomeAssistantStateResponse {
+  option (id) = 39;
+  option (source) = SOURCE_SERVER;
+  string entity_id = 1;
+  string attribute = 2;
+  bool once = 3;
+}
+
+message HomeAssistantStateResponse {
+  option (id) = 40;
+  option (source) = SOURCE_CLIENT;
+  option (no_delay) = true;
+
+  string entity_id = 1;
+  string state = 2;
+  string attribute = 3;
+}
+
+// ==================== IMPORT TIME ====================
+message GetTimeRequest {
+  option (id) = 36;
+  option (source) = SOURCE_BOTH;
+}
+
+message GetTimeResponse {
+  option (id) = 37;
+  option (source) = SOURCE_BOTH;
+  option (no_delay) = true;
+
+  fixed32 epoch_seconds = 1;
+}
+
+// ==================== USER-DEFINES SERVICES ====================
+enum ServiceArgType {
+  SERVICE_ARG_TYPE_BOOL = 0;
+  SERVICE_ARG_TYPE_INT = 1;
+  SERVICE_ARG_TYPE_FLOAT = 2;
+  SERVICE_ARG_TYPE_STRING = 3;
+  SERVICE_ARG_TYPE_BOOL_ARRAY = 4;
+  SERVICE_ARG_TYPE_INT_ARRAY = 5;
+  SERVICE_ARG_TYPE_FLOAT_ARRAY = 6;
+  SERVICE_ARG_TYPE_STRING_ARRAY = 7;
+}
+message ListEntitiesServicesArgument {
+  string name = 1;
+  ServiceArgType type = 2;
+}
+message ListEntitiesServicesResponse {
+  option (id) = 41;
+  option (source) = SOURCE_SERVER;
+
+  string name = 1;
+  fixed32 key = 2;
+  repeated ListEntitiesServicesArgument args = 3;
+}
+message ExecuteServiceArgument {
+  bool bool_ = 1;
+  int32 legacy_int = 2;
+  float float_ = 3;
+  string string_ = 4;
+  // ESPHome 1.14 (api v1.3) make int a signed value
+  sint32 int_ = 5;
+  repeated bool bool_array = 6 [packed=false];
+  repeated sint32 int_array = 7 [packed=false];
+  repeated float float_array = 8 [packed=false];
+  repeated string string_array = 9;
+}
+message ExecuteServiceRequest {
+  option (id) = 42;
+  option (source) = SOURCE_CLIENT;
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  repeated ExecuteServiceArgument args = 2;
+}
+
+// ==================== CAMERA ====================
+message ListEntitiesCameraResponse {
+  option (id) = 43;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_ESP32_CAMERA";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+  bool disabled_by_default = 5;
+  string icon = 6;
+  EntityCategory entity_category = 7;
+}
+
+message CameraImageResponse {
+  option (id) = 44;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_ESP32_CAMERA";
+
+  fixed32 key = 1;
+  bytes data = 2;
+  bool done = 3;
+}
+message CameraImageRequest {
+  option (id) = 45;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_ESP32_CAMERA";
+  option (no_delay) = true;
+
+  bool single = 1;
+  bool stream = 2;
+}
+
+// ==================== CLIMATE ====================
+enum ClimateMode {
+  CLIMATE_MODE_OFF = 0;
+  CLIMATE_MODE_HEAT_COOL = 1;
+  CLIMATE_MODE_COOL = 2;
+  CLIMATE_MODE_HEAT = 3;
+  CLIMATE_MODE_FAN_ONLY = 4;
+  CLIMATE_MODE_DRY = 5;
+  CLIMATE_MODE_AUTO = 6;
+}
+enum ClimateFanMode {
+  CLIMATE_FAN_ON = 0;
+  CLIMATE_FAN_OFF = 1;
+  CLIMATE_FAN_AUTO = 2;
+  CLIMATE_FAN_LOW = 3;
+  CLIMATE_FAN_MEDIUM = 4;
+  CLIMATE_FAN_HIGH = 5;
+  CLIMATE_FAN_MIDDLE = 6;
+  CLIMATE_FAN_FOCUS = 7;
+  CLIMATE_FAN_DIFFUSE = 8;
+  CLIMATE_FAN_QUIET = 9;
+}
+enum ClimateSwingMode {
+  CLIMATE_SWING_OFF = 0;
+  CLIMATE_SWING_BOTH = 1;
+  CLIMATE_SWING_VERTICAL = 2;
+  CLIMATE_SWING_HORIZONTAL = 3;
+}
+enum ClimateAction {
+  CLIMATE_ACTION_OFF = 0;
+  // values same as mode for readability
+  CLIMATE_ACTION_COOLING = 2;
+  CLIMATE_ACTION_HEATING = 3;
+  CLIMATE_ACTION_IDLE = 4;
+  CLIMATE_ACTION_DRYING = 5;
+  CLIMATE_ACTION_FAN = 6;
+}
+enum ClimatePreset {
+  CLIMATE_PRESET_NONE = 0;
+  CLIMATE_PRESET_HOME = 1;
+  CLIMATE_PRESET_AWAY = 2;
+  CLIMATE_PRESET_BOOST = 3;
+  CLIMATE_PRESET_COMFORT = 4;
+  CLIMATE_PRESET_ECO = 5;
+  CLIMATE_PRESET_SLEEP = 6;
+  CLIMATE_PRESET_ACTIVITY = 7;
+}
+message ListEntitiesClimateResponse {
+  option (id) = 46;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_CLIMATE";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  bool supports_current_temperature = 5;
+  bool supports_two_point_target_temperature = 6;
+  repeated ClimateMode supported_modes = 7;
+  float visual_min_temperature = 8;
+  float visual_max_temperature = 9;
+  float visual_target_temperature_step = 10;
+  // for older peer versions - in new system this
+  // is if CLIMATE_PRESET_AWAY exists is supported_presets
+  bool legacy_supports_away = 11;
+  bool supports_action = 12;
+  repeated ClimateFanMode supported_fan_modes = 13;
+  repeated ClimateSwingMode supported_swing_modes = 14;
+  repeated string supported_custom_fan_modes = 15;
+  repeated ClimatePreset supported_presets = 16;
+  repeated string supported_custom_presets = 17;
+  bool disabled_by_default = 18;
+  string icon = 19;
+  EntityCategory entity_category = 20;
+  float visual_current_temperature_step = 21;
+  bool supports_current_humidity = 22;
+  bool supports_target_humidity = 23;
+  float visual_min_humidity = 24;
+  float visual_max_humidity = 25;
+}
+message ClimateStateResponse {
+  option (id) = 47;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_CLIMATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  ClimateMode mode = 2;
+  float current_temperature = 3;
+  float target_temperature = 4;
+  float target_temperature_low = 5;
+  float target_temperature_high = 6;
+  bool unused_legacy_away = 7;
+  ClimateAction action = 8;
+  ClimateFanMode fan_mode = 9;
+  ClimateSwingMode swing_mode = 10;
+  string custom_fan_mode = 11;
+  ClimatePreset preset = 12;
+  string custom_preset = 13;
+  float current_humidity = 14;
+  float target_humidity = 15;
+}
+message ClimateCommandRequest {
+  option (id) = 48;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_CLIMATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool has_mode = 2;
+  ClimateMode mode = 3;
+  bool has_target_temperature = 4;
+  float target_temperature = 5;
+  bool has_target_temperature_low = 6;
+  float target_temperature_low = 7;
+  bool has_target_temperature_high = 8;
+  float target_temperature_high = 9;
+  bool unused_has_legacy_away = 10;
+  bool unused_legacy_away = 11;
+  bool has_fan_mode = 12;
+  ClimateFanMode fan_mode = 13;
+  bool has_swing_mode = 14;
+  ClimateSwingMode swing_mode = 15;
+  bool has_custom_fan_mode = 16;
+  string custom_fan_mode = 17;
+  bool has_preset = 18;
+  ClimatePreset preset = 19;
+  bool has_custom_preset = 20;
+  string custom_preset = 21;
+  bool has_target_humidity = 22;
+  float target_humidity = 23;
+}
+
+// ==================== NUMBER ====================
+enum NumberMode {
+  NUMBER_MODE_AUTO = 0;
+  NUMBER_MODE_BOX = 1;
+  NUMBER_MODE_SLIDER = 2;
+}
+message ListEntitiesNumberResponse {
+  option (id) = 49;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_NUMBER";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  float min_value = 6;
+  float max_value = 7;
+  float step = 8;
+  bool disabled_by_default = 9;
+  EntityCategory entity_category = 10;
+  string unit_of_measurement = 11;
+  NumberMode mode = 12;
+  string device_class = 13;
+}
+message NumberStateResponse {
+  option (id) = 50;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_NUMBER";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  float state = 2;
+  // If the number does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+message NumberCommandRequest {
+  option (id) = 51;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_NUMBER";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  float state = 2;
+}
+
+// ==================== SELECT ====================
+message ListEntitiesSelectResponse {
+  option (id) = 52;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SELECT";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  repeated string options = 6;
+  bool disabled_by_default = 7;
+  EntityCategory entity_category = 8;
+}
+message SelectStateResponse {
+  option (id) = 53;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SELECT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
+  // If the select does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+message SelectCommandRequest {
+  option (id) = 54;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SELECT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
+}
+
+
+// ==================== LOCK ====================
+enum LockState {
+  LOCK_STATE_NONE = 0;
+  LOCK_STATE_LOCKED = 1;
+  LOCK_STATE_UNLOCKED = 2;
+  LOCK_STATE_JAMMED = 3;
+  LOCK_STATE_LOCKING = 4;
+  LOCK_STATE_UNLOCKING = 5;
+}
+enum LockCommand  {
+  LOCK_UNLOCK = 0;
+  LOCK_LOCK = 1;
+  LOCK_OPEN = 2;
+}
+message ListEntitiesLockResponse {
+  option (id) = 58;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_LOCK";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  bool assumed_state = 8;
+
+  bool supports_open = 9;
+  bool requires_code = 10;
+
+  // Not yet implemented:
+  string code_format = 11;
+}
+message LockStateResponse {
+  option (id) = 59;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_LOCK";
+  option (no_delay) = true;
+  fixed32 key = 1;
+  LockState state = 2;
+}
+message LockCommandRequest {
+  option (id) = 60;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_LOCK";
+  option (no_delay) = true;
+  fixed32 key = 1;
+  LockCommand command = 2;
+
+  // Not yet implemented:
+  bool has_code = 3;
+  string code = 4;
+}
+
+// ==================== BUTTON ====================
+message ListEntitiesButtonResponse {
+  option (id) = 61;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BUTTON";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  string device_class = 8;
+}
+message ButtonCommandRequest {
+  option (id) = 62;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BUTTON";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+}
+
+// ==================== MEDIA PLAYER ====================
+enum MediaPlayerState {
+  MEDIA_PLAYER_STATE_NONE = 0;
+  MEDIA_PLAYER_STATE_IDLE = 1;
+  MEDIA_PLAYER_STATE_PLAYING = 2;
+  MEDIA_PLAYER_STATE_PAUSED = 3;
+}
+enum MediaPlayerCommand {
+  MEDIA_PLAYER_COMMAND_PLAY = 0;
+  MEDIA_PLAYER_COMMAND_PAUSE = 1;
+  MEDIA_PLAYER_COMMAND_STOP = 2;
+  MEDIA_PLAYER_COMMAND_MUTE = 3;
+  MEDIA_PLAYER_COMMAND_UNMUTE = 4;
+}
+enum MediaPlayerFormatPurpose {
+  MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT = 0;
+  MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT = 1;
+}
+message MediaPlayerSupportedFormat {
+  option (id) = 119;
+  option (ifdef) = "USE_MEDIA_PLAYER";
+
+  string format = 1;
+  uint32 sample_rate = 2;
+  uint32 num_channels = 3;
+  MediaPlayerFormatPurpose purpose = 4;
+}
+message ListEntitiesMediaPlayerResponse {
+  option (id) = 63;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_MEDIA_PLAYER";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+
+  bool supports_pause = 8;
+
+  repeated MediaPlayerSupportedFormat supported_formats = 9;
+}
+message MediaPlayerStateResponse {
+  option (id) = 64;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_MEDIA_PLAYER";
+  option (no_delay) = true;
+  fixed32 key = 1;
+  MediaPlayerState state = 2;
+  float volume = 3;
+  bool muted = 4;
+}
+message MediaPlayerCommandRequest {
+  option (id) = 65;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_MEDIA_PLAYER";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+
+  bool has_command = 2;
+  MediaPlayerCommand command = 3;
+
+  bool has_volume = 4;
+  float volume = 5;
+
+  bool has_media_url = 6;
+  string media_url = 7;
+
+  bool has_announcement = 8;
+  bool announcement = 9;
+}
+
+// ==================== BLUETOOTH ====================
+message SubscribeBluetoothLEAdvertisementsRequest {
+  option (id) = 66;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint32 flags = 1;
+}
+
+message BluetoothServiceData {
+  string uuid = 1;
+  repeated uint32 legacy_data = 2 [deprecated = true];
+  bytes data = 3; // Changed in proto version 1.7
+}
+message BluetoothLEAdvertisementResponse {
+  option (id) = 67;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+  option (no_delay) = true;
+
+  uint64 address = 1;
+  string name = 2;
+  sint32 rssi = 3;
+
+  repeated string service_uuids = 4;
+  repeated BluetoothServiceData service_data = 5;
+  repeated BluetoothServiceData manufacturer_data = 6;
+
+  uint32 address_type = 7;
+}
+
+message BluetoothLERawAdvertisement {
+  uint64 address = 1;
+  sint32 rssi = 2;
+  uint32 address_type = 3;
+
+  bytes data = 4;
+}
+
+message BluetoothLERawAdvertisementsResponse {
+  option (id) = 93;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+  option (no_delay) = true;
+
+  repeated BluetoothLERawAdvertisement advertisements = 1;
+}
+
+enum BluetoothDeviceRequestType {
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT = 0;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT = 1;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR = 2;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR = 3;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE = 4;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE = 5;
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE = 6;
+}
+
+message BluetoothDeviceRequest {
+  option (id) = 68;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  BluetoothDeviceRequestType request_type = 2;
+  bool has_address_type = 3;
+  uint32 address_type = 4;
+}
+
+message BluetoothDeviceConnectionResponse {
+  option (id) = 69;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  bool connected = 2;
+  uint32 mtu = 3;
+  int32 error = 4;
+}
+
+message BluetoothGATTGetServicesRequest {
+  option (id) = 70;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+}
+
+message BluetoothGATTDescriptor {
+  repeated uint64 uuid = 1;
+  uint32 handle = 2;
+}
+
+message BluetoothGATTCharacteristic {
+  repeated uint64 uuid = 1;
+  uint32 handle = 2;
+  uint32 properties = 3;
+  repeated BluetoothGATTDescriptor descriptors = 4;
+}
+
+message BluetoothGATTService {
+  repeated uint64 uuid = 1;
+  uint32 handle = 2;
+  repeated BluetoothGATTCharacteristic characteristics = 3;
+}
+
+message BluetoothGATTGetServicesResponse {
+  option (id) = 71;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  repeated BluetoothGATTService services = 2;
+}
+
+message BluetoothGATTGetServicesDoneResponse {
+  option (id) = 72;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+}
+
+message BluetoothGATTReadRequest {
+  option (id) = 73;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+}
+
+message BluetoothGATTReadResponse {
+  option (id) = 74;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+
+  bytes data = 3;
+
+}
+
+message BluetoothGATTWriteRequest {
+  option (id) = 75;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+  bool response = 3;
+
+  bytes data = 4;
+}
+
+message BluetoothGATTReadDescriptorRequest {
+  option (id) = 76;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+}
+
+message BluetoothGATTWriteDescriptorRequest {
+  option (id) = 77;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+
+  bytes data = 3;
+}
+
+message BluetoothGATTNotifyRequest {
+  option (id) = 78;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+  bool enable = 3;
+}
+
+message BluetoothGATTNotifyDataResponse {
+  option (id) = 79;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+
+  bytes data = 3;
+}
+
+message SubscribeBluetoothConnectionsFreeRequest {
+  option (id) = 80;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+}
+
+message BluetoothConnectionsFreeResponse {
+  option (id) = 81;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint32 free = 1;
+  uint32 limit = 2;
+}
+
+message BluetoothGATTErrorResponse {
+  option (id) = 82;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+  int32 error = 3;
+}
+
+message BluetoothGATTWriteResponse {
+  option (id) = 83;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+}
+
+message BluetoothGATTNotifyResponse {
+  option (id) = 84;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 handle = 2;
+}
+
+message BluetoothDevicePairingResponse {
+  option (id) = 85;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  bool paired = 2;
+  int32 error = 3;
+}
+
+message BluetoothDeviceUnpairingResponse {
+  option (id) = 86;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  bool success = 2;
+  int32 error = 3;
+}
+
+message UnsubscribeBluetoothLEAdvertisementsRequest {
+  option (id) = 87;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+}
+
+message BluetoothDeviceClearCacheResponse {
+  option (id) = 88;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  bool success = 2;
+  int32 error = 3;
+}
+
+// ==================== PUSH TO TALK ====================
+enum VoiceAssistantSubscribeFlag {
+  VOICE_ASSISTANT_SUBSCRIBE_NONE = 0;
+  VOICE_ASSISTANT_SUBSCRIBE_API_AUDIO = 1;
+}
+
+message SubscribeVoiceAssistantRequest {
+  option (id) = 89;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  bool subscribe = 1;
+  uint32 flags = 2;
+}
+
+enum VoiceAssistantRequestFlag {
+  VOICE_ASSISTANT_REQUEST_NONE = 0;
+  VOICE_ASSISTANT_REQUEST_USE_VAD = 1;
+  VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2;
+}
+
+message VoiceAssistantAudioSettings {
+  uint32 noise_suppression_level = 1;
+  uint32 auto_gain = 2;
+  float volume_multiplier = 3;
+}
+
+message VoiceAssistantRequest {
+  option (id) = 90;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  bool start = 1;
+  string conversation_id = 2;
+  uint32 flags = 3;
+  VoiceAssistantAudioSettings audio_settings = 4;
+  string wake_word_phrase = 5;
+}
+
+message VoiceAssistantResponse {
+  option (id) = 91;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  uint32 port = 1;
+  bool error = 2;
+}
+
+enum VoiceAssistantEvent {
+  VOICE_ASSISTANT_ERROR = 0;
+  VOICE_ASSISTANT_RUN_START = 1;
+  VOICE_ASSISTANT_RUN_END = 2;
+  VOICE_ASSISTANT_STT_START = 3;
+  VOICE_ASSISTANT_STT_END = 4;
+  VOICE_ASSISTANT_INTENT_START = 5;
+  VOICE_ASSISTANT_INTENT_END = 6;
+  VOICE_ASSISTANT_TTS_START = 7;
+  VOICE_ASSISTANT_TTS_END = 8;
+  VOICE_ASSISTANT_WAKE_WORD_START = 9;
+  VOICE_ASSISTANT_WAKE_WORD_END = 10;
+  VOICE_ASSISTANT_STT_VAD_START = 11;
+  VOICE_ASSISTANT_STT_VAD_END = 12;
+  VOICE_ASSISTANT_TTS_STREAM_START = 98;
+  VOICE_ASSISTANT_TTS_STREAM_END = 99;
+}
+
+message VoiceAssistantEventData {
+  string name = 1;
+  string value = 2;
+}
+
+message VoiceAssistantEventResponse {
+  option (id) = 92;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  VoiceAssistantEvent event_type = 1;
+  repeated VoiceAssistantEventData data = 2;
+}
+
+message VoiceAssistantAudio {
+  option (id) = 106;
+  option (source) = SOURCE_BOTH;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  bytes data = 1;
+  bool end = 2;
+}
+
+enum VoiceAssistantTimerEvent {
+  VOICE_ASSISTANT_TIMER_STARTED = 0;
+  VOICE_ASSISTANT_TIMER_UPDATED = 1;
+  VOICE_ASSISTANT_TIMER_CANCELLED = 2;
+  VOICE_ASSISTANT_TIMER_FINISHED = 3;
+}
+
+message VoiceAssistantTimerEventResponse {
+  option (id) = 115;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  VoiceAssistantTimerEvent event_type = 1;
+  string timer_id = 2;
+  string name = 3;
+  uint32 total_seconds = 4;
+  uint32 seconds_left = 5;
+  bool is_active = 6;
+}
+
+// ==================== ALARM CONTROL PANEL ====================
+enum AlarmControlPanelState {
+  ALARM_STATE_DISARMED = 0;
+  ALARM_STATE_ARMED_HOME = 1;
+  ALARM_STATE_ARMED_AWAY = 2;
+  ALARM_STATE_ARMED_NIGHT = 3;
+  ALARM_STATE_ARMED_VACATION = 4;
+  ALARM_STATE_ARMED_CUSTOM_BYPASS = 5;
+  ALARM_STATE_PENDING = 6;
+  ALARM_STATE_ARMING = 7;
+  ALARM_STATE_DISARMING = 8;
+  ALARM_STATE_TRIGGERED = 9;
+}
+
+enum AlarmControlPanelStateCommand {
+  ALARM_CONTROL_PANEL_DISARM = 0;
+  ALARM_CONTROL_PANEL_ARM_AWAY = 1;
+  ALARM_CONTROL_PANEL_ARM_HOME = 2;
+  ALARM_CONTROL_PANEL_ARM_NIGHT = 3;
+  ALARM_CONTROL_PANEL_ARM_VACATION = 4;
+  ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS = 5;
+  ALARM_CONTROL_PANEL_TRIGGER = 6;
+}
+
+message ListEntitiesAlarmControlPanelResponse {
+  option (id) = 94;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_ALARM_CONTROL_PANEL";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  uint32 supported_features = 8;
+  bool requires_code = 9;
+  bool requires_code_to_arm = 10;
+}
+
+message AlarmControlPanelStateResponse {
+  option (id) = 95;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_ALARM_CONTROL_PANEL";
+  option (no_delay) = true;
+  fixed32 key = 1;
+  AlarmControlPanelState state = 2;
+}
+
+message AlarmControlPanelCommandRequest {
+  option (id) = 96;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_ALARM_CONTROL_PANEL";
+  option (no_delay) = true;
+  fixed32 key = 1;
+  AlarmControlPanelStateCommand command = 2;
+  string code = 3;
+}
+
+// ===================== TEXT =====================
+enum TextMode {
+  TEXT_MODE_TEXT = 0;
+  TEXT_MODE_PASSWORD = 1;
+}
+message ListEntitiesTextResponse {
+  option (id) = 97;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_TEXT";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+
+  uint32 min_length = 8;
+  uint32 max_length = 9;
+  string pattern = 10;
+  TextMode mode = 11;
+}
+message TextStateResponse {
+  option (id) = 98;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_TEXT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
+  // If the Text does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 3;
+}
+message TextCommandRequest {
+  option (id) = 99;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_TEXT";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  string state = 2;
+}
+
+
+// ==================== DATETIME DATE ====================
+message ListEntitiesDateResponse {
+  option (id) = 100;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_DATE";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+}
+message DateStateResponse {
+  option (id) = 101;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_DATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  // If the date does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 2;
+  uint32 year = 3;
+  uint32 month = 4;
+  uint32 day = 5;
+}
+message DateCommandRequest {
+  option (id) = 102;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_DATETIME_DATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  uint32 year = 2;
+  uint32 month = 3;
+  uint32 day = 4;
+}
+
+// ==================== DATETIME TIME ====================
+message ListEntitiesTimeResponse {
+  option (id) = 103;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_TIME";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+}
+message TimeStateResponse {
+  option (id) = 104;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_TIME";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  // If the time does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 2;
+  uint32 hour = 3;
+  uint32 minute = 4;
+  uint32 second = 5;
+}
+message TimeCommandRequest {
+  option (id) = 105;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_DATETIME_TIME";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  uint32 hour = 2;
+  uint32 minute = 3;
+  uint32 second = 4;
+}
+
+// ==================== EVENT ====================
+message ListEntitiesEventResponse {
+  option (id) = 107;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_EVENT";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  string device_class = 8;
+
+  repeated string event_types = 9;
+}
+message EventResponse {
+  option (id) = 108;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_EVENT";
+
+  fixed32 key = 1;
+  string event_type = 2;
+}
+
+// ==================== VALVE ====================
+message ListEntitiesValveResponse {
+  option (id) = 109;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VALVE";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  string device_class = 8;
+
+  bool assumed_state = 9;
+  bool supports_position = 10;
+  bool supports_stop = 11;
+}
+
+enum ValveOperation {
+  VALVE_OPERATION_IDLE = 0;
+  VALVE_OPERATION_IS_OPENING = 1;
+  VALVE_OPERATION_IS_CLOSING = 2;
+}
+message ValveStateResponse {
+  option (id) = 110;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VALVE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  float position = 2;
+  ValveOperation current_operation = 3;
+}
+
+message ValveCommandRequest {
+  option (id) = 111;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VALVE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool has_position = 2;
+  float position = 3;
+  bool stop = 4;
+}
+
+// ==================== DATETIME DATETIME ====================
+message ListEntitiesDateTimeResponse {
+  option (id) = 112;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_DATETIME";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+}
+message DateTimeStateResponse {
+  option (id) = 113;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_DATETIME_DATETIME";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  // If the datetime does not have a valid state yet.
+  // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
+  bool missing_state = 2;
+  fixed32 epoch_seconds = 3;
+}
+message DateTimeCommandRequest {
+  option (id) = 114;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_DATETIME_DATETIME";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  fixed32 epoch_seconds = 2;
+}
+
+// ==================== UPDATE ====================
+message ListEntitiesUpdateResponse {
+  option (id) = 116;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_UPDATE";
+
+  string object_id = 1;
+  fixed32 key = 2;
+  string name = 3;
+  string unique_id = 4;
+
+  string icon = 5;
+  bool disabled_by_default = 6;
+  EntityCategory entity_category = 7;
+  string device_class = 8;
+}
+message UpdateStateResponse {
+  option (id) = 117;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_UPDATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  bool missing_state = 2;
+  bool in_progress = 3;
+  bool has_progress = 4;
+  float progress = 5;
+  string current_version = 6;
+  string latest_version = 7;
+  string title = 8;
+  string release_summary = 9;
+  string release_url = 10;
+}
+enum UpdateCommand {
+  UPDATE_COMMAND_NONE = 0;
+  UPDATE_COMMAND_UPDATE = 1;
+  UPDATE_COMMAND_CHECK = 2;
+}
+message UpdateCommandRequest {
+  option (id) = 118;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_UPDATE";
+  option (no_delay) = true;
+
+  fixed32 key = 1;
+  UpdateCommand command = 2;
+}

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,0 +1,1521 @@
+#include "api_connection.h"
+#include <cerrno>
+#include <cinttypes>
+#include <utility>
+#include "esphome/components/network/util.h"
+#include "esphome/core/entity_base.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+#include "esphome/core/version.h"
+
+#ifdef USE_DEEP_SLEEP
+#include "esphome/components/deep_sleep/deep_sleep_component.h"
+#endif
+#ifdef USE_HOMEASSISTANT_TIME
+#include "esphome/components/homeassistant/time/homeassistant_time.h"
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#include "esphome/components/bluetooth_proxy/bluetooth_proxy.h"
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#include "esphome/components/voice_assistant/voice_assistant.h"
+#endif
+
+namespace esphome {
+namespace api {
+
+static const char *const TAG = "api.connection";
+static const int ESP32_CAMERA_STOP_STREAM = 5000;
+
+APIConnection::APIConnection(std::unique_ptr<socket::Socket> sock, APIServer *parent)
+    : parent_(parent), initial_state_iterator_(this), list_entities_iterator_(this) {
+  this->proto_write_buffer_.reserve(64);
+
+#if defined(USE_API_PLAINTEXT)
+  this->helper_ = std::unique_ptr<APIFrameHelper>{new APIPlaintextFrameHelper(std::move(sock))};
+#elif defined(USE_API_NOISE)
+  this->helper_ = std::unique_ptr<APIFrameHelper>{new APINoiseFrameHelper(std::move(sock), parent->get_noise_ctx())};
+#else
+#error "No frame helper defined"
+#endif
+}
+void APIConnection::start() {
+  this->last_traffic_ = millis();
+
+  APIError err = this->helper_->init();
+  if (err != APIError::OK) {
+    on_fatal_error();
+    ESP_LOGW(TAG, "%s: Helper init failed: %s errno=%d", this->client_combined_info_.c_str(), api_error_to_str(err),
+             errno);
+    return;
+  }
+  this->client_info_ = helper_->getpeername();
+  this->client_peername_ = this->client_info_;
+  this->helper_->set_log_info(this->client_info_);
+}
+
+APIConnection::~APIConnection() {
+#ifdef USE_BLUETOOTH_PROXY
+  if (bluetooth_proxy::global_bluetooth_proxy->get_api_connection() == this) {
+    bluetooth_proxy::global_bluetooth_proxy->unsubscribe_api_connection(this);
+  }
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  if (voice_assistant::global_voice_assistant->get_api_connection() == this) {
+    voice_assistant::global_voice_assistant->client_subscription(this, false);
+  }
+#endif
+}
+
+void APIConnection::loop() {
+  if (this->remove_)
+    return;
+
+  if (!network::is_connected()) {
+    // when network is disconnected force disconnect immediately
+    // don't wait for timeout
+    this->on_fatal_error();
+    ESP_LOGW(TAG, "%s: Network unavailable, disconnecting", this->client_combined_info_.c_str());
+    return;
+  }
+  if (this->next_close_) {
+    // requested a disconnect
+    this->helper_->close();
+    this->remove_ = true;
+    return;
+  }
+
+  APIError err = this->helper_->loop();
+  if (err != APIError::OK) {
+    on_fatal_error();
+    ESP_LOGW(TAG, "%s: Socket operation failed: %s errno=%d", this->client_combined_info_.c_str(),
+             api_error_to_str(err), errno);
+    return;
+  }
+  ReadPacketBuffer buffer;
+  err = this->helper_->read_packet(&buffer);
+  if (err == APIError::WOULD_BLOCK) {
+    // pass
+  } else if (err != APIError::OK) {
+    on_fatal_error();
+    if (err == APIError::SOCKET_READ_FAILED && errno == ECONNRESET) {
+      ESP_LOGW(TAG, "%s: Connection reset", this->client_combined_info_.c_str());
+    } else if (err == APIError::CONNECTION_CLOSED) {
+      ESP_LOGW(TAG, "%s: Connection closed", this->client_combined_info_.c_str());
+    } else {
+      ESP_LOGW(TAG, "%s: Reading failed: %s errno=%d", this->client_combined_info_.c_str(), api_error_to_str(err),
+               errno);
+    }
+    return;
+  } else {
+    this->last_traffic_ = millis();
+    // read a packet
+    this->read_message(buffer.data_len, buffer.type, &buffer.container[buffer.data_offset]);
+    if (this->remove_)
+      return;
+  }
+
+  this->list_entities_iterator_.advance();
+  this->initial_state_iterator_.advance();
+
+  static uint32_t keepalive = 60000;
+  static uint8_t max_ping_retries = 60;
+  static uint16_t ping_retry_interval = 1000;
+  const uint32_t now = millis();
+  if (this->sent_ping_) {
+    // Disconnect if not responded within 2.5*keepalive
+    if (now - this->last_traffic_ > (keepalive * 5) / 2) {
+      on_fatal_error();
+      ESP_LOGW(TAG, "%s didn't respond to ping request in time. Disconnecting...", this->client_combined_info_.c_str());
+    }
+  } else if (now - this->last_traffic_ > keepalive && now > this->next_ping_retry_) {
+    ESP_LOGVV(TAG, "Sending keepalive PING...");
+    this->sent_ping_ = this->send_ping_request(PingRequest());
+    if (!this->sent_ping_) {
+      this->next_ping_retry_ = now + ping_retry_interval;
+      this->ping_retries_++;
+      if (this->ping_retries_ >= max_ping_retries) {
+        on_fatal_error();
+        ESP_LOGE(TAG, "%s: Sending keepalive failed %d time(s). Disconnecting...", this->client_combined_info_.c_str(),
+                 this->ping_retries_);
+      } else if (this->ping_retries_ >= 10) {
+        ESP_LOGW(TAG, "%s: Sending keepalive failed %d time(s), will retry in %d ms",
+                 this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
+      } else {
+        ESP_LOGD(TAG, "%s: Sending keepalive failed %d time(s), will retry in %d ms",
+                 this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
+      }
+    }
+  }
+
+#ifdef USE_ESP32_CAMERA
+  if (this->image_reader_.available() && this->helper_->can_write_without_blocking()) {
+    uint32_t to_send = std::min((size_t) 1024, this->image_reader_.available());
+    auto buffer = this->create_buffer();
+    // fixed32 key = 1;
+    buffer.encode_fixed32(1, esp32_camera::global_esp32_camera->get_object_id_hash());
+    // bytes data = 2;
+    buffer.encode_bytes(2, this->image_reader_.peek_data_buffer(), to_send);
+    // bool done = 3;
+    bool done = this->image_reader_.available() == to_send;
+    buffer.encode_bool(3, done);
+    bool success = this->send_buffer(buffer, 44);
+
+    if (success) {
+      this->image_reader_.consume_data(to_send);
+    }
+    if (success && done) {
+      this->image_reader_.return_image();
+    }
+  }
+#endif
+
+  if (state_subs_at_ != -1) {
+    const auto &subs = this->parent_->get_state_subs();
+    if (state_subs_at_ >= (int) subs.size()) {
+      state_subs_at_ = -1;
+    } else {
+      auto &it = subs[state_subs_at_];
+      SubscribeHomeAssistantStateResponse resp;
+      resp.entity_id = it.entity_id;
+      resp.attribute = it.attribute.value();
+      if (this->send_subscribe_home_assistant_state_response(resp)) {
+        state_subs_at_++;
+      }
+    }
+  }
+}
+
+std::string get_default_unique_id(const std::string &component_type, EntityBase *entity) {
+  return App.get_name() + component_type + entity->get_object_id();
+}
+
+DisconnectResponse APIConnection::disconnect(const DisconnectRequest &msg) {
+  // remote initiated disconnect_client
+  // don't close yet, we still need to send the disconnect response
+  // close will happen on next loop
+  ESP_LOGD(TAG, "%s requested disconnected", this->client_combined_info_.c_str());
+  this->next_close_ = true;
+  DisconnectResponse resp;
+  return resp;
+}
+void APIConnection::on_disconnect_response(const DisconnectResponse &value) {
+  // pass
+}
+
+#ifdef USE_BINARY_SENSOR
+bool APIConnection::send_binary_sensor_state(binary_sensor::BinarySensor *binary_sensor, bool state) {
+  if (!this->state_subscription_)
+    return false;
+
+  BinarySensorStateResponse resp;
+  resp.key = binary_sensor->get_object_id_hash();
+  resp.state = state;
+  resp.missing_state = !binary_sensor->has_state();
+  return this->send_binary_sensor_state_response(resp);
+}
+bool APIConnection::send_binary_sensor_info(binary_sensor::BinarySensor *binary_sensor) {
+  ListEntitiesBinarySensorResponse msg;
+  msg.object_id = binary_sensor->get_object_id();
+  msg.key = binary_sensor->get_object_id_hash();
+  if (binary_sensor->has_own_name())
+    msg.name = binary_sensor->get_name();
+  msg.unique_id = get_default_unique_id("binary_sensor", binary_sensor);
+  msg.device_class = binary_sensor->get_device_class();
+  msg.is_status_binary_sensor = binary_sensor->is_status_binary_sensor();
+  msg.disabled_by_default = binary_sensor->is_disabled_by_default();
+  msg.icon = binary_sensor->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(binary_sensor->get_entity_category());
+  return this->send_list_entities_binary_sensor_response(msg);
+}
+#endif
+
+#ifdef USE_COVER
+bool APIConnection::send_cover_state(cover::Cover *cover) {
+  if (!this->state_subscription_)
+    return false;
+
+  auto traits = cover->get_traits();
+  CoverStateResponse resp{};
+  resp.key = cover->get_object_id_hash();
+  resp.legacy_state =
+      (cover->position == cover::COVER_OPEN) ? enums::LEGACY_COVER_STATE_OPEN : enums::LEGACY_COVER_STATE_CLOSED;
+  resp.position = cover->position;
+  if (traits.get_supports_tilt())
+    resp.tilt = cover->tilt;
+  resp.current_operation = static_cast<enums::CoverOperation>(cover->current_operation);
+  return this->send_cover_state_response(resp);
+}
+bool APIConnection::send_cover_info(cover::Cover *cover) {
+  auto traits = cover->get_traits();
+  ListEntitiesCoverResponse msg;
+  msg.key = cover->get_object_id_hash();
+  msg.object_id = cover->get_object_id();
+  if (cover->has_own_name())
+    msg.name = cover->get_name();
+  msg.unique_id = get_default_unique_id("cover", cover);
+  msg.assumed_state = traits.get_is_assumed_state();
+  msg.supports_position = traits.get_supports_position();
+  msg.supports_tilt = traits.get_supports_tilt();
+  msg.supports_stop = traits.get_supports_stop();
+  msg.device_class = cover->get_device_class();
+  msg.disabled_by_default = cover->is_disabled_by_default();
+  msg.icon = cover->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(cover->get_entity_category());
+  return this->send_list_entities_cover_response(msg);
+}
+void APIConnection::cover_command(const CoverCommandRequest &msg) {
+  cover::Cover *cover = App.get_cover_by_key(msg.key);
+  if (cover == nullptr)
+    return;
+
+  auto call = cover->make_call();
+  if (msg.has_legacy_command) {
+    switch (msg.legacy_command) {
+      case enums::LEGACY_COVER_COMMAND_OPEN:
+        call.set_command_open();
+        break;
+      case enums::LEGACY_COVER_COMMAND_CLOSE:
+        call.set_command_close();
+        break;
+      case enums::LEGACY_COVER_COMMAND_STOP:
+        call.set_command_stop();
+        break;
+    }
+  }
+  if (msg.has_position)
+    call.set_position(msg.position);
+  if (msg.has_tilt)
+    call.set_tilt(msg.tilt);
+  if (msg.stop)
+    call.set_command_stop();
+  call.perform();
+}
+#endif
+
+#ifdef USE_FAN
+bool APIConnection::send_fan_state(fan::Fan *fan) {
+  if (!this->state_subscription_)
+    return false;
+
+  auto traits = fan->get_traits();
+  FanStateResponse resp{};
+  resp.key = fan->get_object_id_hash();
+  resp.state = fan->state;
+  if (traits.supports_oscillation())
+    resp.oscillating = fan->oscillating;
+  if (traits.supports_speed()) {
+    resp.speed_level = fan->speed;
+  }
+  if (traits.supports_direction())
+    resp.direction = static_cast<enums::FanDirection>(fan->direction);
+  if (traits.supports_preset_modes())
+    resp.preset_mode = fan->preset_mode;
+  return this->send_fan_state_response(resp);
+}
+bool APIConnection::send_fan_info(fan::Fan *fan) {
+  auto traits = fan->get_traits();
+  ListEntitiesFanResponse msg;
+  msg.key = fan->get_object_id_hash();
+  msg.object_id = fan->get_object_id();
+  if (fan->has_own_name())
+    msg.name = fan->get_name();
+  msg.unique_id = get_default_unique_id("fan", fan);
+  msg.supports_oscillation = traits.supports_oscillation();
+  msg.supports_speed = traits.supports_speed();
+  msg.supports_direction = traits.supports_direction();
+  msg.supported_speed_count = traits.supported_speed_count();
+  for (auto const &preset : traits.supported_preset_modes())
+    msg.supported_preset_modes.push_back(preset);
+  msg.disabled_by_default = fan->is_disabled_by_default();
+  msg.icon = fan->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(fan->get_entity_category());
+  return this->send_list_entities_fan_response(msg);
+}
+void APIConnection::fan_command(const FanCommandRequest &msg) {
+  fan::Fan *fan = App.get_fan_by_key(msg.key);
+  if (fan == nullptr)
+    return;
+
+  auto call = fan->make_call();
+  if (msg.has_state)
+    call.set_state(msg.state);
+  if (msg.has_oscillating)
+    call.set_oscillating(msg.oscillating);
+  if (msg.has_speed_level) {
+    // Prefer level
+    call.set_speed(msg.speed_level);
+  }
+  if (msg.has_direction)
+    call.set_direction(static_cast<fan::FanDirection>(msg.direction));
+  if (msg.has_preset_mode)
+    call.set_preset_mode(msg.preset_mode);
+  call.perform();
+}
+#endif
+
+#ifdef USE_LIGHT
+bool APIConnection::send_light_state(light::LightState *light) {
+  if (!this->state_subscription_)
+    return false;
+
+  auto traits = light->get_traits();
+  auto values = light->remote_values;
+  auto color_mode = values.get_color_mode();
+  LightStateResponse resp{};
+
+  resp.key = light->get_object_id_hash();
+  resp.state = values.is_on();
+  resp.color_mode = static_cast<enums::ColorMode>(color_mode);
+  resp.brightness = values.get_brightness();
+  resp.color_brightness = values.get_color_brightness();
+  resp.red = values.get_red();
+  resp.green = values.get_green();
+  resp.blue = values.get_blue();
+  resp.white = values.get_white();
+  resp.color_temperature = values.get_color_temperature();
+  resp.cold_white = values.get_cold_white();
+  resp.warm_white = values.get_warm_white();
+  if (light->supports_effects())
+    resp.effect = light->get_effect_name();
+  return this->send_light_state_response(resp);
+}
+bool APIConnection::send_light_info(light::LightState *light) {
+  auto traits = light->get_traits();
+  ListEntitiesLightResponse msg;
+  msg.key = light->get_object_id_hash();
+  msg.object_id = light->get_object_id();
+  if (light->has_own_name())
+    msg.name = light->get_name();
+  msg.unique_id = get_default_unique_id("light", light);
+
+  msg.disabled_by_default = light->is_disabled_by_default();
+  msg.icon = light->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(light->get_entity_category());
+
+  for (auto mode : traits.get_supported_color_modes())
+    msg.supported_color_modes.push_back(static_cast<enums::ColorMode>(mode));
+
+  msg.legacy_supports_brightness = traits.supports_color_capability(light::ColorCapability::BRIGHTNESS);
+  msg.legacy_supports_rgb = traits.supports_color_capability(light::ColorCapability::RGB);
+  msg.legacy_supports_white_value =
+      msg.legacy_supports_rgb && (traits.supports_color_capability(light::ColorCapability::WHITE) ||
+                                  traits.supports_color_capability(light::ColorCapability::COLD_WARM_WHITE));
+  msg.legacy_supports_color_temperature = traits.supports_color_capability(light::ColorCapability::COLOR_TEMPERATURE) ||
+                                          traits.supports_color_capability(light::ColorCapability::COLD_WARM_WHITE);
+
+  if (msg.legacy_supports_color_temperature) {
+    msg.min_mireds = traits.get_min_mireds();
+    msg.max_mireds = traits.get_max_mireds();
+  }
+  if (light->supports_effects()) {
+    msg.effects.emplace_back("None");
+    for (auto *effect : light->get_effects())
+      msg.effects.push_back(effect->get_name());
+  }
+  return this->send_list_entities_light_response(msg);
+}
+void APIConnection::light_command(const LightCommandRequest &msg) {
+  light::LightState *light = App.get_light_by_key(msg.key);
+  if (light == nullptr)
+    return;
+
+  auto call = light->make_call();
+  if (msg.has_state)
+    call.set_state(msg.state);
+  if (msg.has_brightness)
+    call.set_brightness(msg.brightness);
+  if (msg.has_color_mode)
+    call.set_color_mode(static_cast<light::ColorMode>(msg.color_mode));
+  if (msg.has_color_brightness)
+    call.set_color_brightness(msg.color_brightness);
+  if (msg.has_rgb) {
+    call.set_red(msg.red);
+    call.set_green(msg.green);
+    call.set_blue(msg.blue);
+  }
+  if (msg.has_white)
+    call.set_white(msg.white);
+  if (msg.has_color_temperature)
+    call.set_color_temperature(msg.color_temperature);
+  if (msg.has_cold_white)
+    call.set_cold_white(msg.cold_white);
+  if (msg.has_warm_white)
+    call.set_warm_white(msg.warm_white);
+  if (msg.has_transition_length)
+    call.set_transition_length(msg.transition_length);
+  if (msg.has_flash_length)
+    call.set_flash_length(msg.flash_length);
+  if (msg.has_effect)
+    call.set_effect(msg.effect);
+  call.perform();
+}
+#endif
+
+#ifdef USE_SENSOR
+bool APIConnection::send_sensor_state(sensor::Sensor *sensor, float state) {
+  if (!this->state_subscription_)
+    return false;
+
+  SensorStateResponse resp{};
+  resp.key = sensor->get_object_id_hash();
+  resp.state = state;
+  resp.missing_state = !sensor->has_state();
+  return this->send_sensor_state_response(resp);
+}
+bool APIConnection::send_sensor_info(sensor::Sensor *sensor) {
+  ListEntitiesSensorResponse msg;
+  msg.key = sensor->get_object_id_hash();
+  msg.object_id = sensor->get_object_id();
+  if (sensor->has_own_name())
+    msg.name = sensor->get_name();
+  msg.unique_id = sensor->unique_id();
+  if (msg.unique_id.empty())
+    msg.unique_id = get_default_unique_id("sensor", sensor);
+  msg.icon = sensor->get_icon();
+  msg.unit_of_measurement = sensor->get_unit_of_measurement();
+  msg.accuracy_decimals = sensor->get_accuracy_decimals();
+  msg.force_update = sensor->get_force_update();
+  msg.device_class = sensor->get_device_class();
+  msg.state_class = static_cast<enums::SensorStateClass>(sensor->get_state_class());
+  msg.disabled_by_default = sensor->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(sensor->get_entity_category());
+  return this->send_list_entities_sensor_response(msg);
+}
+#endif
+
+#ifdef USE_SWITCH
+bool APIConnection::send_switch_state(switch_::Switch *a_switch, bool state) {
+  if (!this->state_subscription_)
+    return false;
+
+  SwitchStateResponse resp{};
+  resp.key = a_switch->get_object_id_hash();
+  resp.state = state;
+  return this->send_switch_state_response(resp);
+}
+bool APIConnection::send_switch_info(switch_::Switch *a_switch) {
+  ListEntitiesSwitchResponse msg;
+  msg.key = a_switch->get_object_id_hash();
+  msg.object_id = a_switch->get_object_id();
+  if (a_switch->has_own_name())
+    msg.name = a_switch->get_name();
+  msg.unique_id = get_default_unique_id("switch", a_switch);
+  msg.icon = a_switch->get_icon();
+  msg.assumed_state = a_switch->assumed_state();
+  msg.disabled_by_default = a_switch->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(a_switch->get_entity_category());
+  msg.device_class = a_switch->get_device_class();
+  return this->send_list_entities_switch_response(msg);
+}
+void APIConnection::switch_command(const SwitchCommandRequest &msg) {
+  switch_::Switch *a_switch = App.get_switch_by_key(msg.key);
+  if (a_switch == nullptr)
+    return;
+
+  if (msg.state) {
+    a_switch->turn_on();
+  } else {
+    a_switch->turn_off();
+  }
+}
+#endif
+
+#ifdef USE_TEXT_SENSOR
+bool APIConnection::send_text_sensor_state(text_sensor::TextSensor *text_sensor, std::string state) {
+  if (!this->state_subscription_)
+    return false;
+
+  TextSensorStateResponse resp{};
+  resp.key = text_sensor->get_object_id_hash();
+  resp.state = std::move(state);
+  resp.missing_state = !text_sensor->has_state();
+  return this->send_text_sensor_state_response(resp);
+}
+bool APIConnection::send_text_sensor_info(text_sensor::TextSensor *text_sensor) {
+  ListEntitiesTextSensorResponse msg;
+  msg.key = text_sensor->get_object_id_hash();
+  msg.object_id = text_sensor->get_object_id();
+  msg.name = text_sensor->get_name();
+  msg.unique_id = text_sensor->unique_id();
+  if (msg.unique_id.empty())
+    msg.unique_id = get_default_unique_id("text_sensor", text_sensor);
+  msg.icon = text_sensor->get_icon();
+  msg.disabled_by_default = text_sensor->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(text_sensor->get_entity_category());
+  msg.device_class = text_sensor->get_device_class();
+  return this->send_list_entities_text_sensor_response(msg);
+}
+#endif
+
+#ifdef USE_CLIMATE
+bool APIConnection::send_climate_state(climate::Climate *climate) {
+  if (!this->state_subscription_)
+    return false;
+
+  auto traits = climate->get_traits();
+  ClimateStateResponse resp{};
+  resp.key = climate->get_object_id_hash();
+  resp.mode = static_cast<enums::ClimateMode>(climate->mode);
+  resp.action = static_cast<enums::ClimateAction>(climate->action);
+  if (traits.get_supports_current_temperature())
+    resp.current_temperature = climate->current_temperature;
+  if (traits.get_supports_two_point_target_temperature()) {
+    resp.target_temperature_low = climate->target_temperature_low;
+    resp.target_temperature_high = climate->target_temperature_high;
+  } else {
+    resp.target_temperature = climate->target_temperature;
+  }
+  if (traits.get_supports_fan_modes() && climate->fan_mode.has_value())
+    resp.fan_mode = static_cast<enums::ClimateFanMode>(climate->fan_mode.value());
+  if (!traits.get_supported_custom_fan_modes().empty() && climate->custom_fan_mode.has_value())
+    resp.custom_fan_mode = climate->custom_fan_mode.value();
+  if (traits.get_supports_presets() && climate->preset.has_value()) {
+    resp.preset = static_cast<enums::ClimatePreset>(climate->preset.value());
+  }
+  if (!traits.get_supported_custom_presets().empty() && climate->custom_preset.has_value())
+    resp.custom_preset = climate->custom_preset.value();
+  if (traits.get_supports_swing_modes())
+    resp.swing_mode = static_cast<enums::ClimateSwingMode>(climate->swing_mode);
+  if (traits.get_supports_current_humidity())
+    resp.current_humidity = climate->current_humidity;
+  if (traits.get_supports_target_humidity())
+    resp.target_humidity = climate->target_humidity;
+  return this->send_climate_state_response(resp);
+}
+bool APIConnection::send_climate_info(climate::Climate *climate) {
+  auto traits = climate->get_traits();
+  ListEntitiesClimateResponse msg;
+  msg.key = climate->get_object_id_hash();
+  msg.object_id = climate->get_object_id();
+  if (climate->has_own_name())
+    msg.name = climate->get_name();
+  msg.unique_id = get_default_unique_id("climate", climate);
+
+  msg.disabled_by_default = climate->is_disabled_by_default();
+  msg.icon = climate->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(climate->get_entity_category());
+
+  msg.supports_current_temperature = traits.get_supports_current_temperature();
+  msg.supports_current_humidity = traits.get_supports_current_humidity();
+  msg.supports_two_point_target_temperature = traits.get_supports_two_point_target_temperature();
+  msg.supports_target_humidity = traits.get_supports_target_humidity();
+
+  for (auto mode : traits.get_supported_modes())
+    msg.supported_modes.push_back(static_cast<enums::ClimateMode>(mode));
+
+  msg.visual_min_temperature = traits.get_visual_min_temperature();
+  msg.visual_max_temperature = traits.get_visual_max_temperature();
+  msg.visual_target_temperature_step = traits.get_visual_target_temperature_step();
+  msg.visual_current_temperature_step = traits.get_visual_current_temperature_step();
+  msg.visual_min_humidity = traits.get_visual_min_humidity();
+  msg.visual_max_humidity = traits.get_visual_max_humidity();
+
+  msg.legacy_supports_away = traits.supports_preset(climate::CLIMATE_PRESET_AWAY);
+  msg.supports_action = traits.get_supports_action();
+
+  for (auto fan_mode : traits.get_supported_fan_modes())
+    msg.supported_fan_modes.push_back(static_cast<enums::ClimateFanMode>(fan_mode));
+  for (auto const &custom_fan_mode : traits.get_supported_custom_fan_modes())
+    msg.supported_custom_fan_modes.push_back(custom_fan_mode);
+  for (auto preset : traits.get_supported_presets())
+    msg.supported_presets.push_back(static_cast<enums::ClimatePreset>(preset));
+  for (auto const &custom_preset : traits.get_supported_custom_presets())
+    msg.supported_custom_presets.push_back(custom_preset);
+  for (auto swing_mode : traits.get_supported_swing_modes())
+    msg.supported_swing_modes.push_back(static_cast<enums::ClimateSwingMode>(swing_mode));
+  return this->send_list_entities_climate_response(msg);
+}
+void APIConnection::climate_command(const ClimateCommandRequest &msg) {
+  climate::Climate *climate = App.get_climate_by_key(msg.key);
+  if (climate == nullptr)
+    return;
+
+  auto call = climate->make_call();
+  if (msg.has_mode)
+    call.set_mode(static_cast<climate::ClimateMode>(msg.mode));
+  if (msg.has_target_temperature)
+    call.set_target_temperature(msg.target_temperature);
+  if (msg.has_target_temperature_low)
+    call.set_target_temperature_low(msg.target_temperature_low);
+  if (msg.has_target_temperature_high)
+    call.set_target_temperature_high(msg.target_temperature_high);
+  if (msg.has_target_humidity)
+    call.set_target_humidity(msg.target_humidity);
+  if (msg.has_fan_mode)
+    call.set_fan_mode(static_cast<climate::ClimateFanMode>(msg.fan_mode));
+  if (msg.has_custom_fan_mode)
+    call.set_fan_mode(msg.custom_fan_mode);
+  if (msg.has_preset)
+    call.set_preset(static_cast<climate::ClimatePreset>(msg.preset));
+  if (msg.has_custom_preset)
+    call.set_preset(msg.custom_preset);
+  if (msg.has_swing_mode)
+    call.set_swing_mode(static_cast<climate::ClimateSwingMode>(msg.swing_mode));
+  call.perform();
+}
+#endif
+
+#ifdef USE_NUMBER
+bool APIConnection::send_number_state(number::Number *number, float state) {
+  if (!this->state_subscription_)
+    return false;
+
+  NumberStateResponse resp{};
+  resp.key = number->get_object_id_hash();
+  resp.state = state;
+  resp.missing_state = !number->has_state();
+  return this->send_number_state_response(resp);
+}
+bool APIConnection::send_number_info(number::Number *number) {
+  ListEntitiesNumberResponse msg;
+  msg.key = number->get_object_id_hash();
+  msg.object_id = number->get_object_id();
+  if (number->has_own_name())
+    msg.name = number->get_name();
+  msg.unique_id = get_default_unique_id("number", number);
+  msg.icon = number->get_icon();
+  msg.disabled_by_default = number->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(number->get_entity_category());
+  msg.unit_of_measurement = number->traits.get_unit_of_measurement();
+  msg.mode = static_cast<enums::NumberMode>(number->traits.get_mode());
+  msg.device_class = number->traits.get_device_class();
+
+  msg.min_value = number->traits.get_min_value();
+  msg.max_value = number->traits.get_max_value();
+  msg.step = number->traits.get_step();
+
+  return this->send_list_entities_number_response(msg);
+}
+void APIConnection::number_command(const NumberCommandRequest &msg) {
+  number::Number *number = App.get_number_by_key(msg.key);
+  if (number == nullptr)
+    return;
+
+  auto call = number->make_call();
+  call.set_value(msg.state);
+  call.perform();
+}
+#endif
+
+#ifdef USE_DATETIME_DATE
+bool APIConnection::send_date_state(datetime::DateEntity *date) {
+  if (!this->state_subscription_)
+    return false;
+
+  DateStateResponse resp{};
+  resp.key = date->get_object_id_hash();
+  resp.missing_state = !date->has_state();
+  resp.year = date->year;
+  resp.month = date->month;
+  resp.day = date->day;
+  return this->send_date_state_response(resp);
+}
+bool APIConnection::send_date_info(datetime::DateEntity *date) {
+  ListEntitiesDateResponse msg;
+  msg.key = date->get_object_id_hash();
+  msg.object_id = date->get_object_id();
+  if (date->has_own_name())
+    msg.name = date->get_name();
+  msg.unique_id = get_default_unique_id("date", date);
+  msg.icon = date->get_icon();
+  msg.disabled_by_default = date->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(date->get_entity_category());
+
+  return this->send_list_entities_date_response(msg);
+}
+void APIConnection::date_command(const DateCommandRequest &msg) {
+  datetime::DateEntity *date = App.get_date_by_key(msg.key);
+  if (date == nullptr)
+    return;
+
+  auto call = date->make_call();
+  call.set_date(msg.year, msg.month, msg.day);
+  call.perform();
+}
+#endif
+
+#ifdef USE_DATETIME_TIME
+bool APIConnection::send_time_state(datetime::TimeEntity *time) {
+  if (!this->state_subscription_)
+    return false;
+
+  TimeStateResponse resp{};
+  resp.key = time->get_object_id_hash();
+  resp.missing_state = !time->has_state();
+  resp.hour = time->hour;
+  resp.minute = time->minute;
+  resp.second = time->second;
+  return this->send_time_state_response(resp);
+}
+bool APIConnection::send_time_info(datetime::TimeEntity *time) {
+  ListEntitiesTimeResponse msg;
+  msg.key = time->get_object_id_hash();
+  msg.object_id = time->get_object_id();
+  if (time->has_own_name())
+    msg.name = time->get_name();
+  msg.unique_id = get_default_unique_id("time", time);
+  msg.icon = time->get_icon();
+  msg.disabled_by_default = time->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(time->get_entity_category());
+
+  return this->send_list_entities_time_response(msg);
+}
+void APIConnection::time_command(const TimeCommandRequest &msg) {
+  datetime::TimeEntity *time = App.get_time_by_key(msg.key);
+  if (time == nullptr)
+    return;
+
+  auto call = time->make_call();
+  call.set_time(msg.hour, msg.minute, msg.second);
+  call.perform();
+}
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+bool APIConnection::send_datetime_state(datetime::DateTimeEntity *datetime) {
+  if (!this->state_subscription_)
+    return false;
+
+  DateTimeStateResponse resp{};
+  resp.key = datetime->get_object_id_hash();
+  resp.missing_state = !datetime->has_state();
+  if (datetime->has_state()) {
+    ESPTime state = datetime->state_as_esptime();
+    resp.epoch_seconds = state.timestamp;
+  }
+  return this->send_date_time_state_response(resp);
+}
+bool APIConnection::send_datetime_info(datetime::DateTimeEntity *datetime) {
+  ListEntitiesDateTimeResponse msg;
+  msg.key = datetime->get_object_id_hash();
+  msg.object_id = datetime->get_object_id();
+  if (datetime->has_own_name())
+    msg.name = datetime->get_name();
+  msg.unique_id = get_default_unique_id("datetime", datetime);
+  msg.icon = datetime->get_icon();
+  msg.disabled_by_default = datetime->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(datetime->get_entity_category());
+
+  return this->send_list_entities_date_time_response(msg);
+}
+void APIConnection::datetime_command(const DateTimeCommandRequest &msg) {
+  datetime::DateTimeEntity *datetime = App.get_datetime_by_key(msg.key);
+  if (datetime == nullptr)
+    return;
+
+  auto call = datetime->make_call();
+  call.set_datetime(msg.epoch_seconds);
+  call.perform();
+}
+#endif
+
+#ifdef USE_TEXT
+bool APIConnection::send_text_state(text::Text *text, std::string state) {
+  if (!this->state_subscription_)
+    return false;
+
+  TextStateResponse resp{};
+  resp.key = text->get_object_id_hash();
+  resp.state = std::move(state);
+  resp.missing_state = !text->has_state();
+  return this->send_text_state_response(resp);
+}
+bool APIConnection::send_text_info(text::Text *text) {
+  ListEntitiesTextResponse msg;
+  msg.key = text->get_object_id_hash();
+  msg.object_id = text->get_object_id();
+  msg.name = text->get_name();
+  msg.icon = text->get_icon();
+  msg.disabled_by_default = text->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(text->get_entity_category());
+  msg.mode = static_cast<enums::TextMode>(text->traits.get_mode());
+
+  msg.min_length = text->traits.get_min_length();
+  msg.max_length = text->traits.get_max_length();
+  msg.pattern = text->traits.get_pattern();
+
+  return this->send_list_entities_text_response(msg);
+}
+void APIConnection::text_command(const TextCommandRequest &msg) {
+  text::Text *text = App.get_text_by_key(msg.key);
+  if (text == nullptr)
+    return;
+
+  auto call = text->make_call();
+  call.set_value(msg.state);
+  call.perform();
+}
+#endif
+
+#ifdef USE_SELECT
+bool APIConnection::send_select_state(select::Select *select, std::string state) {
+  if (!this->state_subscription_)
+    return false;
+
+  SelectStateResponse resp{};
+  resp.key = select->get_object_id_hash();
+  resp.state = std::move(state);
+  resp.missing_state = !select->has_state();
+  return this->send_select_state_response(resp);
+}
+bool APIConnection::send_select_info(select::Select *select) {
+  ListEntitiesSelectResponse msg;
+  msg.key = select->get_object_id_hash();
+  msg.object_id = select->get_object_id();
+  if (select->has_own_name())
+    msg.name = select->get_name();
+  msg.unique_id = get_default_unique_id("select", select);
+  msg.icon = select->get_icon();
+  msg.disabled_by_default = select->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(select->get_entity_category());
+
+  for (const auto &option : select->traits.get_options())
+    msg.options.push_back(option);
+
+  return this->send_list_entities_select_response(msg);
+}
+void APIConnection::select_command(const SelectCommandRequest &msg) {
+  select::Select *select = App.get_select_by_key(msg.key);
+  if (select == nullptr)
+    return;
+
+  auto call = select->make_call();
+  call.set_option(msg.state);
+  call.perform();
+}
+#endif
+
+#ifdef USE_BUTTON
+bool APIConnection::send_button_info(button::Button *button) {
+  ListEntitiesButtonResponse msg;
+  msg.key = button->get_object_id_hash();
+  msg.object_id = button->get_object_id();
+  if (button->has_own_name())
+    msg.name = button->get_name();
+  msg.unique_id = get_default_unique_id("button", button);
+  msg.icon = button->get_icon();
+  msg.disabled_by_default = button->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(button->get_entity_category());
+  msg.device_class = button->get_device_class();
+  return this->send_list_entities_button_response(msg);
+}
+void APIConnection::button_command(const ButtonCommandRequest &msg) {
+  button::Button *button = App.get_button_by_key(msg.key);
+  if (button == nullptr)
+    return;
+
+  button->press();
+}
+#endif
+
+#ifdef USE_LOCK
+bool APIConnection::send_lock_state(lock::Lock *a_lock, lock::LockState state) {
+  if (!this->state_subscription_)
+    return false;
+
+  LockStateResponse resp{};
+  resp.key = a_lock->get_object_id_hash();
+  resp.state = static_cast<enums::LockState>(state);
+  return this->send_lock_state_response(resp);
+}
+bool APIConnection::send_lock_info(lock::Lock *a_lock) {
+  ListEntitiesLockResponse msg;
+  msg.key = a_lock->get_object_id_hash();
+  msg.object_id = a_lock->get_object_id();
+  if (a_lock->has_own_name())
+    msg.name = a_lock->get_name();
+  msg.unique_id = get_default_unique_id("lock", a_lock);
+  msg.icon = a_lock->get_icon();
+  msg.assumed_state = a_lock->traits.get_assumed_state();
+  msg.disabled_by_default = a_lock->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(a_lock->get_entity_category());
+  msg.supports_open = a_lock->traits.get_supports_open();
+  msg.requires_code = a_lock->traits.get_requires_code();
+  return this->send_list_entities_lock_response(msg);
+}
+void APIConnection::lock_command(const LockCommandRequest &msg) {
+  lock::Lock *a_lock = App.get_lock_by_key(msg.key);
+  if (a_lock == nullptr)
+    return;
+
+  switch (msg.command) {
+    case enums::LOCK_UNLOCK:
+      a_lock->unlock();
+      break;
+    case enums::LOCK_LOCK:
+      a_lock->lock();
+      break;
+    case enums::LOCK_OPEN:
+      a_lock->open();
+      break;
+  }
+}
+#endif
+
+#ifdef USE_VALVE
+bool APIConnection::send_valve_state(valve::Valve *valve) {
+  if (!this->state_subscription_)
+    return false;
+
+  ValveStateResponse resp{};
+  resp.key = valve->get_object_id_hash();
+  resp.position = valve->position;
+  resp.current_operation = static_cast<enums::ValveOperation>(valve->current_operation);
+  return this->send_valve_state_response(resp);
+}
+bool APIConnection::send_valve_info(valve::Valve *valve) {
+  auto traits = valve->get_traits();
+  ListEntitiesValveResponse msg;
+  msg.key = valve->get_object_id_hash();
+  msg.object_id = valve->get_object_id();
+  if (valve->has_own_name())
+    msg.name = valve->get_name();
+  msg.unique_id = get_default_unique_id("valve", valve);
+  msg.icon = valve->get_icon();
+  msg.disabled_by_default = valve->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(valve->get_entity_category());
+  msg.device_class = valve->get_device_class();
+  msg.assumed_state = traits.get_is_assumed_state();
+  msg.supports_position = traits.get_supports_position();
+  msg.supports_stop = traits.get_supports_stop();
+  return this->send_list_entities_valve_response(msg);
+}
+void APIConnection::valve_command(const ValveCommandRequest &msg) {
+  valve::Valve *valve = App.get_valve_by_key(msg.key);
+  if (valve == nullptr)
+    return;
+
+  auto call = valve->make_call();
+  if (msg.has_position)
+    call.set_position(msg.position);
+  if (msg.stop)
+    call.set_command_stop();
+  call.perform();
+}
+#endif
+
+#ifdef USE_MEDIA_PLAYER
+bool APIConnection::send_media_player_state(media_player::MediaPlayer *media_player) {
+  if (!this->state_subscription_)
+    return false;
+
+  MediaPlayerStateResponse resp{};
+  resp.key = media_player->get_object_id_hash();
+
+  media_player::MediaPlayerState report_state = media_player->state == media_player::MEDIA_PLAYER_STATE_ANNOUNCING
+                                                    ? media_player::MEDIA_PLAYER_STATE_PLAYING
+                                                    : media_player->state;
+  resp.state = static_cast<enums::MediaPlayerState>(report_state);
+  resp.volume = media_player->volume;
+  resp.muted = media_player->is_muted();
+  return this->send_media_player_state_response(resp);
+}
+bool APIConnection::send_media_player_info(media_player::MediaPlayer *media_player) {
+  ListEntitiesMediaPlayerResponse msg;
+  msg.key = media_player->get_object_id_hash();
+  msg.object_id = media_player->get_object_id();
+  if (media_player->has_own_name())
+    msg.name = media_player->get_name();
+  msg.unique_id = get_default_unique_id("media_player", media_player);
+  msg.icon = media_player->get_icon();
+  msg.disabled_by_default = media_player->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(media_player->get_entity_category());
+
+  auto traits = media_player->get_traits();
+  msg.supports_pause = traits.get_supports_pause();
+
+  for (auto& supported_format : traits.get_supported_formats()) {
+    MediaPlayerSupportedFormat media_format;
+    media_format.format = supported_format.format;
+    media_format.sample_rate = supported_format.sample_rate;
+    media_format.num_channels = supported_format.num_channels;
+    msg.supported_formats.push_back(media_format);
+  }
+
+  return this->send_list_entities_media_player_response(msg);
+}
+void APIConnection::media_player_command(const MediaPlayerCommandRequest &msg) {
+  media_player::MediaPlayer *media_player = App.get_media_player_by_key(msg.key);
+  if (media_player == nullptr)
+    return;
+
+  auto call = media_player->make_call();
+  if (msg.has_command) {
+    call.set_command(static_cast<media_player::MediaPlayerCommand>(msg.command));
+  }
+  if (msg.has_volume) {
+    call.set_volume(msg.volume);
+  }
+  if (msg.has_media_url) {
+    call.set_media_url(msg.media_url);
+  }
+  if (msg.has_announcement) {
+    call.set_announcement(msg.announcement);
+  }
+  call.perform();
+}
+#endif
+
+#ifdef USE_ESP32_CAMERA
+void APIConnection::send_camera_state(std::shared_ptr<esp32_camera::CameraImage> image) {
+  if (!this->state_subscription_)
+    return;
+  if (this->image_reader_.available())
+    return;
+  if (image->was_requested_by(esphome::esp32_camera::API_REQUESTER) ||
+      image->was_requested_by(esphome::esp32_camera::IDLE))
+    this->image_reader_.set_image(std::move(image));
+}
+bool APIConnection::send_camera_info(esp32_camera::ESP32Camera *camera) {
+  ListEntitiesCameraResponse msg;
+  msg.key = camera->get_object_id_hash();
+  msg.object_id = camera->get_object_id();
+  if (camera->has_own_name())
+    msg.name = camera->get_name();
+  msg.unique_id = get_default_unique_id("camera", camera);
+  msg.disabled_by_default = camera->is_disabled_by_default();
+  msg.icon = camera->get_icon();
+  msg.entity_category = static_cast<enums::EntityCategory>(camera->get_entity_category());
+  return this->send_list_entities_camera_response(msg);
+}
+void APIConnection::camera_image(const CameraImageRequest &msg) {
+  if (esp32_camera::global_esp32_camera == nullptr)
+    return;
+
+  if (msg.single)
+    esp32_camera::global_esp32_camera->request_image(esphome::esp32_camera::API_REQUESTER);
+  if (msg.stream) {
+    esp32_camera::global_esp32_camera->start_stream(esphome::esp32_camera::API_REQUESTER);
+
+    App.scheduler.set_timeout(this->parent_, "api_esp32_camera_stop_stream", ESP32_CAMERA_STOP_STREAM, []() {
+      esp32_camera::global_esp32_camera->stop_stream(esphome::esp32_camera::API_REQUESTER);
+    });
+  }
+}
+#endif
+
+#ifdef USE_HOMEASSISTANT_TIME
+void APIConnection::on_get_time_response(const GetTimeResponse &value) {
+  if (homeassistant::global_homeassistant_time != nullptr)
+    homeassistant::global_homeassistant_time->set_epoch_time(value.epoch_seconds);
+}
+#endif
+
+#ifdef USE_BLUETOOTH_PROXY
+void APIConnection::subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->subscribe_api_connection(this, msg.flags);
+}
+void APIConnection::unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->unsubscribe_api_connection(this);
+}
+bool APIConnection::send_bluetooth_le_advertisement(const BluetoothLEAdvertisementResponse &msg) {
+  if (this->client_api_version_major_ < 1 || this->client_api_version_minor_ < 7) {
+    BluetoothLEAdvertisementResponse resp = msg;
+    for (auto &service : resp.service_data) {
+      service.legacy_data.assign(service.data.begin(), service.data.end());
+      service.data.clear();
+    }
+    for (auto &manufacturer_data : resp.manufacturer_data) {
+      manufacturer_data.legacy_data.assign(manufacturer_data.data.begin(), manufacturer_data.data.end());
+      manufacturer_data.data.clear();
+    }
+    return this->send_bluetooth_le_advertisement_response(resp);
+  }
+  return this->send_bluetooth_le_advertisement_response(msg);
+}
+void APIConnection::bluetooth_device_request(const BluetoothDeviceRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_device_request(msg);
+}
+void APIConnection::bluetooth_gatt_read(const BluetoothGATTReadRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_read(msg);
+}
+void APIConnection::bluetooth_gatt_write(const BluetoothGATTWriteRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_write(msg);
+}
+void APIConnection::bluetooth_gatt_read_descriptor(const BluetoothGATTReadDescriptorRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_read_descriptor(msg);
+}
+void APIConnection::bluetooth_gatt_write_descriptor(const BluetoothGATTWriteDescriptorRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_write_descriptor(msg);
+}
+void APIConnection::bluetooth_gatt_get_services(const BluetoothGATTGetServicesRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_send_services(msg);
+}
+
+void APIConnection::bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) {
+  bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_notify(msg);
+}
+
+BluetoothConnectionsFreeResponse APIConnection::subscribe_bluetooth_connections_free(
+    const SubscribeBluetoothConnectionsFreeRequest &msg) {
+  BluetoothConnectionsFreeResponse resp;
+  resp.free = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_connections_free();
+  resp.limit = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_connections_limit();
+  return resp;
+}
+#endif
+
+#ifdef USE_VOICE_ASSISTANT
+void APIConnection::subscribe_voice_assistant(const SubscribeVoiceAssistantRequest &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    voice_assistant::global_voice_assistant->client_subscription(this, msg.subscribe);
+  }
+}
+void APIConnection::on_voice_assistant_response(const VoiceAssistantResponse &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
+      return;
+    }
+
+    if (msg.error) {
+      voice_assistant::global_voice_assistant->failed_to_start();
+      return;
+    }
+    if (msg.port == 0) {
+      // Use API Audio
+      voice_assistant::global_voice_assistant->start_streaming();
+    } else {
+      struct sockaddr_storage storage;
+      socklen_t len = sizeof(storage);
+      this->helper_->getpeername((struct sockaddr *) &storage, &len);
+      voice_assistant::global_voice_assistant->start_streaming(&storage, msg.port);
+    }
+  }
+};
+void APIConnection::on_voice_assistant_event_response(const VoiceAssistantEventResponse &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
+      return;
+    }
+
+    voice_assistant::global_voice_assistant->on_event(msg);
+  }
+}
+void APIConnection::on_voice_assistant_audio(const VoiceAssistantAudio &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
+      return;
+    }
+
+    voice_assistant::global_voice_assistant->on_audio(msg);
+  }
+};
+void APIConnection::on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
+      return;
+    }
+
+    voice_assistant::global_voice_assistant->on_timer_event(msg);
+  }
+};
+
+#endif
+
+#ifdef USE_ALARM_CONTROL_PANEL
+bool APIConnection::send_alarm_control_panel_state(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
+  if (!this->state_subscription_)
+    return false;
+
+  AlarmControlPanelStateResponse resp{};
+  resp.key = a_alarm_control_panel->get_object_id_hash();
+  resp.state = static_cast<enums::AlarmControlPanelState>(a_alarm_control_panel->get_state());
+  return this->send_alarm_control_panel_state_response(resp);
+}
+bool APIConnection::send_alarm_control_panel_info(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
+  ListEntitiesAlarmControlPanelResponse msg;
+  msg.key = a_alarm_control_panel->get_object_id_hash();
+  msg.object_id = a_alarm_control_panel->get_object_id();
+  msg.name = a_alarm_control_panel->get_name();
+  msg.unique_id = get_default_unique_id("alarm_control_panel", a_alarm_control_panel);
+  msg.icon = a_alarm_control_panel->get_icon();
+  msg.disabled_by_default = a_alarm_control_panel->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(a_alarm_control_panel->get_entity_category());
+  msg.supported_features = a_alarm_control_panel->get_supported_features();
+  msg.requires_code = a_alarm_control_panel->get_requires_code();
+  msg.requires_code_to_arm = a_alarm_control_panel->get_requires_code_to_arm();
+  return this->send_list_entities_alarm_control_panel_response(msg);
+}
+void APIConnection::alarm_control_panel_command(const AlarmControlPanelCommandRequest &msg) {
+  alarm_control_panel::AlarmControlPanel *a_alarm_control_panel = App.get_alarm_control_panel_by_key(msg.key);
+  if (a_alarm_control_panel == nullptr)
+    return;
+
+  auto call = a_alarm_control_panel->make_call();
+  switch (msg.command) {
+    case enums::ALARM_CONTROL_PANEL_DISARM:
+      call.disarm();
+      break;
+    case enums::ALARM_CONTROL_PANEL_ARM_AWAY:
+      call.arm_away();
+      break;
+    case enums::ALARM_CONTROL_PANEL_ARM_HOME:
+      call.arm_home();
+      break;
+    case enums::ALARM_CONTROL_PANEL_ARM_NIGHT:
+      call.arm_night();
+      break;
+    case enums::ALARM_CONTROL_PANEL_ARM_VACATION:
+      call.arm_vacation();
+      break;
+    case enums::ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS:
+      call.arm_custom_bypass();
+      break;
+    case enums::ALARM_CONTROL_PANEL_TRIGGER:
+      call.pending();
+      break;
+  }
+  call.set_code(msg.code);
+  call.perform();
+}
+#endif
+
+#ifdef USE_EVENT
+bool APIConnection::send_event(event::Event *event, std::string event_type) {
+  EventResponse resp{};
+  resp.key = event->get_object_id_hash();
+  resp.event_type = std::move(event_type);
+  return this->send_event_response(resp);
+}
+bool APIConnection::send_event_info(event::Event *event) {
+  ListEntitiesEventResponse msg;
+  msg.key = event->get_object_id_hash();
+  msg.object_id = event->get_object_id();
+  if (event->has_own_name())
+    msg.name = event->get_name();
+  msg.unique_id = get_default_unique_id("event", event);
+  msg.icon = event->get_icon();
+  msg.disabled_by_default = event->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(event->get_entity_category());
+  msg.device_class = event->get_device_class();
+  for (const auto &event_type : event->get_event_types())
+    msg.event_types.push_back(event_type);
+  return this->send_list_entities_event_response(msg);
+}
+#endif
+
+#ifdef USE_UPDATE
+bool APIConnection::send_update_state(update::UpdateEntity *update) {
+  if (!this->state_subscription_)
+    return false;
+
+  UpdateStateResponse resp{};
+  resp.key = update->get_object_id_hash();
+  resp.missing_state = !update->has_state();
+  if (update->has_state()) {
+    resp.in_progress = update->state == update::UpdateState::UPDATE_STATE_INSTALLING;
+    if (update->update_info.has_progress) {
+      resp.has_progress = true;
+      resp.progress = update->update_info.progress;
+    }
+    resp.current_version = update->update_info.current_version;
+    resp.latest_version = update->update_info.latest_version;
+    resp.title = update->update_info.title;
+    resp.release_summary = update->update_info.summary;
+    resp.release_url = update->update_info.release_url;
+  }
+
+  return this->send_update_state_response(resp);
+}
+bool APIConnection::send_update_info(update::UpdateEntity *update) {
+  ListEntitiesUpdateResponse msg;
+  msg.key = update->get_object_id_hash();
+  msg.object_id = update->get_object_id();
+  if (update->has_own_name())
+    msg.name = update->get_name();
+  msg.unique_id = get_default_unique_id("update", update);
+  msg.icon = update->get_icon();
+  msg.disabled_by_default = update->is_disabled_by_default();
+  msg.entity_category = static_cast<enums::EntityCategory>(update->get_entity_category());
+  msg.device_class = update->get_device_class();
+  return this->send_list_entities_update_response(msg);
+}
+void APIConnection::update_command(const UpdateCommandRequest &msg) {
+  update::UpdateEntity *update = App.get_update_by_key(msg.key);
+  if (update == nullptr)
+    return;
+
+  switch (msg.command) {
+    case enums::UPDATE_COMMAND_UPDATE:
+      update->perform();
+      break;
+    case enums::UPDATE_COMMAND_CHECK:
+      update->check();
+      break;
+    case enums::UPDATE_COMMAND_NONE:
+      ESP_LOGE(TAG, "UPDATE_COMMAND_NONE not handled. Check client is sending the correct command");
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown update command: %" PRIu32, msg.command);
+      break;
+  }
+}
+#endif
+
+bool APIConnection::send_log_message(int level, const char *tag, const char *line) {
+  if (this->log_subscription_ < level)
+    return false;
+
+  // Send raw so that we don't copy too much
+  auto buffer = this->create_buffer();
+  // LogLevel level = 1;
+  buffer.encode_uint32(1, static_cast<uint32_t>(level));
+  // string message = 3;
+  buffer.encode_string(3, line, strlen(line));
+  // SubscribeLogsResponse - 29
+  return this->send_buffer(buffer, 29);
+}
+
+HelloResponse APIConnection::hello(const HelloRequest &msg) {
+  this->client_info_ = msg.client_info;
+  this->client_peername_ = this->helper_->getpeername();
+  this->client_combined_info_ = this->client_info_ + " (" + this->client_peername_ + ")";
+  this->helper_->set_log_info(this->client_combined_info_);
+  this->client_api_version_major_ = msg.api_version_major;
+  this->client_api_version_minor_ = msg.api_version_minor;
+  ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %" PRIu32 ".%" PRIu32, this->client_info_.c_str(),
+           this->client_peername_.c_str(), this->client_api_version_major_, this->client_api_version_minor_);
+
+  HelloResponse resp;
+  resp.api_version_major = 1;
+  resp.api_version_minor = 10;
+  resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
+  resp.name = App.get_name();
+
+  this->connection_state_ = ConnectionState::CONNECTED;
+  return resp;
+}
+ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
+  bool correct = this->parent_->check_password(msg.password);
+
+  ConnectResponse resp;
+  // bool invalid_password = 1;
+  resp.invalid_password = !correct;
+  if (correct) {
+    ESP_LOGD(TAG, "%s: Connected successfully", this->client_combined_info_.c_str());
+    this->connection_state_ = ConnectionState::AUTHENTICATED;
+    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+#ifdef USE_HOMEASSISTANT_TIME
+    if (homeassistant::global_homeassistant_time != nullptr) {
+      this->send_time_request();
+    }
+#endif
+  }
+  return resp;
+}
+DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
+  DeviceInfoResponse resp{};
+  resp.uses_password = this->parent_->uses_password();
+  resp.name = App.get_name();
+  resp.friendly_name = App.get_friendly_name();
+  resp.suggested_area = App.get_area();
+  resp.mac_address = get_mac_address_pretty();
+  resp.esphome_version = ESPHOME_VERSION;
+  resp.compilation_time = App.get_compilation_time();
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  resp.manufacturer = "Espressif";
+#elif defined(USE_RP2040)
+  resp.manufacturer = "Raspberry Pi";
+#elif defined(USE_BK72XX)
+  resp.manufacturer = "Beken";
+#elif defined(USE_RTL87XX)
+  resp.manufacturer = "Realtek";
+#elif defined(USE_HOST)
+  resp.manufacturer = "Host";
+#endif
+  resp.model = ESPHOME_BOARD;
+#ifdef USE_DEEP_SLEEP
+  resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;
+#endif
+#ifdef ESPHOME_PROJECT_NAME
+  resp.project_name = ESPHOME_PROJECT_NAME;
+  resp.project_version = ESPHOME_PROJECT_VERSION;
+#endif
+#ifdef USE_WEBSERVER
+  resp.webserver_port = USE_WEBSERVER_PORT;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  resp.legacy_bluetooth_proxy_version = bluetooth_proxy::global_bluetooth_proxy->get_legacy_version();
+  resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  resp.legacy_voice_assistant_version = voice_assistant::global_voice_assistant->get_legacy_version();
+  resp.voice_assistant_feature_flags = voice_assistant::global_voice_assistant->get_feature_flags();
+#endif
+  return resp;
+}
+void APIConnection::on_home_assistant_state_response(const HomeAssistantStateResponse &msg) {
+  for (auto &it : this->parent_->get_state_subs()) {
+    if (it.entity_id == msg.entity_id && it.attribute.value() == msg.attribute) {
+      it.callback(msg.state);
+    }
+  }
+}
+void APIConnection::execute_service(const ExecuteServiceRequest &msg) {
+  bool found = false;
+  for (auto *service : this->parent_->get_user_services()) {
+    if (service->execute_service(msg)) {
+      found = true;
+    }
+  }
+  if (!found) {
+    ESP_LOGV(TAG, "Could not find matching service!");
+  }
+}
+void APIConnection::subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) {
+  state_subs_at_ = 0;
+}
+bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) {
+  if (this->remove_)
+    return false;
+  if (!this->helper_->can_write_without_blocking()) {
+    delay(0);
+    APIError err = this->helper_->loop();
+    if (err != APIError::OK) {
+      on_fatal_error();
+      ESP_LOGW(TAG, "%s: Socket operation failed: %s errno=%d", this->client_combined_info_.c_str(),
+               api_error_to_str(err), errno);
+      return false;
+    }
+    if (!this->helper_->can_write_without_blocking()) {
+      // SubscribeLogsResponse
+      if (message_type != 29) {
+        ESP_LOGV(TAG, "Cannot send message because of TCP buffer space");
+      }
+      delay(0);
+      return false;
+    }
+  }
+
+  APIError err = this->helper_->write_packet(message_type, buffer.get_buffer()->data(), buffer.get_buffer()->size());
+  if (err == APIError::WOULD_BLOCK)
+    return false;
+  if (err != APIError::OK) {
+    on_fatal_error();
+    if (err == APIError::SOCKET_WRITE_FAILED && errno == ECONNRESET) {
+      ESP_LOGW(TAG, "%s: Connection reset", this->client_combined_info_.c_str());
+    } else {
+      ESP_LOGW(TAG, "%s: Packet write failed %s errno=%d", this->client_combined_info_.c_str(), api_error_to_str(err),
+               errno);
+    }
+    return false;
+  }
+  // Do not set last_traffic_ on send
+  return true;
+}
+void APIConnection::on_unauthenticated_access() {
+  this->on_fatal_error();
+  ESP_LOGD(TAG, "%s: tried to access without authentication.", this->client_combined_info_.c_str());
+}
+void APIConnection::on_no_setup_connection() {
+  this->on_fatal_error();
+  ESP_LOGD(TAG, "%s: tried to access without full connection.", this->client_combined_info_.c_str());
+}
+void APIConnection::on_fatal_error() {
+  this->helper_->close();
+  this->remove_ = true;
+}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include "api_frame_helper.h"
+#include "api_pb2.h"
+#include "api_pb2_service.h"
+#include "api_server.h"
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+
+#include <vector>
+
+namespace esphome {
+namespace api {
+
+class APIConnection : public APIServerConnection {
+ public:
+  APIConnection(std::unique_ptr<socket::Socket> socket, APIServer *parent);
+  virtual ~APIConnection();
+
+  void start();
+  void loop();
+
+  bool send_list_info_done() {
+    ListEntitiesDoneResponse resp;
+    return this->send_list_entities_done_response(resp);
+  }
+#ifdef USE_BINARY_SENSOR
+  bool send_binary_sensor_state(binary_sensor::BinarySensor *binary_sensor, bool state);
+  bool send_binary_sensor_info(binary_sensor::BinarySensor *binary_sensor);
+#endif
+#ifdef USE_COVER
+  bool send_cover_state(cover::Cover *cover);
+  bool send_cover_info(cover::Cover *cover);
+  void cover_command(const CoverCommandRequest &msg) override;
+#endif
+#ifdef USE_FAN
+  bool send_fan_state(fan::Fan *fan);
+  bool send_fan_info(fan::Fan *fan);
+  void fan_command(const FanCommandRequest &msg) override;
+#endif
+#ifdef USE_LIGHT
+  bool send_light_state(light::LightState *light);
+  bool send_light_info(light::LightState *light);
+  void light_command(const LightCommandRequest &msg) override;
+#endif
+#ifdef USE_SENSOR
+  bool send_sensor_state(sensor::Sensor *sensor, float state);
+  bool send_sensor_info(sensor::Sensor *sensor);
+#endif
+#ifdef USE_SWITCH
+  bool send_switch_state(switch_::Switch *a_switch, bool state);
+  bool send_switch_info(switch_::Switch *a_switch);
+  void switch_command(const SwitchCommandRequest &msg) override;
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool send_text_sensor_state(text_sensor::TextSensor *text_sensor, std::string state);
+  bool send_text_sensor_info(text_sensor::TextSensor *text_sensor);
+#endif
+#ifdef USE_ESP32_CAMERA
+  void send_camera_state(std::shared_ptr<esp32_camera::CameraImage> image);
+  bool send_camera_info(esp32_camera::ESP32Camera *camera);
+  void camera_image(const CameraImageRequest &msg) override;
+#endif
+#ifdef USE_CLIMATE
+  bool send_climate_state(climate::Climate *climate);
+  bool send_climate_info(climate::Climate *climate);
+  void climate_command(const ClimateCommandRequest &msg) override;
+#endif
+#ifdef USE_NUMBER
+  bool send_number_state(number::Number *number, float state);
+  bool send_number_info(number::Number *number);
+  void number_command(const NumberCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_DATE
+  bool send_date_state(datetime::DateEntity *date);
+  bool send_date_info(datetime::DateEntity *date);
+  void date_command(const DateCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_TIME
+  bool send_time_state(datetime::TimeEntity *time);
+  bool send_time_info(datetime::TimeEntity *time);
+  void time_command(const TimeCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  bool send_datetime_state(datetime::DateTimeEntity *datetime);
+  bool send_datetime_info(datetime::DateTimeEntity *datetime);
+  void datetime_command(const DateTimeCommandRequest &msg) override;
+#endif
+#ifdef USE_TEXT
+  bool send_text_state(text::Text *text, std::string state);
+  bool send_text_info(text::Text *text);
+  void text_command(const TextCommandRequest &msg) override;
+#endif
+#ifdef USE_SELECT
+  bool send_select_state(select::Select *select, std::string state);
+  bool send_select_info(select::Select *select);
+  void select_command(const SelectCommandRequest &msg) override;
+#endif
+#ifdef USE_BUTTON
+  bool send_button_info(button::Button *button);
+  void button_command(const ButtonCommandRequest &msg) override;
+#endif
+#ifdef USE_LOCK
+  bool send_lock_state(lock::Lock *a_lock, lock::LockState state);
+  bool send_lock_info(lock::Lock *a_lock);
+  void lock_command(const LockCommandRequest &msg) override;
+#endif
+#ifdef USE_VALVE
+  bool send_valve_state(valve::Valve *valve);
+  bool send_valve_info(valve::Valve *valve);
+  void valve_command(const ValveCommandRequest &msg) override;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool send_media_player_state(media_player::MediaPlayer *media_player);
+  bool send_media_player_info(media_player::MediaPlayer *media_player);
+  void media_player_command(const MediaPlayerCommandRequest &msg) override;
+#endif
+  bool send_log_message(int level, const char *tag, const char *line);
+  void send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
+    if (!this->service_call_subscription_)
+      return;
+    this->send_homeassistant_service_response(call);
+  }
+#ifdef USE_BLUETOOTH_PROXY
+  void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) override;
+  void unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override;
+  bool send_bluetooth_le_advertisement(const BluetoothLEAdvertisementResponse &msg);
+
+  void bluetooth_device_request(const BluetoothDeviceRequest &msg) override;
+  void bluetooth_gatt_read(const BluetoothGATTReadRequest &msg) override;
+  void bluetooth_gatt_write(const BluetoothGATTWriteRequest &msg) override;
+  void bluetooth_gatt_read_descriptor(const BluetoothGATTReadDescriptorRequest &msg) override;
+  void bluetooth_gatt_write_descriptor(const BluetoothGATTWriteDescriptorRequest &msg) override;
+  void bluetooth_gatt_get_services(const BluetoothGATTGetServicesRequest &msg) override;
+  void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) override;
+  BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
+      const SubscribeBluetoothConnectionsFreeRequest &msg) override;
+
+#endif
+#ifdef USE_HOMEASSISTANT_TIME
+  void send_time_request() {
+    GetTimeRequest req;
+    this->send_get_time_request(req);
+  }
+#endif
+
+#ifdef USE_VOICE_ASSISTANT
+  void subscribe_voice_assistant(const SubscribeVoiceAssistantRequest &msg) override;
+  void on_voice_assistant_response(const VoiceAssistantResponse &msg) override;
+  void on_voice_assistant_event_response(const VoiceAssistantEventResponse &msg) override;
+  void on_voice_assistant_audio(const VoiceAssistantAudio &msg) override;
+  void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &msg) override;
+#endif
+
+#ifdef USE_ALARM_CONTROL_PANEL
+  bool send_alarm_control_panel_state(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel);
+  bool send_alarm_control_panel_info(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel);
+  void alarm_control_panel_command(const AlarmControlPanelCommandRequest &msg) override;
+#endif
+
+#ifdef USE_EVENT
+  bool send_event(event::Event *event, std::string event_type);
+  bool send_event_info(event::Event *event);
+#endif
+
+#ifdef USE_UPDATE
+  bool send_update_state(update::UpdateEntity *update);
+  bool send_update_info(update::UpdateEntity *update);
+  void update_command(const UpdateCommandRequest &msg) override;
+#endif
+
+  void on_disconnect_response(const DisconnectResponse &value) override;
+  void on_ping_response(const PingResponse &value) override {
+    // we initiated ping
+    this->ping_retries_ = 0;
+    this->sent_ping_ = false;
+  }
+  void on_home_assistant_state_response(const HomeAssistantStateResponse &msg) override;
+#ifdef USE_HOMEASSISTANT_TIME
+  void on_get_time_response(const GetTimeResponse &value) override;
+#endif
+  HelloResponse hello(const HelloRequest &msg) override;
+  ConnectResponse connect(const ConnectRequest &msg) override;
+  DisconnectResponse disconnect(const DisconnectRequest &msg) override;
+  PingResponse ping(const PingRequest &msg) override { return {}; }
+  DeviceInfoResponse device_info(const DeviceInfoRequest &msg) override;
+  void list_entities(const ListEntitiesRequest &msg) override { this->list_entities_iterator_.begin(); }
+  void subscribe_states(const SubscribeStatesRequest &msg) override {
+    this->state_subscription_ = true;
+    this->initial_state_iterator_.begin();
+  }
+  void subscribe_logs(const SubscribeLogsRequest &msg) override {
+    this->log_subscription_ = msg.level;
+    if (msg.dump_config)
+      App.schedule_dump_config();
+  }
+  void subscribe_homeassistant_services(const SubscribeHomeassistantServicesRequest &msg) override {
+    this->service_call_subscription_ = true;
+  }
+  void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) override;
+  GetTimeResponse get_time(const GetTimeRequest &msg) override {
+    // TODO
+    return {};
+  }
+  void execute_service(const ExecuteServiceRequest &msg) override;
+
+  bool is_authenticated() override { return this->connection_state_ == ConnectionState::AUTHENTICATED; }
+  bool is_connection_setup() override {
+    return this->connection_state_ == ConnectionState ::CONNECTED || this->is_authenticated();
+  }
+  void on_fatal_error() override;
+  void on_unauthenticated_access() override;
+  void on_no_setup_connection() override;
+  ProtoWriteBuffer create_buffer() override {
+    // FIXME: ensure no recursive writes can happen
+    this->proto_write_buffer_.clear();
+    return {&this->proto_write_buffer_};
+  }
+  bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) override;
+
+  std::string get_client_combined_info() const { return this->client_combined_info_; }
+
+ protected:
+  friend APIServer;
+
+  bool send_(const void *buf, size_t len, bool force);
+
+  enum class ConnectionState {
+    WAITING_FOR_HELLO,
+    CONNECTED,
+    AUTHENTICATED,
+  } connection_state_{ConnectionState::WAITING_FOR_HELLO};
+
+  bool remove_{false};
+
+  // Buffer used to encode proto messages
+  // Re-use to prevent allocations
+  std::vector<uint8_t> proto_write_buffer_;
+  std::unique_ptr<APIFrameHelper> helper_;
+
+  std::string client_info_;
+  std::string client_peername_;
+  std::string client_combined_info_;
+  uint32_t client_api_version_major_{0};
+  uint32_t client_api_version_minor_{0};
+#ifdef USE_ESP32_CAMERA
+  esp32_camera::CameraImageReader image_reader_;
+#endif
+
+  bool state_subscription_{false};
+  int log_subscription_{ESPHOME_LOG_LEVEL_NONE};
+  uint32_t last_traffic_;
+  uint32_t next_ping_retry_{0};
+  uint8_t ping_retries_{0};
+  bool sent_ping_{false};
+  bool service_call_subscription_{false};
+  bool next_close_ = false;
+  APIServer *parent_;
+  InitialStateIterator initial_state_iterator_;
+  ListEntitiesIterator list_entities_iterator_;
+  int state_subs_at_ = -1;
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -1,0 +1,1030 @@
+#include "api_frame_helper.h"
+
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/application.h"
+#include "proto.h"
+#include <cstring>
+
+namespace esphome {
+namespace api {
+
+static const char *const TAG = "api.socket";
+
+/// Is the given return value (from write syscalls) a wouldblock error?
+bool is_would_block(ssize_t ret) {
+  if (ret == -1) {
+    return errno == EWOULDBLOCK || errno == EAGAIN;
+  }
+  return ret == 0;
+}
+
+const char *api_error_to_str(APIError err) {
+  // not using switch to ensure compiler doesn't try to build a big table out of it
+  if (err == APIError::OK) {
+    return "OK";
+  } else if (err == APIError::WOULD_BLOCK) {
+    return "WOULD_BLOCK";
+  } else if (err == APIError::BAD_HANDSHAKE_PACKET_LEN) {
+    return "BAD_HANDSHAKE_PACKET_LEN";
+  } else if (err == APIError::BAD_INDICATOR) {
+    return "BAD_INDICATOR";
+  } else if (err == APIError::BAD_DATA_PACKET) {
+    return "BAD_DATA_PACKET";
+  } else if (err == APIError::TCP_NODELAY_FAILED) {
+    return "TCP_NODELAY_FAILED";
+  } else if (err == APIError::TCP_NONBLOCKING_FAILED) {
+    return "TCP_NONBLOCKING_FAILED";
+  } else if (err == APIError::CLOSE_FAILED) {
+    return "CLOSE_FAILED";
+  } else if (err == APIError::SHUTDOWN_FAILED) {
+    return "SHUTDOWN_FAILED";
+  } else if (err == APIError::BAD_STATE) {
+    return "BAD_STATE";
+  } else if (err == APIError::BAD_ARG) {
+    return "BAD_ARG";
+  } else if (err == APIError::SOCKET_READ_FAILED) {
+    return "SOCKET_READ_FAILED";
+  } else if (err == APIError::SOCKET_WRITE_FAILED) {
+    return "SOCKET_WRITE_FAILED";
+  } else if (err == APIError::HANDSHAKESTATE_READ_FAILED) {
+    return "HANDSHAKESTATE_READ_FAILED";
+  } else if (err == APIError::HANDSHAKESTATE_WRITE_FAILED) {
+    return "HANDSHAKESTATE_WRITE_FAILED";
+  } else if (err == APIError::HANDSHAKESTATE_BAD_STATE) {
+    return "HANDSHAKESTATE_BAD_STATE";
+  } else if (err == APIError::CIPHERSTATE_DECRYPT_FAILED) {
+    return "CIPHERSTATE_DECRYPT_FAILED";
+  } else if (err == APIError::CIPHERSTATE_ENCRYPT_FAILED) {
+    return "CIPHERSTATE_ENCRYPT_FAILED";
+  } else if (err == APIError::OUT_OF_MEMORY) {
+    return "OUT_OF_MEMORY";
+  } else if (err == APIError::HANDSHAKESTATE_SETUP_FAILED) {
+    return "HANDSHAKESTATE_SETUP_FAILED";
+  } else if (err == APIError::HANDSHAKESTATE_SPLIT_FAILED) {
+    return "HANDSHAKESTATE_SPLIT_FAILED";
+  } else if (err == APIError::BAD_HANDSHAKE_ERROR_BYTE) {
+    return "BAD_HANDSHAKE_ERROR_BYTE";
+  } else if (err == APIError::CONNECTION_CLOSED) {
+    return "CONNECTION_CLOSED";
+  }
+  return "UNKNOWN";
+}
+
+#define HELPER_LOG(msg, ...) ESP_LOGVV(TAG, "%s: " msg, info_.c_str(), ##__VA_ARGS__)
+// uncomment to log raw packets
+//#define HELPER_LOG_PACKETS
+
+#ifdef USE_API_NOISE
+static const char *const PROLOGUE_INIT = "NoiseAPIInit";
+
+/// Convert a noise error code to a readable error
+std::string noise_err_to_str(int err) {
+  if (err == NOISE_ERROR_NO_MEMORY)
+    return "NO_MEMORY";
+  if (err == NOISE_ERROR_UNKNOWN_ID)
+    return "UNKNOWN_ID";
+  if (err == NOISE_ERROR_UNKNOWN_NAME)
+    return "UNKNOWN_NAME";
+  if (err == NOISE_ERROR_MAC_FAILURE)
+    return "MAC_FAILURE";
+  if (err == NOISE_ERROR_NOT_APPLICABLE)
+    return "NOT_APPLICABLE";
+  if (err == NOISE_ERROR_SYSTEM)
+    return "SYSTEM";
+  if (err == NOISE_ERROR_REMOTE_KEY_REQUIRED)
+    return "REMOTE_KEY_REQUIRED";
+  if (err == NOISE_ERROR_LOCAL_KEY_REQUIRED)
+    return "LOCAL_KEY_REQUIRED";
+  if (err == NOISE_ERROR_PSK_REQUIRED)
+    return "PSK_REQUIRED";
+  if (err == NOISE_ERROR_INVALID_LENGTH)
+    return "INVALID_LENGTH";
+  if (err == NOISE_ERROR_INVALID_PARAM)
+    return "INVALID_PARAM";
+  if (err == NOISE_ERROR_INVALID_STATE)
+    return "INVALID_STATE";
+  if (err == NOISE_ERROR_INVALID_NONCE)
+    return "INVALID_NONCE";
+  if (err == NOISE_ERROR_INVALID_PRIVATE_KEY)
+    return "INVALID_PRIVATE_KEY";
+  if (err == NOISE_ERROR_INVALID_PUBLIC_KEY)
+    return "INVALID_PUBLIC_KEY";
+  if (err == NOISE_ERROR_INVALID_FORMAT)
+    return "INVALID_FORMAT";
+  if (err == NOISE_ERROR_INVALID_SIGNATURE)
+    return "INVALID_SIGNATURE";
+  return to_string(err);
+}
+
+/// Initialize the frame helper, returns OK if successful.
+APIError APINoiseFrameHelper::init() {
+  if (state_ != State::INITIALIZE || socket_ == nullptr) {
+    HELPER_LOG("Bad state for init %d", (int) state_);
+    return APIError::BAD_STATE;
+  }
+  int err = socket_->setblocking(false);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nonblocking failed with errno %d", errno);
+    return APIError::TCP_NONBLOCKING_FAILED;
+  }
+
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
+  }
+
+  // init prologue
+  prologue_.insert(prologue_.end(), PROLOGUE_INIT, PROLOGUE_INIT + strlen(PROLOGUE_INIT));
+
+  state_ = State::CLIENT_HELLO;
+  return APIError::OK;
+}
+/// Run through handshake messages (if in that phase)
+APIError APINoiseFrameHelper::loop() {
+  APIError err = state_action_();
+  if (err == APIError::WOULD_BLOCK)
+    return APIError::OK;
+  if (err != APIError::OK)
+    return err;
+  if (!tx_buf_.empty()) {
+    err = try_send_tx_buf_();
+    if (err != APIError::OK) {
+      return err;
+    }
+  }
+  return APIError::OK;
+}
+
+/** Read a packet into the rx_buf_. If successful, stores frame data in the frame parameter
+ *
+ * @param frame: The struct to hold the frame information in.
+ *   msg_start: points to the start of the payload - this pointer is only valid until the next
+ *     try_receive_raw_ call
+ *
+ * @return 0 if a full packet is in rx_buf_
+ * @return -1 if error, check errno.
+ *
+ * errno EWOULDBLOCK: Packet could not be read without blocking. Try again later.
+ * errno ENOMEM: Not enough memory for reading packet.
+ * errno API_ERROR_BAD_INDICATOR: Bad indicator byte at start of frame.
+ * errno API_ERROR_HANDSHAKE_PACKET_LEN: Packet too big for this phase.
+ */
+APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
+  if (frame == nullptr) {
+    HELPER_LOG("Bad argument for try_read_frame_");
+    return APIError::BAD_ARG;
+  }
+
+  // read header
+  if (rx_header_buf_len_ < 3) {
+    // no header information yet
+    size_t to_read = 3 - rx_header_buf_len_;
+    ssize_t received = socket_->read(&rx_header_buf_[rx_header_buf_len_], to_read);
+    if (received == -1) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        return APIError::WOULD_BLOCK;
+      }
+      state_ = State::FAILED;
+      HELPER_LOG("Socket read failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    } else if (received == 0) {
+      state_ = State::FAILED;
+      HELPER_LOG("Connection closed");
+      return APIError::CONNECTION_CLOSED;
+    }
+    rx_header_buf_len_ += received;
+    if ((size_t) received != to_read) {
+      // not a full read
+      return APIError::WOULD_BLOCK;
+    }
+
+    // header reading done
+  }
+
+  // read body
+  uint8_t indicator = rx_header_buf_[0];
+  if (indicator != 0x01) {
+    state_ = State::FAILED;
+    HELPER_LOG("Bad indicator byte %u", indicator);
+    return APIError::BAD_INDICATOR;
+  }
+
+  uint16_t msg_size = (((uint16_t) rx_header_buf_[1]) << 8) | rx_header_buf_[2];
+
+  if (state_ != State::DATA && msg_size > 128) {
+    // for handshake message only permit up to 128 bytes
+    state_ = State::FAILED;
+    HELPER_LOG("Bad packet len for handshake: %d", msg_size);
+    return APIError::BAD_HANDSHAKE_PACKET_LEN;
+  }
+
+  // reserve space for body
+  if (rx_buf_.size() != msg_size) {
+    rx_buf_.resize(msg_size);
+  }
+
+  if (rx_buf_len_ < msg_size) {
+    // more data to read
+    size_t to_read = msg_size - rx_buf_len_;
+    ssize_t received = socket_->read(&rx_buf_[rx_buf_len_], to_read);
+    if (received == -1) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        return APIError::WOULD_BLOCK;
+      }
+      state_ = State::FAILED;
+      HELPER_LOG("Socket read failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    } else if (received == 0) {
+      state_ = State::FAILED;
+      HELPER_LOG("Connection closed");
+      return APIError::CONNECTION_CLOSED;
+    }
+    rx_buf_len_ += received;
+    if ((size_t) received != to_read) {
+      // not all read
+      return APIError::WOULD_BLOCK;
+    }
+  }
+
+  // uncomment for even more debugging
+#ifdef HELPER_LOG_PACKETS
+  ESP_LOGVV(TAG, "Received frame: %s", format_hex_pretty(rx_buf_).c_str());
+#endif
+  frame->msg = std::move(rx_buf_);
+  // consume msg
+  rx_buf_ = {};
+  rx_buf_len_ = 0;
+  rx_header_buf_len_ = 0;
+  return APIError::OK;
+}
+
+/** To be called from read/write methods.
+ *
+ * This method runs through the internal handshake methods, if in that state.
+ *
+ * If the handshake is still active when this method returns and a read/write can't take place at
+ * the moment, returns WOULD_BLOCK.
+ * If an error occurred, returns that error. Only returns OK if the transport is ready for data
+ * traffic.
+ */
+APIError APINoiseFrameHelper::state_action_() {
+  int err;
+  APIError aerr;
+  if (state_ == State::INITIALIZE) {
+    HELPER_LOG("Bad state for method: %d", (int) state_);
+    return APIError::BAD_STATE;
+  }
+  if (state_ == State::CLIENT_HELLO) {
+    // waiting for client hello
+    ParsedFrame frame;
+    aerr = try_read_frame_(&frame);
+    if (aerr == APIError::BAD_INDICATOR) {
+      send_explicit_handshake_reject_("Bad indicator byte");
+      return aerr;
+    }
+    if (aerr == APIError::BAD_HANDSHAKE_PACKET_LEN) {
+      send_explicit_handshake_reject_("Bad handshake packet len");
+      return aerr;
+    }
+    if (aerr != APIError::OK)
+      return aerr;
+    // ignore contents, may be used in future for flags
+    prologue_.push_back((uint8_t) (frame.msg.size() >> 8));
+    prologue_.push_back((uint8_t) frame.msg.size());
+    prologue_.insert(prologue_.end(), frame.msg.begin(), frame.msg.end());
+
+    state_ = State::SERVER_HELLO;
+  }
+  if (state_ == State::SERVER_HELLO) {
+    // send server hello
+    std::vector<uint8_t> msg;
+    // chosen proto
+    msg.push_back(0x01);
+
+    // node name, terminated by null byte
+    const std::string &name = App.get_name();
+    const uint8_t *name_ptr = reinterpret_cast<const uint8_t *>(name.c_str());
+    msg.insert(msg.end(), name_ptr, name_ptr + name.size() + 1);
+
+    aerr = write_frame_(msg.data(), msg.size());
+    if (aerr != APIError::OK)
+      return aerr;
+
+    // start handshake
+    aerr = init_handshake_();
+    if (aerr != APIError::OK)
+      return aerr;
+
+    state_ = State::HANDSHAKE;
+  }
+  if (state_ == State::HANDSHAKE) {
+    int action = noise_handshakestate_get_action(handshake_);
+    if (action == NOISE_ACTION_READ_MESSAGE) {
+      // waiting for handshake msg
+      ParsedFrame frame;
+      aerr = try_read_frame_(&frame);
+      if (aerr == APIError::BAD_INDICATOR) {
+        send_explicit_handshake_reject_("Bad indicator byte");
+        return aerr;
+      }
+      if (aerr == APIError::BAD_HANDSHAKE_PACKET_LEN) {
+        send_explicit_handshake_reject_("Bad handshake packet len");
+        return aerr;
+      }
+      if (aerr != APIError::OK)
+        return aerr;
+
+      if (frame.msg.empty()) {
+        send_explicit_handshake_reject_("Empty handshake message");
+        return APIError::BAD_HANDSHAKE_ERROR_BYTE;
+      } else if (frame.msg[0] != 0x00) {
+        HELPER_LOG("Bad handshake error byte: %u", frame.msg[0]);
+        send_explicit_handshake_reject_("Bad handshake error byte");
+        return APIError::BAD_HANDSHAKE_ERROR_BYTE;
+      }
+
+      NoiseBuffer mbuf;
+      noise_buffer_init(mbuf);
+      noise_buffer_set_input(mbuf, frame.msg.data() + 1, frame.msg.size() - 1);
+      err = noise_handshakestate_read_message(handshake_, &mbuf, nullptr);
+      if (err != 0) {
+        state_ = State::FAILED;
+        HELPER_LOG("noise_handshakestate_read_message failed: %s", noise_err_to_str(err).c_str());
+        if (err == NOISE_ERROR_MAC_FAILURE) {
+          send_explicit_handshake_reject_("Handshake MAC failure");
+        } else {
+          send_explicit_handshake_reject_("Handshake error");
+        }
+        return APIError::HANDSHAKESTATE_READ_FAILED;
+      }
+
+      aerr = check_handshake_finished_();
+      if (aerr != APIError::OK)
+        return aerr;
+    } else if (action == NOISE_ACTION_WRITE_MESSAGE) {
+      uint8_t buffer[65];
+      NoiseBuffer mbuf;
+      noise_buffer_init(mbuf);
+      noise_buffer_set_output(mbuf, buffer + 1, sizeof(buffer) - 1);
+
+      err = noise_handshakestate_write_message(handshake_, &mbuf, nullptr);
+      if (err != 0) {
+        state_ = State::FAILED;
+        HELPER_LOG("noise_handshakestate_write_message failed: %s", noise_err_to_str(err).c_str());
+        return APIError::HANDSHAKESTATE_WRITE_FAILED;
+      }
+      buffer[0] = 0x00;  // success
+
+      aerr = write_frame_(buffer, mbuf.size + 1);
+      if (aerr != APIError::OK)
+        return aerr;
+      aerr = check_handshake_finished_();
+      if (aerr != APIError::OK)
+        return aerr;
+    } else {
+      // bad state for action
+      state_ = State::FAILED;
+      HELPER_LOG("Bad action for handshake: %d", action);
+      return APIError::HANDSHAKESTATE_BAD_STATE;
+    }
+  }
+  if (state_ == State::CLOSED || state_ == State::FAILED) {
+    return APIError::BAD_STATE;
+  }
+  return APIError::OK;
+}
+void APINoiseFrameHelper::send_explicit_handshake_reject_(const std::string &reason) {
+  std::vector<uint8_t> data;
+  data.resize(reason.length() + 1);
+  data[0] = 0x01;  // failure
+  for (size_t i = 0; i < reason.length(); i++) {
+    data[i + 1] = (uint8_t) reason[i];
+  }
+  // temporarily remove failed state
+  auto orig_state = state_;
+  state_ = State::EXPLICIT_REJECT;
+  write_frame_(data.data(), data.size());
+  state_ = orig_state;
+}
+
+APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
+  int err;
+  APIError aerr;
+  aerr = state_action_();
+  if (aerr != APIError::OK) {
+    return aerr;
+  }
+
+  if (state_ != State::DATA) {
+    return APIError::WOULD_BLOCK;
+  }
+
+  ParsedFrame frame;
+  aerr = try_read_frame_(&frame);
+  if (aerr != APIError::OK)
+    return aerr;
+
+  NoiseBuffer mbuf;
+  noise_buffer_init(mbuf);
+  noise_buffer_set_inout(mbuf, frame.msg.data(), frame.msg.size(), frame.msg.size());
+  err = noise_cipherstate_decrypt(recv_cipher_, &mbuf);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_cipherstate_decrypt failed: %s", noise_err_to_str(err).c_str());
+    return APIError::CIPHERSTATE_DECRYPT_FAILED;
+  }
+
+  size_t msg_size = mbuf.size;
+  uint8_t *msg_data = frame.msg.data();
+  if (msg_size < 4) {
+    state_ = State::FAILED;
+    HELPER_LOG("Bad data packet: size %d too short", msg_size);
+    return APIError::BAD_DATA_PACKET;
+  }
+
+  // uint16_t type;
+  // uint16_t data_len;
+  // uint8_t *data;
+  // uint8_t *padding;  zero or more bytes to fill up the rest of the packet
+  uint16_t type = (((uint16_t) msg_data[0]) << 8) | msg_data[1];
+  uint16_t data_len = (((uint16_t) msg_data[2]) << 8) | msg_data[3];
+  if (data_len > msg_size - 4) {
+    state_ = State::FAILED;
+    HELPER_LOG("Bad data packet: data_len %u greater than msg_size %u", data_len, msg_size);
+    return APIError::BAD_DATA_PACKET;
+  }
+
+  buffer->container = std::move(frame.msg);
+  buffer->data_offset = 4;
+  buffer->data_len = data_len;
+  buffer->type = type;
+  return APIError::OK;
+}
+bool APINoiseFrameHelper::can_write_without_blocking() { return state_ == State::DATA && tx_buf_.empty(); }
+APIError APINoiseFrameHelper::write_packet(uint16_t type, const uint8_t *payload, size_t payload_len) {
+  int err;
+  APIError aerr;
+  aerr = state_action_();
+  if (aerr != APIError::OK) {
+    return aerr;
+  }
+
+  if (state_ != State::DATA) {
+    return APIError::WOULD_BLOCK;
+  }
+
+  size_t padding = 0;
+  size_t msg_len = 4 + payload_len + padding;
+  size_t frame_len = 3 + msg_len + noise_cipherstate_get_mac_length(send_cipher_);
+  auto tmpbuf = std::unique_ptr<uint8_t[]>{new (std::nothrow) uint8_t[frame_len]};
+  if (tmpbuf == nullptr) {
+    HELPER_LOG("Could not allocate for writing packet");
+    return APIError::OUT_OF_MEMORY;
+  }
+
+  tmpbuf[0] = 0x01;  // indicator
+  // tmpbuf[1], tmpbuf[2] to be set later
+  const uint8_t msg_offset = 3;
+  const uint8_t payload_offset = msg_offset + 4;
+  tmpbuf[msg_offset + 0] = (uint8_t) (type >> 8);  // type
+  tmpbuf[msg_offset + 1] = (uint8_t) type;
+  tmpbuf[msg_offset + 2] = (uint8_t) (payload_len >> 8);  // data_len
+  tmpbuf[msg_offset + 3] = (uint8_t) payload_len;
+  // copy data
+  std::copy(payload, payload + payload_len, &tmpbuf[payload_offset]);
+  // fill padding with zeros
+  std::fill(&tmpbuf[payload_offset + payload_len], &tmpbuf[frame_len], 0);
+
+  NoiseBuffer mbuf;
+  noise_buffer_init(mbuf);
+  noise_buffer_set_inout(mbuf, &tmpbuf[msg_offset], msg_len, frame_len - msg_offset);
+  err = noise_cipherstate_encrypt(send_cipher_, &mbuf);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_cipherstate_encrypt failed: %s", noise_err_to_str(err).c_str());
+    return APIError::CIPHERSTATE_ENCRYPT_FAILED;
+  }
+
+  size_t total_len = 3 + mbuf.size;
+  tmpbuf[1] = (uint8_t) (mbuf.size >> 8);
+  tmpbuf[2] = (uint8_t) mbuf.size;
+
+  struct iovec iov;
+  iov.iov_base = &tmpbuf[0];
+  iov.iov_len = total_len;
+
+  // write raw to not have two packets sent if NAGLE disabled
+  return write_raw_(&iov, 1);
+}
+APIError APINoiseFrameHelper::try_send_tx_buf_() {
+  // try send from tx_buf
+  while (state_ != State::CLOSED && !tx_buf_.empty()) {
+    ssize_t sent = socket_->write(tx_buf_.data(), tx_buf_.size());
+    if (sent == -1) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN)
+        break;
+      state_ = State::FAILED;
+      HELPER_LOG("Socket write failed with errno %d", errno);
+      return APIError::SOCKET_WRITE_FAILED;
+    } else if (sent == 0) {
+      break;
+    }
+    // TODO: inefficient if multiple packets in txbuf
+    // replace with deque of buffers
+    tx_buf_.erase(tx_buf_.begin(), tx_buf_.begin() + sent);
+  }
+
+  return APIError::OK;
+}
+/** Write the data to the socket, or buffer it a write would block
+ *
+ * @param data The data to write
+ * @param len The length of data
+ */
+APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
+  if (iovcnt == 0)
+    return APIError::OK;
+  APIError aerr;
+
+  size_t total_write_len = 0;
+  for (int i = 0; i < iovcnt; i++) {
+#ifdef HELPER_LOG_PACKETS
+    ESP_LOGVV(TAG, "Sending raw: %s",
+              format_hex_pretty(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len).c_str());
+#endif
+    total_write_len += iov[i].iov_len;
+  }
+
+  if (!tx_buf_.empty()) {
+    // try to empty tx_buf_ first
+    aerr = try_send_tx_buf_();
+    if (aerr != APIError::OK && aerr != APIError::WOULD_BLOCK)
+      return aerr;
+  }
+
+  if (!tx_buf_.empty()) {
+    // tx buf not empty, can't write now because then stream would be inconsistent
+    for (int i = 0; i < iovcnt; i++) {
+      tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
+                     reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+    }
+    return APIError::OK;
+  }
+
+  ssize_t sent = socket_->writev(iov, iovcnt);
+  if (is_would_block(sent)) {
+    // operation would block, add buffer to tx_buf
+    for (int i = 0; i < iovcnt; i++) {
+      tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
+                     reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+    }
+    return APIError::OK;
+  } else if (sent == -1) {
+    // an error occurred
+    state_ = State::FAILED;
+    HELPER_LOG("Socket write failed with errno %d", errno);
+    return APIError::SOCKET_WRITE_FAILED;
+  } else if ((size_t) sent != total_write_len) {
+    // partially sent, add end to tx_buf
+    size_t to_consume = sent;
+    for (int i = 0; i < iovcnt; i++) {
+      if (to_consume >= iov[i].iov_len) {
+        to_consume -= iov[i].iov_len;
+      } else {
+        tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base) + to_consume,
+                       reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+        to_consume = 0;
+      }
+    }
+    return APIError::OK;
+  }
+  // fully sent
+  return APIError::OK;
+}
+APIError APINoiseFrameHelper::write_frame_(const uint8_t *data, size_t len) {
+  uint8_t header[3];
+  header[0] = 0x01;  // indicator
+  header[1] = (uint8_t) (len >> 8);
+  header[2] = (uint8_t) len;
+
+  struct iovec iov[2];
+  iov[0].iov_base = header;
+  iov[0].iov_len = 3;
+  if (len == 0) {
+    return write_raw_(iov, 1);
+  }
+  iov[1].iov_base = const_cast<uint8_t *>(data);
+  iov[1].iov_len = len;
+
+  return write_raw_(iov, 2);
+}
+
+/** Initiate the data structures for the handshake.
+ *
+ * @return 0 on success, -1 on error (check errno)
+ */
+APIError APINoiseFrameHelper::init_handshake_() {
+  int err;
+  memset(&nid_, 0, sizeof(nid_));
+  // const char *proto = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
+  // err = noise_protocol_name_to_id(&nid_, proto, strlen(proto));
+  nid_.pattern_id = NOISE_PATTERN_NN;
+  nid_.cipher_id = NOISE_CIPHER_CHACHAPOLY;
+  nid_.dh_id = NOISE_DH_CURVE25519;
+  nid_.prefix_id = NOISE_PREFIX_STANDARD;
+  nid_.hybrid_id = NOISE_DH_NONE;
+  nid_.hash_id = NOISE_HASH_SHA256;
+  nid_.modifier_ids[0] = NOISE_MODIFIER_PSK0;
+
+  err = noise_handshakestate_new_by_id(&handshake_, &nid_, NOISE_ROLE_RESPONDER);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_handshakestate_new_by_id failed: %s", noise_err_to_str(err).c_str());
+    return APIError::HANDSHAKESTATE_SETUP_FAILED;
+  }
+
+  const auto &psk = ctx_->get_psk();
+  err = noise_handshakestate_set_pre_shared_key(handshake_, psk.data(), psk.size());
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_handshakestate_set_pre_shared_key failed: %s", noise_err_to_str(err).c_str());
+    return APIError::HANDSHAKESTATE_SETUP_FAILED;
+  }
+
+  err = noise_handshakestate_set_prologue(handshake_, prologue_.data(), prologue_.size());
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_handshakestate_set_prologue failed: %s", noise_err_to_str(err).c_str());
+    return APIError::HANDSHAKESTATE_SETUP_FAILED;
+  }
+  // set_prologue copies it into handshakestate, so we can get rid of it now
+  prologue_ = {};
+
+  err = noise_handshakestate_start(handshake_);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_handshakestate_start failed: %s", noise_err_to_str(err).c_str());
+    return APIError::HANDSHAKESTATE_SETUP_FAILED;
+  }
+  return APIError::OK;
+}
+
+APIError APINoiseFrameHelper::check_handshake_finished_() {
+  assert(state_ == State::HANDSHAKE);
+
+  int action = noise_handshakestate_get_action(handshake_);
+  if (action == NOISE_ACTION_READ_MESSAGE || action == NOISE_ACTION_WRITE_MESSAGE)
+    return APIError::OK;
+  if (action != NOISE_ACTION_SPLIT) {
+    state_ = State::FAILED;
+    HELPER_LOG("Bad action for handshake: %d", action);
+    return APIError::HANDSHAKESTATE_BAD_STATE;
+  }
+  int err = noise_handshakestate_split(handshake_, &send_cipher_, &recv_cipher_);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("noise_handshakestate_split failed: %s", noise_err_to_str(err).c_str());
+    return APIError::HANDSHAKESTATE_SPLIT_FAILED;
+  }
+
+  HELPER_LOG("Handshake complete!");
+  noise_handshakestate_free(handshake_);
+  handshake_ = nullptr;
+  state_ = State::DATA;
+  return APIError::OK;
+}
+
+APINoiseFrameHelper::~APINoiseFrameHelper() {
+  if (handshake_ != nullptr) {
+    noise_handshakestate_free(handshake_);
+    handshake_ = nullptr;
+  }
+  if (send_cipher_ != nullptr) {
+    noise_cipherstate_free(send_cipher_);
+    send_cipher_ = nullptr;
+  }
+  if (recv_cipher_ != nullptr) {
+    noise_cipherstate_free(recv_cipher_);
+    recv_cipher_ = nullptr;
+  }
+}
+
+APIError APINoiseFrameHelper::close() {
+  state_ = State::CLOSED;
+  int err = socket_->close();
+  if (err == -1)
+    return APIError::CLOSE_FAILED;
+  return APIError::OK;
+}
+APIError APINoiseFrameHelper::shutdown(int how) {
+  int err = socket_->shutdown(how);
+  if (err == -1)
+    return APIError::SHUTDOWN_FAILED;
+  if (how == SHUT_RDWR) {
+    state_ = State::CLOSED;
+  }
+  return APIError::OK;
+}
+extern "C" {
+// declare how noise generates random bytes (here with a good HWRNG based on the RF system)
+void noise_rand_bytes(void *output, size_t len) {
+  if (!esphome::random_bytes(reinterpret_cast<uint8_t *>(output), len)) {
+    ESP_LOGE(TAG, "Failed to acquire random bytes, rebooting!");
+    arch_restart();
+  }
+}
+}
+#endif  // USE_API_NOISE
+
+#ifdef USE_API_PLAINTEXT
+
+/// Initialize the frame helper, returns OK if successful.
+APIError APIPlaintextFrameHelper::init() {
+  if (state_ != State::INITIALIZE || socket_ == nullptr) {
+    HELPER_LOG("Bad state for init %d", (int) state_);
+    return APIError::BAD_STATE;
+  }
+  int err = socket_->setblocking(false);
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nonblocking failed with errno %d", errno);
+    return APIError::TCP_NONBLOCKING_FAILED;
+  }
+  int enable = 1;
+  err = socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(int));
+  if (err != 0) {
+    state_ = State::FAILED;
+    HELPER_LOG("Setting nodelay failed with errno %d", errno);
+    return APIError::TCP_NODELAY_FAILED;
+  }
+
+  state_ = State::DATA;
+  return APIError::OK;
+}
+/// Not used for plaintext
+APIError APIPlaintextFrameHelper::loop() {
+  if (state_ != State::DATA) {
+    return APIError::BAD_STATE;
+  }
+  // try send pending TX data
+  if (!tx_buf_.empty()) {
+    APIError err = try_send_tx_buf_();
+    if (err != APIError::OK) {
+      return err;
+    }
+  }
+  return APIError::OK;
+}
+
+/** Read a packet into the rx_buf_. If successful, stores frame data in the frame parameter
+ *
+ * @param frame: The struct to hold the frame information in.
+ *   msg: store the parsed frame in that struct
+ *
+ * @return See APIError
+ *
+ * error API_ERROR_BAD_INDICATOR: Bad indicator byte at start of frame.
+ */
+APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
+  if (frame == nullptr) {
+    HELPER_LOG("Bad argument for try_read_frame_");
+    return APIError::BAD_ARG;
+  }
+
+  // read header
+  while (!rx_header_parsed_) {
+    uint8_t data;
+    ssize_t received = socket_->read(&data, 1);
+    if (received == -1) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        return APIError::WOULD_BLOCK;
+      }
+      state_ = State::FAILED;
+      HELPER_LOG("Socket read failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    } else if (received == 0) {
+      state_ = State::FAILED;
+      HELPER_LOG("Connection closed");
+      return APIError::CONNECTION_CLOSED;
+    }
+    rx_header_buf_.push_back(data);
+
+    // try parse header
+    if (rx_header_buf_[0] != 0x00) {
+      state_ = State::FAILED;
+      HELPER_LOG("Bad indicator byte %u", rx_header_buf_[0]);
+      return APIError::BAD_INDICATOR;
+    }
+
+    size_t i = 1;
+    uint32_t consumed = 0;
+    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[i], rx_header_buf_.size() - i, &consumed);
+    if (!msg_size_varint.has_value()) {
+      // not enough data there yet
+      continue;
+    }
+
+    i += consumed;
+    rx_header_parsed_len_ = msg_size_varint->as_uint32();
+
+    auto msg_type_varint = ProtoVarInt::parse(&rx_header_buf_[i], rx_header_buf_.size() - i, &consumed);
+    if (!msg_type_varint.has_value()) {
+      // not enough data there yet
+      continue;
+    }
+    rx_header_parsed_type_ = msg_type_varint->as_uint32();
+    rx_header_parsed_ = true;
+  }
+  // header reading done
+
+  // reserve space for body
+  if (rx_buf_.size() != rx_header_parsed_len_) {
+    rx_buf_.resize(rx_header_parsed_len_);
+  }
+
+  if (rx_buf_len_ < rx_header_parsed_len_) {
+    // more data to read
+    size_t to_read = rx_header_parsed_len_ - rx_buf_len_;
+    ssize_t received = socket_->read(&rx_buf_[rx_buf_len_], to_read);
+    if (received == -1) {
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        return APIError::WOULD_BLOCK;
+      }
+      state_ = State::FAILED;
+      HELPER_LOG("Socket read failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    } else if (received == 0) {
+      state_ = State::FAILED;
+      HELPER_LOG("Connection closed");
+      return APIError::CONNECTION_CLOSED;
+    }
+    rx_buf_len_ += received;
+    if ((size_t) received != to_read) {
+      // not all read
+      return APIError::WOULD_BLOCK;
+    }
+  }
+
+  // uncomment for even more debugging
+#ifdef HELPER_LOG_PACKETS
+  ESP_LOGVV(TAG, "Received frame: %s", format_hex_pretty(rx_buf_).c_str());
+#endif
+  frame->msg = std::move(rx_buf_);
+  // consume msg
+  rx_buf_ = {};
+  rx_buf_len_ = 0;
+  rx_header_buf_.clear();
+  rx_header_parsed_ = false;
+  return APIError::OK;
+}
+
+APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
+  APIError aerr;
+
+  if (state_ != State::DATA) {
+    return APIError::WOULD_BLOCK;
+  }
+
+  ParsedFrame frame;
+  aerr = try_read_frame_(&frame);
+  if (aerr != APIError::OK)
+    return aerr;
+
+  buffer->container = std::move(frame.msg);
+  buffer->data_offset = 0;
+  buffer->data_len = rx_header_parsed_len_;
+  buffer->type = rx_header_parsed_type_;
+  return APIError::OK;
+}
+bool APIPlaintextFrameHelper::can_write_without_blocking() { return state_ == State::DATA && tx_buf_.empty(); }
+APIError APIPlaintextFrameHelper::write_packet(uint16_t type, const uint8_t *payload, size_t payload_len) {
+  if (state_ != State::DATA) {
+    return APIError::BAD_STATE;
+  }
+
+  std::vector<uint8_t> header;
+  header.push_back(0x00);
+  ProtoVarInt(payload_len).encode(header);
+  ProtoVarInt(type).encode(header);
+
+  struct iovec iov[2];
+  iov[0].iov_base = &header[0];
+  iov[0].iov_len = header.size();
+  if (payload_len == 0) {
+    return write_raw_(iov, 1);
+  }
+  iov[1].iov_base = const_cast<uint8_t *>(payload);
+  iov[1].iov_len = payload_len;
+
+  return write_raw_(iov, 2);
+}
+APIError APIPlaintextFrameHelper::try_send_tx_buf_() {
+  // try send from tx_buf
+  while (state_ != State::CLOSED && !tx_buf_.empty()) {
+    ssize_t sent = socket_->write(tx_buf_.data(), tx_buf_.size());
+    if (is_would_block(sent)) {
+      break;
+    } else if (sent == -1) {
+      state_ = State::FAILED;
+      HELPER_LOG("Socket write failed with errno %d", errno);
+      return APIError::SOCKET_WRITE_FAILED;
+    }
+    // TODO: inefficient if multiple packets in txbuf
+    // replace with deque of buffers
+    tx_buf_.erase(tx_buf_.begin(), tx_buf_.begin() + sent);
+  }
+
+  return APIError::OK;
+}
+/** Write the data to the socket, or buffer it a write would block
+ *
+ * @param data The data to write
+ * @param len The length of data
+ */
+APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
+  if (iovcnt == 0)
+    return APIError::OK;
+  APIError aerr;
+
+  size_t total_write_len = 0;
+  for (int i = 0; i < iovcnt; i++) {
+#ifdef HELPER_LOG_PACKETS
+    ESP_LOGVV(TAG, "Sending raw: %s",
+              format_hex_pretty(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len).c_str());
+#endif
+    total_write_len += iov[i].iov_len;
+  }
+
+  if (!tx_buf_.empty()) {
+    // try to empty tx_buf_ first
+    aerr = try_send_tx_buf_();
+    if (aerr != APIError::OK && aerr != APIError::WOULD_BLOCK)
+      return aerr;
+  }
+
+  if (!tx_buf_.empty()) {
+    // tx buf not empty, can't write now because then stream would be inconsistent
+    for (int i = 0; i < iovcnt; i++) {
+      tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
+                     reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+    }
+    return APIError::OK;
+  }
+
+  ssize_t sent = socket_->writev(iov, iovcnt);
+  if (is_would_block(sent)) {
+    // operation would block, add buffer to tx_buf
+    for (int i = 0; i < iovcnt; i++) {
+      tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
+                     reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+    }
+    return APIError::OK;
+  } else if (sent == -1) {
+    // an error occurred
+    state_ = State::FAILED;
+    HELPER_LOG("Socket write failed with errno %d", errno);
+    return APIError::SOCKET_WRITE_FAILED;
+  } else if ((size_t) sent != total_write_len) {
+    // partially sent, add end to tx_buf
+    size_t to_consume = sent;
+    for (int i = 0; i < iovcnt; i++) {
+      if (to_consume >= iov[i].iov_len) {
+        to_consume -= iov[i].iov_len;
+      } else {
+        tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base) + to_consume,
+                       reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
+        to_consume = 0;
+      }
+    }
+    return APIError::OK;
+  }
+  // fully sent
+  return APIError::OK;
+}
+
+APIError APIPlaintextFrameHelper::close() {
+  state_ = State::CLOSED;
+  int err = socket_->close();
+  if (err == -1)
+    return APIError::CLOSE_FAILED;
+  return APIError::OK;
+}
+APIError APIPlaintextFrameHelper::shutdown(int how) {
+  int err = socket_->shutdown(how);
+  if (err == -1)
+    return APIError::SHUTDOWN_FAILED;
+  if (how == SHUT_RDWR) {
+    state_ = State::CLOSED;
+  }
+  return APIError::OK;
+}
+#endif  // USE_API_PLAINTEXT
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -1,0 +1,192 @@
+#pragma once
+#include <cstdint>
+#include <deque>
+#include <utility>
+#include <vector>
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_API_NOISE
+#include "noise/protocol.h"
+#endif
+
+#include "api_noise_context.h"
+#include "esphome/components/socket/socket.h"
+
+namespace esphome {
+namespace api {
+
+struct ReadPacketBuffer {
+  std::vector<uint8_t> container;
+  uint16_t type;
+  size_t data_offset;
+  size_t data_len;
+};
+
+struct PacketBuffer {
+  const std::vector<uint8_t> container;
+  uint16_t type;
+  uint8_t data_offset;
+  uint8_t data_len;
+};
+
+enum class APIError : int {
+  OK = 0,
+  WOULD_BLOCK = 1001,
+  BAD_HANDSHAKE_PACKET_LEN = 1002,
+  BAD_INDICATOR = 1003,
+  BAD_DATA_PACKET = 1004,
+  TCP_NODELAY_FAILED = 1005,
+  TCP_NONBLOCKING_FAILED = 1006,
+  CLOSE_FAILED = 1007,
+  SHUTDOWN_FAILED = 1008,
+  BAD_STATE = 1009,
+  BAD_ARG = 1010,
+  SOCKET_READ_FAILED = 1011,
+  SOCKET_WRITE_FAILED = 1012,
+  HANDSHAKESTATE_READ_FAILED = 1013,
+  HANDSHAKESTATE_WRITE_FAILED = 1014,
+  HANDSHAKESTATE_BAD_STATE = 1015,
+  CIPHERSTATE_DECRYPT_FAILED = 1016,
+  CIPHERSTATE_ENCRYPT_FAILED = 1017,
+  OUT_OF_MEMORY = 1018,
+  HANDSHAKESTATE_SETUP_FAILED = 1019,
+  HANDSHAKESTATE_SPLIT_FAILED = 1020,
+  BAD_HANDSHAKE_ERROR_BYTE = 1021,
+  CONNECTION_CLOSED = 1022,
+};
+
+const char *api_error_to_str(APIError err);
+
+class APIFrameHelper {
+ public:
+  virtual ~APIFrameHelper() = default;
+  virtual APIError init() = 0;
+  virtual APIError loop() = 0;
+  virtual APIError read_packet(ReadPacketBuffer *buffer) = 0;
+  virtual bool can_write_without_blocking() = 0;
+  virtual APIError write_packet(uint16_t type, const uint8_t *data, size_t len) = 0;
+  virtual std::string getpeername() = 0;
+  virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;
+  virtual APIError close() = 0;
+  virtual APIError shutdown(int how) = 0;
+  // Give this helper a name for logging
+  virtual void set_log_info(std::string info) = 0;
+};
+
+#ifdef USE_API_NOISE
+class APINoiseFrameHelper : public APIFrameHelper {
+ public:
+  APINoiseFrameHelper(std::unique_ptr<socket::Socket> socket, std::shared_ptr<APINoiseContext> ctx)
+      : socket_(std::move(socket)), ctx_(std::move(std::move(ctx))) {}
+  ~APINoiseFrameHelper() override;
+  APIError init() override;
+  APIError loop() override;
+  APIError read_packet(ReadPacketBuffer *buffer) override;
+  bool can_write_without_blocking() override;
+  APIError write_packet(uint16_t type, const uint8_t *payload, size_t len) override;
+  std::string getpeername() override { return this->socket_->getpeername(); }
+  int getpeername(struct sockaddr *addr, socklen_t *addrlen) override {
+    return this->socket_->getpeername(addr, addrlen);
+  }
+  APIError close() override;
+  APIError shutdown(int how) override;
+  // Give this helper a name for logging
+  void set_log_info(std::string info) override { info_ = std::move(info); }
+
+ protected:
+  struct ParsedFrame {
+    std::vector<uint8_t> msg;
+  };
+
+  APIError state_action_();
+  APIError try_read_frame_(ParsedFrame *frame);
+  APIError try_send_tx_buf_();
+  APIError write_frame_(const uint8_t *data, size_t len);
+  APIError write_raw_(const struct iovec *iov, int iovcnt);
+  APIError init_handshake_();
+  APIError check_handshake_finished_();
+  void send_explicit_handshake_reject_(const std::string &reason);
+
+  std::unique_ptr<socket::Socket> socket_;
+
+  std::string info_;
+  uint8_t rx_header_buf_[3];
+  size_t rx_header_buf_len_ = 0;
+  std::vector<uint8_t> rx_buf_;
+  size_t rx_buf_len_ = 0;
+
+  std::vector<uint8_t> tx_buf_;
+  std::vector<uint8_t> prologue_;
+
+  std::shared_ptr<APINoiseContext> ctx_;
+  NoiseHandshakeState *handshake_{nullptr};
+  NoiseCipherState *send_cipher_{nullptr};
+  NoiseCipherState *recv_cipher_{nullptr};
+  NoiseProtocolId nid_;
+
+  enum class State {
+    INITIALIZE = 1,
+    CLIENT_HELLO = 2,
+    SERVER_HELLO = 3,
+    HANDSHAKE = 4,
+    DATA = 5,
+    CLOSED = 6,
+    FAILED = 7,
+    EXPLICIT_REJECT = 8,
+  } state_ = State::INITIALIZE;
+};
+#endif  // USE_API_NOISE
+
+#ifdef USE_API_PLAINTEXT
+class APIPlaintextFrameHelper : public APIFrameHelper {
+ public:
+  APIPlaintextFrameHelper(std::unique_ptr<socket::Socket> socket) : socket_(std::move(socket)) {}
+  ~APIPlaintextFrameHelper() override = default;
+  APIError init() override;
+  APIError loop() override;
+  APIError read_packet(ReadPacketBuffer *buffer) override;
+  bool can_write_without_blocking() override;
+  APIError write_packet(uint16_t type, const uint8_t *payload, size_t len) override;
+  std::string getpeername() override { return this->socket_->getpeername(); }
+  int getpeername(struct sockaddr *addr, socklen_t *addrlen) override {
+    return this->socket_->getpeername(addr, addrlen);
+  }
+  APIError close() override;
+  APIError shutdown(int how) override;
+  // Give this helper a name for logging
+  void set_log_info(std::string info) override { info_ = std::move(info); }
+
+ protected:
+  struct ParsedFrame {
+    std::vector<uint8_t> msg;
+  };
+
+  APIError try_read_frame_(ParsedFrame *frame);
+  APIError try_send_tx_buf_();
+  APIError write_raw_(const struct iovec *iov, int iovcnt);
+
+  std::unique_ptr<socket::Socket> socket_;
+
+  std::string info_;
+  std::vector<uint8_t> rx_header_buf_;
+  bool rx_header_parsed_ = false;
+  uint32_t rx_header_parsed_type_ = 0;
+  uint32_t rx_header_parsed_len_ = 0;
+
+  std::vector<uint8_t> rx_buf_;
+  size_t rx_buf_len_ = 0;
+
+  std::vector<uint8_t> tx_buf_;
+
+  enum class State {
+    INITIALIZE = 1,
+    DATA = 2,
+    CLOSED = 3,
+    FAILED = 4,
+  } state_ = State::INITIALIZE;
+};
+#endif
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_noise_context.h
+++ b/esphome/components/api/api_noise_context.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+#include <array>
+#include "esphome/core/defines.h"
+
+namespace esphome {
+namespace api {
+
+#ifdef USE_API_NOISE
+using psk_t = std::array<uint8_t, 32>;
+
+class APINoiseContext {
+ public:
+  void set_psk(psk_t psk) { psk_ = psk; }
+  const psk_t &get_psk() const { return psk_; }
+
+ protected:
+  psk_t psk_;
+};
+#endif  // USE_API_NOISE
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_options.proto
+++ b/esphome/components/api/api_options.proto
@@ -1,0 +1,24 @@
+syntax = "proto2";
+import "google/protobuf/descriptor.proto";
+
+
+enum APISourceType {
+    SOURCE_BOTH = 0;
+    SOURCE_SERVER = 1;
+    SOURCE_CLIENT = 2;
+}
+
+message void {}
+
+extend google.protobuf.MethodOptions {
+    optional bool needs_setup_connection = 1038 [default=true];
+    optional bool needs_authentication = 1039 [default=true];
+}
+
+extend google.protobuf.MessageOptions {
+    optional uint32 id = 1036 [default=0];
+    optional APISourceType source = 1037 [default=SOURCE_BOTH];
+    optional string ifdef = 1038;
+    optional bool log = 1039 [default=true];
+    optional bool no_delay = 1040 [default=false];
+}

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1,0 +1,8747 @@
+// This file was automatically generated with a tool.
+// See scripts/api_protobuf/api_protobuf.py
+    #include "api_pb2.h"
+    #include "esphome/core/log.h"
+
+    #include <cinttypes>
+
+    namespace esphome {
+    namespace api {
+
+    #ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
+  switch (value) {
+    case enums::ENTITY_CATEGORY_NONE:
+      return "ENTITY_CATEGORY_NONE";
+    case enums::ENTITY_CATEGORY_CONFIG:
+      return "ENTITY_CATEGORY_CONFIG";
+    case enums::ENTITY_CATEGORY_DIAGNOSTIC:
+      return "ENTITY_CATEGORY_DIAGNOSTIC";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::LegacyCoverState>(enums::LegacyCoverState value) {
+  switch (value) {
+    case enums::LEGACY_COVER_STATE_OPEN:
+      return "LEGACY_COVER_STATE_OPEN";
+    case enums::LEGACY_COVER_STATE_CLOSED:
+      return "LEGACY_COVER_STATE_CLOSED";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::CoverOperation>(enums::CoverOperation value) {
+  switch (value) {
+    case enums::COVER_OPERATION_IDLE:
+      return "COVER_OPERATION_IDLE";
+    case enums::COVER_OPERATION_IS_OPENING:
+      return "COVER_OPERATION_IS_OPENING";
+    case enums::COVER_OPERATION_IS_CLOSING:
+      return "COVER_OPERATION_IS_CLOSING";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::LegacyCoverCommand>(enums::LegacyCoverCommand value) {
+  switch (value) {
+    case enums::LEGACY_COVER_COMMAND_OPEN:
+      return "LEGACY_COVER_COMMAND_OPEN";
+    case enums::LEGACY_COVER_COMMAND_CLOSE:
+      return "LEGACY_COVER_COMMAND_CLOSE";
+    case enums::LEGACY_COVER_COMMAND_STOP:
+      return "LEGACY_COVER_COMMAND_STOP";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::FanSpeed>(enums::FanSpeed value) {
+  switch (value) {
+    case enums::FAN_SPEED_LOW:
+      return "FAN_SPEED_LOW";
+    case enums::FAN_SPEED_MEDIUM:
+      return "FAN_SPEED_MEDIUM";
+    case enums::FAN_SPEED_HIGH:
+      return "FAN_SPEED_HIGH";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::FanDirection>(enums::FanDirection value) {
+  switch (value) {
+    case enums::FAN_DIRECTION_FORWARD:
+      return "FAN_DIRECTION_FORWARD";
+    case enums::FAN_DIRECTION_REVERSE:
+      return "FAN_DIRECTION_REVERSE";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ColorMode>(enums::ColorMode value) {
+  switch (value) {
+    case enums::COLOR_MODE_UNKNOWN:
+      return "COLOR_MODE_UNKNOWN";
+    case enums::COLOR_MODE_ON_OFF:
+      return "COLOR_MODE_ON_OFF";
+    case enums::COLOR_MODE_BRIGHTNESS:
+      return "COLOR_MODE_BRIGHTNESS";
+    case enums::COLOR_MODE_WHITE:
+      return "COLOR_MODE_WHITE";
+    case enums::COLOR_MODE_COLOR_TEMPERATURE:
+      return "COLOR_MODE_COLOR_TEMPERATURE";
+    case enums::COLOR_MODE_COLD_WARM_WHITE:
+      return "COLOR_MODE_COLD_WARM_WHITE";
+    case enums::COLOR_MODE_RGB:
+      return "COLOR_MODE_RGB";
+    case enums::COLOR_MODE_RGB_WHITE:
+      return "COLOR_MODE_RGB_WHITE";
+    case enums::COLOR_MODE_RGB_COLOR_TEMPERATURE:
+      return "COLOR_MODE_RGB_COLOR_TEMPERATURE";
+    case enums::COLOR_MODE_RGB_COLD_WARM_WHITE:
+      return "COLOR_MODE_RGB_COLD_WARM_WHITE";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::SensorStateClass>(enums::SensorStateClass value) {
+  switch (value) {
+    case enums::STATE_CLASS_NONE:
+      return "STATE_CLASS_NONE";
+    case enums::STATE_CLASS_MEASUREMENT:
+      return "STATE_CLASS_MEASUREMENT";
+    case enums::STATE_CLASS_TOTAL_INCREASING:
+      return "STATE_CLASS_TOTAL_INCREASING";
+    case enums::STATE_CLASS_TOTAL:
+      return "STATE_CLASS_TOTAL";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::SensorLastResetType>(enums::SensorLastResetType value) {
+  switch (value) {
+    case enums::LAST_RESET_NONE:
+      return "LAST_RESET_NONE";
+    case enums::LAST_RESET_NEVER:
+      return "LAST_RESET_NEVER";
+    case enums::LAST_RESET_AUTO:
+      return "LAST_RESET_AUTO";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::LogLevel>(enums::LogLevel value) {
+  switch (value) {
+    case enums::LOG_LEVEL_NONE:
+      return "LOG_LEVEL_NONE";
+    case enums::LOG_LEVEL_ERROR:
+      return "LOG_LEVEL_ERROR";
+    case enums::LOG_LEVEL_WARN:
+      return "LOG_LEVEL_WARN";
+    case enums::LOG_LEVEL_INFO:
+      return "LOG_LEVEL_INFO";
+    case enums::LOG_LEVEL_CONFIG:
+      return "LOG_LEVEL_CONFIG";
+    case enums::LOG_LEVEL_DEBUG:
+      return "LOG_LEVEL_DEBUG";
+    case enums::LOG_LEVEL_VERBOSE:
+      return "LOG_LEVEL_VERBOSE";
+    case enums::LOG_LEVEL_VERY_VERBOSE:
+      return "LOG_LEVEL_VERY_VERBOSE";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ServiceArgType>(enums::ServiceArgType value) {
+  switch (value) {
+    case enums::SERVICE_ARG_TYPE_BOOL:
+      return "SERVICE_ARG_TYPE_BOOL";
+    case enums::SERVICE_ARG_TYPE_INT:
+      return "SERVICE_ARG_TYPE_INT";
+    case enums::SERVICE_ARG_TYPE_FLOAT:
+      return "SERVICE_ARG_TYPE_FLOAT";
+    case enums::SERVICE_ARG_TYPE_STRING:
+      return "SERVICE_ARG_TYPE_STRING";
+    case enums::SERVICE_ARG_TYPE_BOOL_ARRAY:
+      return "SERVICE_ARG_TYPE_BOOL_ARRAY";
+    case enums::SERVICE_ARG_TYPE_INT_ARRAY:
+      return "SERVICE_ARG_TYPE_INT_ARRAY";
+    case enums::SERVICE_ARG_TYPE_FLOAT_ARRAY:
+      return "SERVICE_ARG_TYPE_FLOAT_ARRAY";
+    case enums::SERVICE_ARG_TYPE_STRING_ARRAY:
+      return "SERVICE_ARG_TYPE_STRING_ARRAY";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ClimateMode>(enums::ClimateMode value) {
+  switch (value) {
+    case enums::CLIMATE_MODE_OFF:
+      return "CLIMATE_MODE_OFF";
+    case enums::CLIMATE_MODE_HEAT_COOL:
+      return "CLIMATE_MODE_HEAT_COOL";
+    case enums::CLIMATE_MODE_COOL:
+      return "CLIMATE_MODE_COOL";
+    case enums::CLIMATE_MODE_HEAT:
+      return "CLIMATE_MODE_HEAT";
+    case enums::CLIMATE_MODE_FAN_ONLY:
+      return "CLIMATE_MODE_FAN_ONLY";
+    case enums::CLIMATE_MODE_DRY:
+      return "CLIMATE_MODE_DRY";
+    case enums::CLIMATE_MODE_AUTO:
+      return "CLIMATE_MODE_AUTO";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ClimateFanMode>(enums::ClimateFanMode value) {
+  switch (value) {
+    case enums::CLIMATE_FAN_ON:
+      return "CLIMATE_FAN_ON";
+    case enums::CLIMATE_FAN_OFF:
+      return "CLIMATE_FAN_OFF";
+    case enums::CLIMATE_FAN_AUTO:
+      return "CLIMATE_FAN_AUTO";
+    case enums::CLIMATE_FAN_LOW:
+      return "CLIMATE_FAN_LOW";
+    case enums::CLIMATE_FAN_MEDIUM:
+      return "CLIMATE_FAN_MEDIUM";
+    case enums::CLIMATE_FAN_HIGH:
+      return "CLIMATE_FAN_HIGH";
+    case enums::CLIMATE_FAN_MIDDLE:
+      return "CLIMATE_FAN_MIDDLE";
+    case enums::CLIMATE_FAN_FOCUS:
+      return "CLIMATE_FAN_FOCUS";
+    case enums::CLIMATE_FAN_DIFFUSE:
+      return "CLIMATE_FAN_DIFFUSE";
+    case enums::CLIMATE_FAN_QUIET:
+      return "CLIMATE_FAN_QUIET";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ClimateSwingMode>(enums::ClimateSwingMode value) {
+  switch (value) {
+    case enums::CLIMATE_SWING_OFF:
+      return "CLIMATE_SWING_OFF";
+    case enums::CLIMATE_SWING_BOTH:
+      return "CLIMATE_SWING_BOTH";
+    case enums::CLIMATE_SWING_VERTICAL:
+      return "CLIMATE_SWING_VERTICAL";
+    case enums::CLIMATE_SWING_HORIZONTAL:
+      return "CLIMATE_SWING_HORIZONTAL";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ClimateAction>(enums::ClimateAction value) {
+  switch (value) {
+    case enums::CLIMATE_ACTION_OFF:
+      return "CLIMATE_ACTION_OFF";
+    case enums::CLIMATE_ACTION_COOLING:
+      return "CLIMATE_ACTION_COOLING";
+    case enums::CLIMATE_ACTION_HEATING:
+      return "CLIMATE_ACTION_HEATING";
+    case enums::CLIMATE_ACTION_IDLE:
+      return "CLIMATE_ACTION_IDLE";
+    case enums::CLIMATE_ACTION_DRYING:
+      return "CLIMATE_ACTION_DRYING";
+    case enums::CLIMATE_ACTION_FAN:
+      return "CLIMATE_ACTION_FAN";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ClimatePreset>(enums::ClimatePreset value) {
+  switch (value) {
+    case enums::CLIMATE_PRESET_NONE:
+      return "CLIMATE_PRESET_NONE";
+    case enums::CLIMATE_PRESET_HOME:
+      return "CLIMATE_PRESET_HOME";
+    case enums::CLIMATE_PRESET_AWAY:
+      return "CLIMATE_PRESET_AWAY";
+    case enums::CLIMATE_PRESET_BOOST:
+      return "CLIMATE_PRESET_BOOST";
+    case enums::CLIMATE_PRESET_COMFORT:
+      return "CLIMATE_PRESET_COMFORT";
+    case enums::CLIMATE_PRESET_ECO:
+      return "CLIMATE_PRESET_ECO";
+    case enums::CLIMATE_PRESET_SLEEP:
+      return "CLIMATE_PRESET_SLEEP";
+    case enums::CLIMATE_PRESET_ACTIVITY:
+      return "CLIMATE_PRESET_ACTIVITY";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::NumberMode>(enums::NumberMode value) {
+  switch (value) {
+    case enums::NUMBER_MODE_AUTO:
+      return "NUMBER_MODE_AUTO";
+    case enums::NUMBER_MODE_BOX:
+      return "NUMBER_MODE_BOX";
+    case enums::NUMBER_MODE_SLIDER:
+      return "NUMBER_MODE_SLIDER";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::LockState>(enums::LockState value) {
+  switch (value) {
+    case enums::LOCK_STATE_NONE:
+      return "LOCK_STATE_NONE";
+    case enums::LOCK_STATE_LOCKED:
+      return "LOCK_STATE_LOCKED";
+    case enums::LOCK_STATE_UNLOCKED:
+      return "LOCK_STATE_UNLOCKED";
+    case enums::LOCK_STATE_JAMMED:
+      return "LOCK_STATE_JAMMED";
+    case enums::LOCK_STATE_LOCKING:
+      return "LOCK_STATE_LOCKING";
+    case enums::LOCK_STATE_UNLOCKING:
+      return "LOCK_STATE_UNLOCKING";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::LockCommand>(enums::LockCommand value) {
+  switch (value) {
+    case enums::LOCK_UNLOCK:
+      return "LOCK_UNLOCK";
+    case enums::LOCK_LOCK:
+      return "LOCK_LOCK";
+    case enums::LOCK_OPEN:
+      return "LOCK_OPEN";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::MediaPlayerState>(enums::MediaPlayerState value) {
+  switch (value) {
+    case enums::MEDIA_PLAYER_STATE_NONE:
+      return "MEDIA_PLAYER_STATE_NONE";
+    case enums::MEDIA_PLAYER_STATE_IDLE:
+      return "MEDIA_PLAYER_STATE_IDLE";
+    case enums::MEDIA_PLAYER_STATE_PLAYING:
+      return "MEDIA_PLAYER_STATE_PLAYING";
+    case enums::MEDIA_PLAYER_STATE_PAUSED:
+      return "MEDIA_PLAYER_STATE_PAUSED";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::MediaPlayerCommand value) {
+  switch (value) {
+    case enums::MEDIA_PLAYER_COMMAND_PLAY:
+      return "MEDIA_PLAYER_COMMAND_PLAY";
+    case enums::MEDIA_PLAYER_COMMAND_PAUSE:
+      return "MEDIA_PLAYER_COMMAND_PAUSE";
+    case enums::MEDIA_PLAYER_COMMAND_STOP:
+      return "MEDIA_PLAYER_COMMAND_STOP";
+    case enums::MEDIA_PLAYER_COMMAND_MUTE:
+      return "MEDIA_PLAYER_COMMAND_MUTE";
+    case enums::MEDIA_PLAYER_COMMAND_UNMUTE:
+      return "MEDIA_PLAYER_COMMAND_UNMUTE";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::MediaPlayerFormatPurpose>(enums::MediaPlayerFormatPurpose value) {
+  switch (value) {
+    case enums::MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT:
+      return "MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT";
+    case enums::MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT:
+      return "MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
+  switch (value) {
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE";
+    case enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE:
+      return "BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::VoiceAssistantSubscribeFlag>(enums::VoiceAssistantSubscribeFlag value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_SUBSCRIBE_NONE:
+      return "VOICE_ASSISTANT_SUBSCRIBE_NONE";
+    case enums::VOICE_ASSISTANT_SUBSCRIBE_API_AUDIO:
+      return "VOICE_ASSISTANT_SUBSCRIBE_API_AUDIO";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::VoiceAssistantRequestFlag>(enums::VoiceAssistantRequestFlag value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_REQUEST_NONE:
+      return "VOICE_ASSISTANT_REQUEST_NONE";
+    case enums::VOICE_ASSISTANT_REQUEST_USE_VAD:
+      return "VOICE_ASSISTANT_REQUEST_USE_VAD";
+    case enums::VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD:
+      return "VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::VoiceAssistantEvent value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_ERROR:
+      return "VOICE_ASSISTANT_ERROR";
+    case enums::VOICE_ASSISTANT_RUN_START:
+      return "VOICE_ASSISTANT_RUN_START";
+    case enums::VOICE_ASSISTANT_RUN_END:
+      return "VOICE_ASSISTANT_RUN_END";
+    case enums::VOICE_ASSISTANT_STT_START:
+      return "VOICE_ASSISTANT_STT_START";
+    case enums::VOICE_ASSISTANT_STT_END:
+      return "VOICE_ASSISTANT_STT_END";
+    case enums::VOICE_ASSISTANT_INTENT_START:
+      return "VOICE_ASSISTANT_INTENT_START";
+    case enums::VOICE_ASSISTANT_INTENT_END:
+      return "VOICE_ASSISTANT_INTENT_END";
+    case enums::VOICE_ASSISTANT_TTS_START:
+      return "VOICE_ASSISTANT_TTS_START";
+    case enums::VOICE_ASSISTANT_TTS_END:
+      return "VOICE_ASSISTANT_TTS_END";
+    case enums::VOICE_ASSISTANT_WAKE_WORD_START:
+      return "VOICE_ASSISTANT_WAKE_WORD_START";
+    case enums::VOICE_ASSISTANT_WAKE_WORD_END:
+      return "VOICE_ASSISTANT_WAKE_WORD_END";
+    case enums::VOICE_ASSISTANT_STT_VAD_START:
+      return "VOICE_ASSISTANT_STT_VAD_START";
+    case enums::VOICE_ASSISTANT_STT_VAD_END:
+      return "VOICE_ASSISTANT_STT_VAD_END";
+    case enums::VOICE_ASSISTANT_TTS_STREAM_START:
+      return "VOICE_ASSISTANT_TTS_STREAM_START";
+    case enums::VOICE_ASSISTANT_TTS_STREAM_END:
+      return "VOICE_ASSISTANT_TTS_STREAM_END";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::VoiceAssistantTimerEvent>(enums::VoiceAssistantTimerEvent value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_TIMER_STARTED:
+      return "VOICE_ASSISTANT_TIMER_STARTED";
+    case enums::VOICE_ASSISTANT_TIMER_UPDATED:
+      return "VOICE_ASSISTANT_TIMER_UPDATED";
+    case enums::VOICE_ASSISTANT_TIMER_CANCELLED:
+      return "VOICE_ASSISTANT_TIMER_CANCELLED";
+    case enums::VOICE_ASSISTANT_TIMER_FINISHED:
+      return "VOICE_ASSISTANT_TIMER_FINISHED";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::AlarmControlPanelState>(enums::AlarmControlPanelState value) {
+  switch (value) {
+    case enums::ALARM_STATE_DISARMED:
+      return "ALARM_STATE_DISARMED";
+    case enums::ALARM_STATE_ARMED_HOME:
+      return "ALARM_STATE_ARMED_HOME";
+    case enums::ALARM_STATE_ARMED_AWAY:
+      return "ALARM_STATE_ARMED_AWAY";
+    case enums::ALARM_STATE_ARMED_NIGHT:
+      return "ALARM_STATE_ARMED_NIGHT";
+    case enums::ALARM_STATE_ARMED_VACATION:
+      return "ALARM_STATE_ARMED_VACATION";
+    case enums::ALARM_STATE_ARMED_CUSTOM_BYPASS:
+      return "ALARM_STATE_ARMED_CUSTOM_BYPASS";
+    case enums::ALARM_STATE_PENDING:
+      return "ALARM_STATE_PENDING";
+    case enums::ALARM_STATE_ARMING:
+      return "ALARM_STATE_ARMING";
+    case enums::ALARM_STATE_DISARMING:
+      return "ALARM_STATE_DISARMING";
+    case enums::ALARM_STATE_TRIGGERED:
+      return "ALARM_STATE_TRIGGERED";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::AlarmControlPanelStateCommand>(enums::AlarmControlPanelStateCommand value) {
+  switch (value) {
+    case enums::ALARM_CONTROL_PANEL_DISARM:
+      return "ALARM_CONTROL_PANEL_DISARM";
+    case enums::ALARM_CONTROL_PANEL_ARM_AWAY:
+      return "ALARM_CONTROL_PANEL_ARM_AWAY";
+    case enums::ALARM_CONTROL_PANEL_ARM_HOME:
+      return "ALARM_CONTROL_PANEL_ARM_HOME";
+    case enums::ALARM_CONTROL_PANEL_ARM_NIGHT:
+      return "ALARM_CONTROL_PANEL_ARM_NIGHT";
+    case enums::ALARM_CONTROL_PANEL_ARM_VACATION:
+      return "ALARM_CONTROL_PANEL_ARM_VACATION";
+    case enums::ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS:
+      return "ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS";
+    case enums::ALARM_CONTROL_PANEL_TRIGGER:
+      return "ALARM_CONTROL_PANEL_TRIGGER";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::TextMode>(enums::TextMode value) {
+  switch (value) {
+    case enums::TEXT_MODE_TEXT:
+      return "TEXT_MODE_TEXT";
+    case enums::TEXT_MODE_PASSWORD:
+      return "TEXT_MODE_PASSWORD";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::ValveOperation>(enums::ValveOperation value) {
+  switch (value) {
+    case enums::VALVE_OPERATION_IDLE:
+      return "VALVE_OPERATION_IDLE";
+    case enums::VALVE_OPERATION_IS_OPENING:
+      return "VALVE_OPERATION_IS_OPENING";
+    case enums::VALVE_OPERATION_IS_CLOSING:
+      return "VALVE_OPERATION_IS_CLOSING";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateCommand value) {
+  switch (value) {
+    case enums::UPDATE_COMMAND_NONE:
+      return "UPDATE_COMMAND_NONE";
+    case enums::UPDATE_COMMAND_UPDATE:
+      return "UPDATE_COMMAND_UPDATE";
+    case enums::UPDATE_COMMAND_CHECK:
+      return "UPDATE_COMMAND_CHECK";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->api_version_major = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->api_version_minor = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->client_info = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void HelloRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->client_info);
+  buffer.encode_uint32(2, this->api_version_major);
+  buffer.encode_uint32(3, this->api_version_minor);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void HelloRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("HelloRequest {\n");
+  out.append("  client_info: ");
+  out.append("'").append(this->client_info).append("'");
+  out.append("\n");
+
+  out.append("  api_version_major: ");
+  sprintf(buffer, "%" PRIu32, this->api_version_major);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  api_version_minor: ");
+  sprintf(buffer, "%" PRIu32, this->api_version_minor);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool HelloResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->api_version_major = value.as_uint32();
+      return true;
+    }
+    case 2: {
+      this->api_version_minor = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool HelloResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->server_info = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->name = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void HelloResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint32(1, this->api_version_major);
+  buffer.encode_uint32(2, this->api_version_minor);
+  buffer.encode_string(3, this->server_info);
+  buffer.encode_string(4, this->name);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void HelloResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("HelloResponse {\n");
+  out.append("  api_version_major: ");
+  sprintf(buffer, "%" PRIu32, this->api_version_major);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  api_version_minor: ");
+  sprintf(buffer, "%" PRIu32, this->api_version_minor);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  server_info: ");
+  out.append("'").append(this->server_info).append("'");
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->password = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ConnectRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ConnectRequest {\n");
+  out.append("  password: ");
+  out.append("'").append(this->password).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->invalid_password = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ConnectResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ConnectResponse {\n");
+  out.append("  invalid_password: ");
+  out.append(YESNO(this->invalid_password));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void DisconnectRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
+#endif
+void DisconnectResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
+#endif
+void PingRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
+#endif
+void PingResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}"); }
+#endif
+void DeviceInfoRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
+#endif
+bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->uses_password = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->has_deep_sleep = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->webserver_port = value.as_uint32();
+      return true;
+    }
+    case 11: {
+      this->legacy_bluetooth_proxy_version = value.as_uint32();
+      return true;
+    }
+    case 15: {
+      this->bluetooth_proxy_feature_flags = value.as_uint32();
+      return true;
+    }
+    case 14: {
+      this->legacy_voice_assistant_version = value.as_uint32();
+      return true;
+    }
+    case 17: {
+      this->voice_assistant_feature_flags = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool DeviceInfoResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->mac_address = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->esphome_version = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->compilation_time = value.as_string();
+      return true;
+    }
+    case 6: {
+      this->model = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->project_name = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->project_version = value.as_string();
+      return true;
+    }
+    case 12: {
+      this->manufacturer = value.as_string();
+      return true;
+    }
+    case 13: {
+      this->friendly_name = value.as_string();
+      return true;
+    }
+    case 16: {
+      this->suggested_area = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_bool(1, this->uses_password);
+  buffer.encode_string(2, this->name);
+  buffer.encode_string(3, this->mac_address);
+  buffer.encode_string(4, this->esphome_version);
+  buffer.encode_string(5, this->compilation_time);
+  buffer.encode_string(6, this->model);
+  buffer.encode_bool(7, this->has_deep_sleep);
+  buffer.encode_string(8, this->project_name);
+  buffer.encode_string(9, this->project_version);
+  buffer.encode_uint32(10, this->webserver_port);
+  buffer.encode_uint32(11, this->legacy_bluetooth_proxy_version);
+  buffer.encode_uint32(15, this->bluetooth_proxy_feature_flags);
+  buffer.encode_string(12, this->manufacturer);
+  buffer.encode_string(13, this->friendly_name);
+  buffer.encode_uint32(14, this->legacy_voice_assistant_version);
+  buffer.encode_uint32(17, this->voice_assistant_feature_flags);
+  buffer.encode_string(16, this->suggested_area);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DeviceInfoResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("DeviceInfoResponse {\n");
+  out.append("  uses_password: ");
+  out.append(YESNO(this->uses_password));
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  mac_address: ");
+  out.append("'").append(this->mac_address).append("'");
+  out.append("\n");
+
+  out.append("  esphome_version: ");
+  out.append("'").append(this->esphome_version).append("'");
+  out.append("\n");
+
+  out.append("  compilation_time: ");
+  out.append("'").append(this->compilation_time).append("'");
+  out.append("\n");
+
+  out.append("  model: ");
+  out.append("'").append(this->model).append("'");
+  out.append("\n");
+
+  out.append("  has_deep_sleep: ");
+  out.append(YESNO(this->has_deep_sleep));
+  out.append("\n");
+
+  out.append("  project_name: ");
+  out.append("'").append(this->project_name).append("'");
+  out.append("\n");
+
+  out.append("  project_version: ");
+  out.append("'").append(this->project_version).append("'");
+  out.append("\n");
+
+  out.append("  webserver_port: ");
+  sprintf(buffer, "%" PRIu32, this->webserver_port);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  legacy_bluetooth_proxy_version: ");
+  sprintf(buffer, "%" PRIu32, this->legacy_bluetooth_proxy_version);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  bluetooth_proxy_feature_flags: ");
+  sprintf(buffer, "%" PRIu32, this->bluetooth_proxy_feature_flags);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  manufacturer: ");
+  out.append("'").append(this->manufacturer).append("'");
+  out.append("\n");
+
+  out.append("  friendly_name: ");
+  out.append("'").append(this->friendly_name).append("'");
+  out.append("\n");
+
+  out.append("  legacy_voice_assistant_version: ");
+  sprintf(buffer, "%" PRIu32, this->legacy_voice_assistant_version);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  voice_assistant_feature_flags: ");
+  sprintf(buffer, "%" PRIu32, this->voice_assistant_feature_flags);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  suggested_area: ");
+  out.append("'").append(this->suggested_area).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void ListEntitiesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesRequest::dump_to(std::string &out) const { out.append("ListEntitiesRequest {}"); }
+#endif
+void ListEntitiesDoneResponse::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("ListEntitiesDoneResponse {}"); }
+#endif
+void SubscribeStatesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
+#endif
+bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->is_status_binary_sensor = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 9: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesBinarySensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesBinarySensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->device_class);
+  buffer.encode_bool(6, this->is_status_binary_sensor);
+  buffer.encode_bool(7, this->disabled_by_default);
+  buffer.encode_string(8, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(9, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesBinarySensorResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+
+  out.append("  is_status_binary_sensor: ");
+  out.append(YESNO(this->is_status_binary_sensor));
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BinarySensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BinarySensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BinarySensorStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BinarySensorStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5: {
+      this->assumed_state = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->supports_position = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->supports_tilt = value.as_bool();
+      return true;
+    }
+    case 9: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 12: {
+      this->supports_stop = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesCoverResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    case 10: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesCoverResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_bool(5, this->assumed_state);
+  buffer.encode_bool(6, this->supports_position);
+  buffer.encode_bool(7, this->supports_tilt);
+  buffer.encode_string(8, this->device_class);
+  buffer.encode_bool(9, this->disabled_by_default);
+  buffer.encode_string(10, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(11, this->entity_category);
+  buffer.encode_bool(12, this->supports_stop);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesCoverResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesCoverResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  assumed_state: ");
+  out.append(YESNO(this->assumed_state));
+  out.append("\n");
+
+  out.append("  supports_position: ");
+  out.append(YESNO(this->supports_position));
+  out.append("\n");
+
+  out.append("  supports_tilt: ");
+  out.append(YESNO(this->supports_tilt));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  supports_stop: ");
+  out.append(YESNO(this->supports_stop));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->legacy_state = value.as_enum<enums::LegacyCoverState>();
+      return true;
+    }
+    case 5: {
+      this->current_operation = value.as_enum<enums::CoverOperation>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool CoverStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->position = value.as_float();
+      return true;
+    }
+    case 4: {
+      this->tilt = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::LegacyCoverState>(2, this->legacy_state);
+  buffer.encode_float(3, this->position);
+  buffer.encode_float(4, this->tilt);
+  buffer.encode_enum<enums::CoverOperation>(5, this->current_operation);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void CoverStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("CoverStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  legacy_state: ");
+  out.append(proto_enum_to_string<enums::LegacyCoverState>(this->legacy_state));
+  out.append("\n");
+
+  out.append("  position: ");
+  sprintf(buffer, "%g", this->position);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  tilt: ");
+  sprintf(buffer, "%g", this->tilt);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  current_operation: ");
+  out.append(proto_enum_to_string<enums::CoverOperation>(this->current_operation));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_legacy_command = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->legacy_command = value.as_enum<enums::LegacyCoverCommand>();
+      return true;
+    }
+    case 4: {
+      this->has_position = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->has_tilt = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->stop = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->position = value.as_float();
+      return true;
+    }
+    case 7: {
+      this->tilt = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_legacy_command);
+  buffer.encode_enum<enums::LegacyCoverCommand>(3, this->legacy_command);
+  buffer.encode_bool(4, this->has_position);
+  buffer.encode_float(5, this->position);
+  buffer.encode_bool(6, this->has_tilt);
+  buffer.encode_float(7, this->tilt);
+  buffer.encode_bool(8, this->stop);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void CoverCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("CoverCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_legacy_command: ");
+  out.append(YESNO(this->has_legacy_command));
+  out.append("\n");
+
+  out.append("  legacy_command: ");
+  out.append(proto_enum_to_string<enums::LegacyCoverCommand>(this->legacy_command));
+  out.append("\n");
+
+  out.append("  has_position: ");
+  out.append(YESNO(this->has_position));
+  out.append("\n");
+
+  out.append("  position: ");
+  sprintf(buffer, "%g", this->position);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_tilt: ");
+  out.append(YESNO(this->has_tilt));
+  out.append("\n");
+
+  out.append("  tilt: ");
+  sprintf(buffer, "%g", this->tilt);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  stop: ");
+  out.append(YESNO(this->stop));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesFanResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5: {
+      this->supports_oscillation = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->supports_speed = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->supports_direction = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->supported_speed_count = value.as_int32();
+      return true;
+    }
+    case 9: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesFanResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 10: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 12: {
+      this->supported_preset_modes.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesFanResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_bool(5, this->supports_oscillation);
+  buffer.encode_bool(6, this->supports_speed);
+  buffer.encode_bool(7, this->supports_direction);
+  buffer.encode_int32(8, this->supported_speed_count);
+  buffer.encode_bool(9, this->disabled_by_default);
+  buffer.encode_string(10, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(11, this->entity_category);
+  for (auto &it : this->supported_preset_modes) {
+    buffer.encode_string(12, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesFanResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesFanResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  supports_oscillation: ");
+  out.append(YESNO(this->supports_oscillation));
+  out.append("\n");
+
+  out.append("  supports_speed: ");
+  out.append(YESNO(this->supports_speed));
+  out.append("\n");
+
+  out.append("  supports_direction: ");
+  out.append(YESNO(this->supports_direction));
+  out.append("\n");
+
+  out.append("  supported_speed_count: ");
+  sprintf(buffer, "%" PRId32, this->supported_speed_count);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  for (const auto &it : this->supported_preset_modes) {
+    out.append("  supported_preset_modes: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->oscillating = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->speed = value.as_enum<enums::FanSpeed>();
+      return true;
+    }
+    case 5: {
+      this->direction = value.as_enum<enums::FanDirection>();
+      return true;
+    }
+    case 6: {
+      this->speed_level = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool FanStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 7: {
+      this->preset_mode = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool FanStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->state);
+  buffer.encode_bool(3, this->oscillating);
+  buffer.encode_enum<enums::FanSpeed>(4, this->speed);
+  buffer.encode_enum<enums::FanDirection>(5, this->direction);
+  buffer.encode_int32(6, this->speed_level);
+  buffer.encode_string(7, this->preset_mode);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void FanStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("FanStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  oscillating: ");
+  out.append(YESNO(this->oscillating));
+  out.append("\n");
+
+  out.append("  speed: ");
+  out.append(proto_enum_to_string<enums::FanSpeed>(this->speed));
+  out.append("\n");
+
+  out.append("  direction: ");
+  out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
+  out.append("\n");
+
+  out.append("  speed_level: ");
+  sprintf(buffer, "%" PRId32, this->speed_level);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  preset_mode: ");
+  out.append("'").append(this->preset_mode).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->state = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->has_speed = value.as_bool();
+      return true;
+    }
+    case 5: {
+      this->speed = value.as_enum<enums::FanSpeed>();
+      return true;
+    }
+    case 6: {
+      this->has_oscillating = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->oscillating = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->has_direction = value.as_bool();
+      return true;
+    }
+    case 9: {
+      this->direction = value.as_enum<enums::FanDirection>();
+      return true;
+    }
+    case 10: {
+      this->has_speed_level = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->speed_level = value.as_int32();
+      return true;
+    }
+    case 12: {
+      this->has_preset_mode = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool FanCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 13: {
+      this->preset_mode = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_state);
+  buffer.encode_bool(3, this->state);
+  buffer.encode_bool(4, this->has_speed);
+  buffer.encode_enum<enums::FanSpeed>(5, this->speed);
+  buffer.encode_bool(6, this->has_oscillating);
+  buffer.encode_bool(7, this->oscillating);
+  buffer.encode_bool(8, this->has_direction);
+  buffer.encode_enum<enums::FanDirection>(9, this->direction);
+  buffer.encode_bool(10, this->has_speed_level);
+  buffer.encode_int32(11, this->speed_level);
+  buffer.encode_bool(12, this->has_preset_mode);
+  buffer.encode_string(13, this->preset_mode);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void FanCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("FanCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_state: ");
+  out.append(YESNO(this->has_state));
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  has_speed: ");
+  out.append(YESNO(this->has_speed));
+  out.append("\n");
+
+  out.append("  speed: ");
+  out.append(proto_enum_to_string<enums::FanSpeed>(this->speed));
+  out.append("\n");
+
+  out.append("  has_oscillating: ");
+  out.append(YESNO(this->has_oscillating));
+  out.append("\n");
+
+  out.append("  oscillating: ");
+  out.append(YESNO(this->oscillating));
+  out.append("\n");
+
+  out.append("  has_direction: ");
+  out.append(YESNO(this->has_direction));
+  out.append("\n");
+
+  out.append("  direction: ");
+  out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
+  out.append("\n");
+
+  out.append("  has_speed_level: ");
+  out.append(YESNO(this->has_speed_level));
+  out.append("\n");
+
+  out.append("  speed_level: ");
+  sprintf(buffer, "%" PRId32, this->speed_level);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_preset_mode: ");
+  out.append(YESNO(this->has_preset_mode));
+  out.append("\n");
+
+  out.append("  preset_mode: ");
+  out.append("'").append(this->preset_mode).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 12: {
+      this->supported_color_modes.push_back(value.as_enum<enums::ColorMode>());
+      return true;
+    }
+    case 5: {
+      this->legacy_supports_brightness = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->legacy_supports_rgb = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->legacy_supports_white_value = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->legacy_supports_color_temperature = value.as_bool();
+      return true;
+    }
+    case 13: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 15: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesLightResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 11: {
+      this->effects.push_back(value.as_string());
+      return true;
+    }
+    case 14: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesLightResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 9: {
+      this->min_mireds = value.as_float();
+      return true;
+    }
+    case 10: {
+      this->max_mireds = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  for (auto &it : this->supported_color_modes) {
+    buffer.encode_enum<enums::ColorMode>(12, it, true);
+  }
+  buffer.encode_bool(5, this->legacy_supports_brightness);
+  buffer.encode_bool(6, this->legacy_supports_rgb);
+  buffer.encode_bool(7, this->legacy_supports_white_value);
+  buffer.encode_bool(8, this->legacy_supports_color_temperature);
+  buffer.encode_float(9, this->min_mireds);
+  buffer.encode_float(10, this->max_mireds);
+  for (auto &it : this->effects) {
+    buffer.encode_string(11, it, true);
+  }
+  buffer.encode_bool(13, this->disabled_by_default);
+  buffer.encode_string(14, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(15, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesLightResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesLightResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->supported_color_modes) {
+    out.append("  supported_color_modes: ");
+    out.append(proto_enum_to_string<enums::ColorMode>(it));
+    out.append("\n");
+  }
+
+  out.append("  legacy_supports_brightness: ");
+  out.append(YESNO(this->legacy_supports_brightness));
+  out.append("\n");
+
+  out.append("  legacy_supports_rgb: ");
+  out.append(YESNO(this->legacy_supports_rgb));
+  out.append("\n");
+
+  out.append("  legacy_supports_white_value: ");
+  out.append(YESNO(this->legacy_supports_white_value));
+  out.append("\n");
+
+  out.append("  legacy_supports_color_temperature: ");
+  out.append(YESNO(this->legacy_supports_color_temperature));
+  out.append("\n");
+
+  out.append("  min_mireds: ");
+  sprintf(buffer, "%g", this->min_mireds);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  max_mireds: ");
+  sprintf(buffer, "%g", this->max_mireds);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->effects) {
+    out.append("  effects: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->color_mode = value.as_enum<enums::ColorMode>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LightStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 9: {
+      this->effect = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LightStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->brightness = value.as_float();
+      return true;
+    }
+    case 10: {
+      this->color_brightness = value.as_float();
+      return true;
+    }
+    case 4: {
+      this->red = value.as_float();
+      return true;
+    }
+    case 5: {
+      this->green = value.as_float();
+      return true;
+    }
+    case 6: {
+      this->blue = value.as_float();
+      return true;
+    }
+    case 7: {
+      this->white = value.as_float();
+      return true;
+    }
+    case 8: {
+      this->color_temperature = value.as_float();
+      return true;
+    }
+    case 12: {
+      this->cold_white = value.as_float();
+      return true;
+    }
+    case 13: {
+      this->warm_white = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->state);
+  buffer.encode_float(3, this->brightness);
+  buffer.encode_enum<enums::ColorMode>(11, this->color_mode);
+  buffer.encode_float(10, this->color_brightness);
+  buffer.encode_float(4, this->red);
+  buffer.encode_float(5, this->green);
+  buffer.encode_float(6, this->blue);
+  buffer.encode_float(7, this->white);
+  buffer.encode_float(8, this->color_temperature);
+  buffer.encode_float(12, this->cold_white);
+  buffer.encode_float(13, this->warm_white);
+  buffer.encode_string(9, this->effect);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void LightStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("LightStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  brightness: ");
+  sprintf(buffer, "%g", this->brightness);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  color_mode: ");
+  out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
+  out.append("\n");
+
+  out.append("  color_brightness: ");
+  sprintf(buffer, "%g", this->color_brightness);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  red: ");
+  sprintf(buffer, "%g", this->red);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  green: ");
+  sprintf(buffer, "%g", this->green);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  blue: ");
+  sprintf(buffer, "%g", this->blue);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  white: ");
+  sprintf(buffer, "%g", this->white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  color_temperature: ");
+  sprintf(buffer, "%g", this->color_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  cold_white: ");
+  sprintf(buffer, "%g", this->cold_white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  warm_white: ");
+  sprintf(buffer, "%g", this->warm_white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  effect: ");
+  out.append("'").append(this->effect).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->state = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->has_brightness = value.as_bool();
+      return true;
+    }
+    case 22: {
+      this->has_color_mode = value.as_bool();
+      return true;
+    }
+    case 23: {
+      this->color_mode = value.as_enum<enums::ColorMode>();
+      return true;
+    }
+    case 20: {
+      this->has_color_brightness = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->has_rgb = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->has_white = value.as_bool();
+      return true;
+    }
+    case 12: {
+      this->has_color_temperature = value.as_bool();
+      return true;
+    }
+    case 24: {
+      this->has_cold_white = value.as_bool();
+      return true;
+    }
+    case 26: {
+      this->has_warm_white = value.as_bool();
+      return true;
+    }
+    case 14: {
+      this->has_transition_length = value.as_bool();
+      return true;
+    }
+    case 15: {
+      this->transition_length = value.as_uint32();
+      return true;
+    }
+    case 16: {
+      this->has_flash_length = value.as_bool();
+      return true;
+    }
+    case 17: {
+      this->flash_length = value.as_uint32();
+      return true;
+    }
+    case 18: {
+      this->has_effect = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LightCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 19: {
+      this->effect = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->brightness = value.as_float();
+      return true;
+    }
+    case 21: {
+      this->color_brightness = value.as_float();
+      return true;
+    }
+    case 7: {
+      this->red = value.as_float();
+      return true;
+    }
+    case 8: {
+      this->green = value.as_float();
+      return true;
+    }
+    case 9: {
+      this->blue = value.as_float();
+      return true;
+    }
+    case 11: {
+      this->white = value.as_float();
+      return true;
+    }
+    case 13: {
+      this->color_temperature = value.as_float();
+      return true;
+    }
+    case 25: {
+      this->cold_white = value.as_float();
+      return true;
+    }
+    case 27: {
+      this->warm_white = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_state);
+  buffer.encode_bool(3, this->state);
+  buffer.encode_bool(4, this->has_brightness);
+  buffer.encode_float(5, this->brightness);
+  buffer.encode_bool(22, this->has_color_mode);
+  buffer.encode_enum<enums::ColorMode>(23, this->color_mode);
+  buffer.encode_bool(20, this->has_color_brightness);
+  buffer.encode_float(21, this->color_brightness);
+  buffer.encode_bool(6, this->has_rgb);
+  buffer.encode_float(7, this->red);
+  buffer.encode_float(8, this->green);
+  buffer.encode_float(9, this->blue);
+  buffer.encode_bool(10, this->has_white);
+  buffer.encode_float(11, this->white);
+  buffer.encode_bool(12, this->has_color_temperature);
+  buffer.encode_float(13, this->color_temperature);
+  buffer.encode_bool(24, this->has_cold_white);
+  buffer.encode_float(25, this->cold_white);
+  buffer.encode_bool(26, this->has_warm_white);
+  buffer.encode_float(27, this->warm_white);
+  buffer.encode_bool(14, this->has_transition_length);
+  buffer.encode_uint32(15, this->transition_length);
+  buffer.encode_bool(16, this->has_flash_length);
+  buffer.encode_uint32(17, this->flash_length);
+  buffer.encode_bool(18, this->has_effect);
+  buffer.encode_string(19, this->effect);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void LightCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("LightCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_state: ");
+  out.append(YESNO(this->has_state));
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  has_brightness: ");
+  out.append(YESNO(this->has_brightness));
+  out.append("\n");
+
+  out.append("  brightness: ");
+  sprintf(buffer, "%g", this->brightness);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_color_mode: ");
+  out.append(YESNO(this->has_color_mode));
+  out.append("\n");
+
+  out.append("  color_mode: ");
+  out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
+  out.append("\n");
+
+  out.append("  has_color_brightness: ");
+  out.append(YESNO(this->has_color_brightness));
+  out.append("\n");
+
+  out.append("  color_brightness: ");
+  sprintf(buffer, "%g", this->color_brightness);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_rgb: ");
+  out.append(YESNO(this->has_rgb));
+  out.append("\n");
+
+  out.append("  red: ");
+  sprintf(buffer, "%g", this->red);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  green: ");
+  sprintf(buffer, "%g", this->green);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  blue: ");
+  sprintf(buffer, "%g", this->blue);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_white: ");
+  out.append(YESNO(this->has_white));
+  out.append("\n");
+
+  out.append("  white: ");
+  sprintf(buffer, "%g", this->white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_color_temperature: ");
+  out.append(YESNO(this->has_color_temperature));
+  out.append("\n");
+
+  out.append("  color_temperature: ");
+  sprintf(buffer, "%g", this->color_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_cold_white: ");
+  out.append(YESNO(this->has_cold_white));
+  out.append("\n");
+
+  out.append("  cold_white: ");
+  sprintf(buffer, "%g", this->cold_white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_warm_white: ");
+  out.append(YESNO(this->has_warm_white));
+  out.append("\n");
+
+  out.append("  warm_white: ");
+  sprintf(buffer, "%g", this->warm_white);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_transition_length: ");
+  out.append(YESNO(this->has_transition_length));
+  out.append("\n");
+
+  out.append("  transition_length: ");
+  sprintf(buffer, "%" PRIu32, this->transition_length);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_flash_length: ");
+  out.append(YESNO(this->has_flash_length));
+  out.append("\n");
+
+  out.append("  flash_length: ");
+  sprintf(buffer, "%" PRIu32, this->flash_length);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_effect: ");
+  out.append(YESNO(this->has_effect));
+  out.append("\n");
+
+  out.append("  effect: ");
+  out.append("'").append(this->effect).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 7: {
+      this->accuracy_decimals = value.as_int32();
+      return true;
+    }
+    case 8: {
+      this->force_update = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->state_class = value.as_enum<enums::SensorStateClass>();
+      return true;
+    }
+    case 11: {
+      this->legacy_last_reset_type = value.as_enum<enums::SensorLastResetType>();
+      return true;
+    }
+    case 12: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 13: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 6: {
+      this->unit_of_measurement = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_string(6, this->unit_of_measurement);
+  buffer.encode_int32(7, this->accuracy_decimals);
+  buffer.encode_bool(8, this->force_update);
+  buffer.encode_string(9, this->device_class);
+  buffer.encode_enum<enums::SensorStateClass>(10, this->state_class);
+  buffer.encode_enum<enums::SensorLastResetType>(11, this->legacy_last_reset_type);
+  buffer.encode_bool(12, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(13, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesSensorResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesSensorResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  unit_of_measurement: ");
+  out.append("'").append(this->unit_of_measurement).append("'");
+  out.append("\n");
+
+  out.append("  accuracy_decimals: ");
+  sprintf(buffer, "%" PRId32, this->accuracy_decimals);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  force_update: ");
+  out.append(YESNO(this->force_update));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+
+  out.append("  state_class: ");
+  out.append(proto_enum_to_string<enums::SensorStateClass>(this->state_class));
+  out.append("\n");
+
+  out.append("  legacy_last_reset_type: ");
+  out.append(proto_enum_to_string<enums::SensorLastResetType>(this->legacy_last_reset_type));
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 2: {
+      this->state = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_float(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SensorStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SensorStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  sprintf(buffer, "%g", this->state);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesSwitchResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->assumed_state = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSwitchResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSwitchResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->assumed_state);
+  buffer.encode_bool(7, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(8, this->entity_category);
+  buffer.encode_string(9, this->device_class);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesSwitchResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  assumed_state: ");
+  out.append(YESNO(this->assumed_state));
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SwitchStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SwitchStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SwitchStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SwitchStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SwitchCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SwitchCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(YESNO(this->state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesTextSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTextSensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTextSensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesTextSensorResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool TextSensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TextSensorStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TextSensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void TextSensorStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("TextSensorStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->level = value.as_enum<enums::LogLevel>();
+      return true;
+    }
+    case 2: {
+      this->dump_config = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::LogLevel>(1, this->level);
+  buffer.encode_bool(2, this->dump_config);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeLogsRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SubscribeLogsRequest {\n");
+  out.append("  level: ");
+  out.append(proto_enum_to_string<enums::LogLevel>(this->level));
+  out.append("\n");
+
+  out.append("  dump_config: ");
+  out.append(YESNO(this->dump_config));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SubscribeLogsResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->level = value.as_enum<enums::LogLevel>();
+      return true;
+    }
+    case 4: {
+      this->send_failed = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SubscribeLogsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->message = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::LogLevel>(1, this->level);
+  buffer.encode_string(3, this->message);
+  buffer.encode_bool(4, this->send_failed);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeLogsResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SubscribeLogsResponse {\n");
+  out.append("  level: ");
+  out.append(proto_enum_to_string<enums::LogLevel>(this->level));
+  out.append("\n");
+
+  out.append("  message: ");
+  out.append("'").append(this->message).append("'");
+  out.append("\n");
+
+  out.append("  send_failed: ");
+  out.append(YESNO(this->send_failed));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void SubscribeHomeassistantServicesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
+  out.append("SubscribeHomeassistantServicesRequest {}");
+}
+#endif
+bool HomeassistantServiceMap::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->value = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->key);
+  buffer.encode_string(2, this->value);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void HomeassistantServiceMap::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("HomeassistantServiceMap {\n");
+  out.append("  key: ");
+  out.append("'").append(this->key).append("'");
+  out.append("\n");
+
+  out.append("  value: ");
+  out.append("'").append(this->value).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool HomeassistantServiceResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5: {
+      this->is_event = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool HomeassistantServiceResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->service = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->data.push_back(value.as_message<HomeassistantServiceMap>());
+      return true;
+    }
+    case 3: {
+      this->data_template.push_back(value.as_message<HomeassistantServiceMap>());
+      return true;
+    }
+    case 4: {
+      this->variables.push_back(value.as_message<HomeassistantServiceMap>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->service);
+  for (auto &it : this->data) {
+    buffer.encode_message<HomeassistantServiceMap>(2, it, true);
+  }
+  for (auto &it : this->data_template) {
+    buffer.encode_message<HomeassistantServiceMap>(3, it, true);
+  }
+  for (auto &it : this->variables) {
+    buffer.encode_message<HomeassistantServiceMap>(4, it, true);
+  }
+  buffer.encode_bool(5, this->is_event);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void HomeassistantServiceResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("HomeassistantServiceResponse {\n");
+  out.append("  service: ");
+  out.append("'").append(this->service).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->data) {
+    out.append("  data: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  for (const auto &it : this->data_template) {
+    out.append("  data_template: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  for (const auto &it : this->variables) {
+    out.append("  variables: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  out.append("  is_event: ");
+  out.append(YESNO(this->is_event));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void SubscribeHomeAssistantStatesRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
+  out.append("SubscribeHomeAssistantStatesRequest {}");
+}
+#endif
+bool SubscribeHomeAssistantStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->once = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SubscribeHomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->entity_id = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->attribute = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->entity_id);
+  buffer.encode_string(2, this->attribute);
+  buffer.encode_bool(3, this->once);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SubscribeHomeAssistantStateResponse {\n");
+  out.append("  entity_id: ");
+  out.append("'").append(this->entity_id).append("'");
+  out.append("\n");
+
+  out.append("  attribute: ");
+  out.append("'").append(this->attribute).append("'");
+  out.append("\n");
+
+  out.append("  once: ");
+  out.append(YESNO(this->once));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->entity_id = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->attribute = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->entity_id);
+  buffer.encode_string(2, this->state);
+  buffer.encode_string(3, this->attribute);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void HomeAssistantStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("HomeAssistantStateResponse {\n");
+  out.append("  entity_id: ");
+  out.append("'").append(this->entity_id).append("'");
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  attribute: ");
+  out.append("'").append(this->attribute).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void GetTimeRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
+#endif
+bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->epoch_seconds = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void GetTimeResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->epoch_seconds); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void GetTimeResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("GetTimeResponse {\n");
+  out.append("  epoch_seconds: ");
+  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesServicesArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->type = value.as_enum<enums::ServiceArgType>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesServicesArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->name = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->name);
+  buffer.encode_enum<enums::ServiceArgType>(2, this->type);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesServicesArgument::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesServicesArgument {\n");
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  type: ");
+  out.append(proto_enum_to_string<enums::ServiceArgType>(this->type));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->args.push_back(value.as_message<ListEntitiesServicesArgument>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesServicesResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->name);
+  buffer.encode_fixed32(2, this->key);
+  for (auto &it : this->args) {
+    buffer.encode_message<ListEntitiesServicesArgument>(3, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesServicesResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesServicesResponse {\n");
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->args) {
+    out.append("  args: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->bool_ = value.as_bool();
+      return true;
+    }
+    case 2: {
+      this->legacy_int = value.as_int32();
+      return true;
+    }
+    case 5: {
+      this->int_ = value.as_sint32();
+      return true;
+    }
+    case 6: {
+      this->bool_array.push_back(value.as_bool());
+      return true;
+    }
+    case 7: {
+      this->int_array.push_back(value.as_sint32());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ExecuteServiceArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 4: {
+      this->string_ = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->string_array.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ExecuteServiceArgument::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 3: {
+      this->float_ = value.as_float();
+      return true;
+    }
+    case 8: {
+      this->float_array.push_back(value.as_float());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_bool(1, this->bool_);
+  buffer.encode_int32(2, this->legacy_int);
+  buffer.encode_float(3, this->float_);
+  buffer.encode_string(4, this->string_);
+  buffer.encode_sint32(5, this->int_);
+  for (auto it : this->bool_array) {
+    buffer.encode_bool(6, it, true);
+  }
+  for (auto &it : this->int_array) {
+    buffer.encode_sint32(7, it, true);
+  }
+  for (auto &it : this->float_array) {
+    buffer.encode_float(8, it, true);
+  }
+  for (auto &it : this->string_array) {
+    buffer.encode_string(9, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ExecuteServiceArgument::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ExecuteServiceArgument {\n");
+  out.append("  bool_: ");
+  out.append(YESNO(this->bool_));
+  out.append("\n");
+
+  out.append("  legacy_int: ");
+  sprintf(buffer, "%" PRId32, this->legacy_int);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  float_: ");
+  sprintf(buffer, "%g", this->float_);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  string_: ");
+  out.append("'").append(this->string_).append("'");
+  out.append("\n");
+
+  out.append("  int_: ");
+  sprintf(buffer, "%" PRId32, this->int_);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto it : this->bool_array) {
+    out.append("  bool_array: ");
+    out.append(YESNO(it));
+    out.append("\n");
+  }
+
+  for (const auto &it : this->int_array) {
+    out.append("  int_array: ");
+    sprintf(buffer, "%" PRId32, it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  for (const auto &it : this->float_array) {
+    out.append("  float_array: ");
+    sprintf(buffer, "%g", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  for (const auto &it : this->string_array) {
+    out.append("  string_array: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->args.push_back(value.as_message<ExecuteServiceArgument>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  for (auto &it : this->args) {
+    buffer.encode_message<ExecuteServiceArgument>(2, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ExecuteServiceRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ExecuteServiceRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->args) {
+    out.append("  args: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool ListEntitiesCameraResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesCameraResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 6: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesCameraResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_bool(5, this->disabled_by_default);
+  buffer.encode_string(6, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesCameraResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesCameraResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->done = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool CameraImageResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool CameraImageResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->data);
+  buffer.encode_bool(3, this->done);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void CameraImageResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("CameraImageResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+
+  out.append("  done: ");
+  out.append(YESNO(this->done));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->single = value.as_bool();
+      return true;
+    }
+    case 2: {
+      this->stream = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_bool(1, this->single);
+  buffer.encode_bool(2, this->stream);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void CameraImageRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("CameraImageRequest {\n");
+  out.append("  single: ");
+  out.append(YESNO(this->single));
+  out.append("\n");
+
+  out.append("  stream: ");
+  out.append(YESNO(this->stream));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5: {
+      this->supports_current_temperature = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->supports_two_point_target_temperature = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->supported_modes.push_back(value.as_enum<enums::ClimateMode>());
+      return true;
+    }
+    case 11: {
+      this->legacy_supports_away = value.as_bool();
+      return true;
+    }
+    case 12: {
+      this->supports_action = value.as_bool();
+      return true;
+    }
+    case 13: {
+      this->supported_fan_modes.push_back(value.as_enum<enums::ClimateFanMode>());
+      return true;
+    }
+    case 14: {
+      this->supported_swing_modes.push_back(value.as_enum<enums::ClimateSwingMode>());
+      return true;
+    }
+    case 16: {
+      this->supported_presets.push_back(value.as_enum<enums::ClimatePreset>());
+      return true;
+    }
+    case 18: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 20: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 22: {
+      this->supports_current_humidity = value.as_bool();
+      return true;
+    }
+    case 23: {
+      this->supports_target_humidity = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesClimateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 15: {
+      this->supported_custom_fan_modes.push_back(value.as_string());
+      return true;
+    }
+    case 17: {
+      this->supported_custom_presets.push_back(value.as_string());
+      return true;
+    }
+    case 19: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesClimateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 8: {
+      this->visual_min_temperature = value.as_float();
+      return true;
+    }
+    case 9: {
+      this->visual_max_temperature = value.as_float();
+      return true;
+    }
+    case 10: {
+      this->visual_target_temperature_step = value.as_float();
+      return true;
+    }
+    case 21: {
+      this->visual_current_temperature_step = value.as_float();
+      return true;
+    }
+    case 24: {
+      this->visual_min_humidity = value.as_float();
+      return true;
+    }
+    case 25: {
+      this->visual_max_humidity = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_bool(5, this->supports_current_temperature);
+  buffer.encode_bool(6, this->supports_two_point_target_temperature);
+  for (auto &it : this->supported_modes) {
+    buffer.encode_enum<enums::ClimateMode>(7, it, true);
+  }
+  buffer.encode_float(8, this->visual_min_temperature);
+  buffer.encode_float(9, this->visual_max_temperature);
+  buffer.encode_float(10, this->visual_target_temperature_step);
+  buffer.encode_bool(11, this->legacy_supports_away);
+  buffer.encode_bool(12, this->supports_action);
+  for (auto &it : this->supported_fan_modes) {
+    buffer.encode_enum<enums::ClimateFanMode>(13, it, true);
+  }
+  for (auto &it : this->supported_swing_modes) {
+    buffer.encode_enum<enums::ClimateSwingMode>(14, it, true);
+  }
+  for (auto &it : this->supported_custom_fan_modes) {
+    buffer.encode_string(15, it, true);
+  }
+  for (auto &it : this->supported_presets) {
+    buffer.encode_enum<enums::ClimatePreset>(16, it, true);
+  }
+  for (auto &it : this->supported_custom_presets) {
+    buffer.encode_string(17, it, true);
+  }
+  buffer.encode_bool(18, this->disabled_by_default);
+  buffer.encode_string(19, this->icon);
+  buffer.encode_enum<enums::EntityCategory>(20, this->entity_category);
+  buffer.encode_float(21, this->visual_current_temperature_step);
+  buffer.encode_bool(22, this->supports_current_humidity);
+  buffer.encode_bool(23, this->supports_target_humidity);
+  buffer.encode_float(24, this->visual_min_humidity);
+  buffer.encode_float(25, this->visual_max_humidity);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesClimateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesClimateResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  supports_current_temperature: ");
+  out.append(YESNO(this->supports_current_temperature));
+  out.append("\n");
+
+  out.append("  supports_two_point_target_temperature: ");
+  out.append(YESNO(this->supports_two_point_target_temperature));
+  out.append("\n");
+
+  for (const auto &it : this->supported_modes) {
+    out.append("  supported_modes: ");
+    out.append(proto_enum_to_string<enums::ClimateMode>(it));
+    out.append("\n");
+  }
+
+  out.append("  visual_min_temperature: ");
+  sprintf(buffer, "%g", this->visual_min_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  visual_max_temperature: ");
+  sprintf(buffer, "%g", this->visual_max_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  visual_target_temperature_step: ");
+  sprintf(buffer, "%g", this->visual_target_temperature_step);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  legacy_supports_away: ");
+  out.append(YESNO(this->legacy_supports_away));
+  out.append("\n");
+
+  out.append("  supports_action: ");
+  out.append(YESNO(this->supports_action));
+  out.append("\n");
+
+  for (const auto &it : this->supported_fan_modes) {
+    out.append("  supported_fan_modes: ");
+    out.append(proto_enum_to_string<enums::ClimateFanMode>(it));
+    out.append("\n");
+  }
+
+  for (const auto &it : this->supported_swing_modes) {
+    out.append("  supported_swing_modes: ");
+    out.append(proto_enum_to_string<enums::ClimateSwingMode>(it));
+    out.append("\n");
+  }
+
+  for (const auto &it : this->supported_custom_fan_modes) {
+    out.append("  supported_custom_fan_modes: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  for (const auto &it : this->supported_presets) {
+    out.append("  supported_presets: ");
+    out.append(proto_enum_to_string<enums::ClimatePreset>(it));
+    out.append("\n");
+  }
+
+  for (const auto &it : this->supported_custom_presets) {
+    out.append("  supported_custom_presets: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  visual_current_temperature_step: ");
+  sprintf(buffer, "%g", this->visual_current_temperature_step);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  supports_current_humidity: ");
+  out.append(YESNO(this->supports_current_humidity));
+  out.append("\n");
+
+  out.append("  supports_target_humidity: ");
+  out.append(YESNO(this->supports_target_humidity));
+  out.append("\n");
+
+  out.append("  visual_min_humidity: ");
+  sprintf(buffer, "%g", this->visual_min_humidity);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  visual_max_humidity: ");
+  sprintf(buffer, "%g", this->visual_max_humidity);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->mode = value.as_enum<enums::ClimateMode>();
+      return true;
+    }
+    case 7: {
+      this->unused_legacy_away = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->action = value.as_enum<enums::ClimateAction>();
+      return true;
+    }
+    case 9: {
+      this->fan_mode = value.as_enum<enums::ClimateFanMode>();
+      return true;
+    }
+    case 10: {
+      this->swing_mode = value.as_enum<enums::ClimateSwingMode>();
+      return true;
+    }
+    case 12: {
+      this->preset = value.as_enum<enums::ClimatePreset>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ClimateStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 11: {
+      this->custom_fan_mode = value.as_string();
+      return true;
+    }
+    case 13: {
+      this->custom_preset = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ClimateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->current_temperature = value.as_float();
+      return true;
+    }
+    case 4: {
+      this->target_temperature = value.as_float();
+      return true;
+    }
+    case 5: {
+      this->target_temperature_low = value.as_float();
+      return true;
+    }
+    case 6: {
+      this->target_temperature_high = value.as_float();
+      return true;
+    }
+    case 14: {
+      this->current_humidity = value.as_float();
+      return true;
+    }
+    case 15: {
+      this->target_humidity = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::ClimateMode>(2, this->mode);
+  buffer.encode_float(3, this->current_temperature);
+  buffer.encode_float(4, this->target_temperature);
+  buffer.encode_float(5, this->target_temperature_low);
+  buffer.encode_float(6, this->target_temperature_high);
+  buffer.encode_bool(7, this->unused_legacy_away);
+  buffer.encode_enum<enums::ClimateAction>(8, this->action);
+  buffer.encode_enum<enums::ClimateFanMode>(9, this->fan_mode);
+  buffer.encode_enum<enums::ClimateSwingMode>(10, this->swing_mode);
+  buffer.encode_string(11, this->custom_fan_mode);
+  buffer.encode_enum<enums::ClimatePreset>(12, this->preset);
+  buffer.encode_string(13, this->custom_preset);
+  buffer.encode_float(14, this->current_humidity);
+  buffer.encode_float(15, this->target_humidity);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ClimateStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ClimateStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  mode: ");
+  out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
+  out.append("\n");
+
+  out.append("  current_temperature: ");
+  sprintf(buffer, "%g", this->current_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  target_temperature: ");
+  sprintf(buffer, "%g", this->target_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  target_temperature_low: ");
+  sprintf(buffer, "%g", this->target_temperature_low);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  target_temperature_high: ");
+  sprintf(buffer, "%g", this->target_temperature_high);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  unused_legacy_away: ");
+  out.append(YESNO(this->unused_legacy_away));
+  out.append("\n");
+
+  out.append("  action: ");
+  out.append(proto_enum_to_string<enums::ClimateAction>(this->action));
+  out.append("\n");
+
+  out.append("  fan_mode: ");
+  out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
+  out.append("\n");
+
+  out.append("  swing_mode: ");
+  out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
+  out.append("\n");
+
+  out.append("  custom_fan_mode: ");
+  out.append("'").append(this->custom_fan_mode).append("'");
+  out.append("\n");
+
+  out.append("  preset: ");
+  out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
+  out.append("\n");
+
+  out.append("  custom_preset: ");
+  out.append("'").append(this->custom_preset).append("'");
+  out.append("\n");
+
+  out.append("  current_humidity: ");
+  sprintf(buffer, "%g", this->current_humidity);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  target_humidity: ");
+  sprintf(buffer, "%g", this->target_humidity);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_mode = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->mode = value.as_enum<enums::ClimateMode>();
+      return true;
+    }
+    case 4: {
+      this->has_target_temperature = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->has_target_temperature_low = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->has_target_temperature_high = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->unused_has_legacy_away = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->unused_legacy_away = value.as_bool();
+      return true;
+    }
+    case 12: {
+      this->has_fan_mode = value.as_bool();
+      return true;
+    }
+    case 13: {
+      this->fan_mode = value.as_enum<enums::ClimateFanMode>();
+      return true;
+    }
+    case 14: {
+      this->has_swing_mode = value.as_bool();
+      return true;
+    }
+    case 15: {
+      this->swing_mode = value.as_enum<enums::ClimateSwingMode>();
+      return true;
+    }
+    case 16: {
+      this->has_custom_fan_mode = value.as_bool();
+      return true;
+    }
+    case 18: {
+      this->has_preset = value.as_bool();
+      return true;
+    }
+    case 19: {
+      this->preset = value.as_enum<enums::ClimatePreset>();
+      return true;
+    }
+    case 20: {
+      this->has_custom_preset = value.as_bool();
+      return true;
+    }
+    case 22: {
+      this->has_target_humidity = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ClimateCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 17: {
+      this->custom_fan_mode = value.as_string();
+      return true;
+    }
+    case 21: {
+      this->custom_preset = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->target_temperature = value.as_float();
+      return true;
+    }
+    case 7: {
+      this->target_temperature_low = value.as_float();
+      return true;
+    }
+    case 9: {
+      this->target_temperature_high = value.as_float();
+      return true;
+    }
+    case 23: {
+      this->target_humidity = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_mode);
+  buffer.encode_enum<enums::ClimateMode>(3, this->mode);
+  buffer.encode_bool(4, this->has_target_temperature);
+  buffer.encode_float(5, this->target_temperature);
+  buffer.encode_bool(6, this->has_target_temperature_low);
+  buffer.encode_float(7, this->target_temperature_low);
+  buffer.encode_bool(8, this->has_target_temperature_high);
+  buffer.encode_float(9, this->target_temperature_high);
+  buffer.encode_bool(10, this->unused_has_legacy_away);
+  buffer.encode_bool(11, this->unused_legacy_away);
+  buffer.encode_bool(12, this->has_fan_mode);
+  buffer.encode_enum<enums::ClimateFanMode>(13, this->fan_mode);
+  buffer.encode_bool(14, this->has_swing_mode);
+  buffer.encode_enum<enums::ClimateSwingMode>(15, this->swing_mode);
+  buffer.encode_bool(16, this->has_custom_fan_mode);
+  buffer.encode_string(17, this->custom_fan_mode);
+  buffer.encode_bool(18, this->has_preset);
+  buffer.encode_enum<enums::ClimatePreset>(19, this->preset);
+  buffer.encode_bool(20, this->has_custom_preset);
+  buffer.encode_string(21, this->custom_preset);
+  buffer.encode_bool(22, this->has_target_humidity);
+  buffer.encode_float(23, this->target_humidity);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ClimateCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ClimateCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_mode: ");
+  out.append(YESNO(this->has_mode));
+  out.append("\n");
+
+  out.append("  mode: ");
+  out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
+  out.append("\n");
+
+  out.append("  has_target_temperature: ");
+  out.append(YESNO(this->has_target_temperature));
+  out.append("\n");
+
+  out.append("  target_temperature: ");
+  sprintf(buffer, "%g", this->target_temperature);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_target_temperature_low: ");
+  out.append(YESNO(this->has_target_temperature_low));
+  out.append("\n");
+
+  out.append("  target_temperature_low: ");
+  sprintf(buffer, "%g", this->target_temperature_low);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_target_temperature_high: ");
+  out.append(YESNO(this->has_target_temperature_high));
+  out.append("\n");
+
+  out.append("  target_temperature_high: ");
+  sprintf(buffer, "%g", this->target_temperature_high);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  unused_has_legacy_away: ");
+  out.append(YESNO(this->unused_has_legacy_away));
+  out.append("\n");
+
+  out.append("  unused_legacy_away: ");
+  out.append(YESNO(this->unused_legacy_away));
+  out.append("\n");
+
+  out.append("  has_fan_mode: ");
+  out.append(YESNO(this->has_fan_mode));
+  out.append("\n");
+
+  out.append("  fan_mode: ");
+  out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
+  out.append("\n");
+
+  out.append("  has_swing_mode: ");
+  out.append(YESNO(this->has_swing_mode));
+  out.append("\n");
+
+  out.append("  swing_mode: ");
+  out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
+  out.append("\n");
+
+  out.append("  has_custom_fan_mode: ");
+  out.append(YESNO(this->has_custom_fan_mode));
+  out.append("\n");
+
+  out.append("  custom_fan_mode: ");
+  out.append("'").append(this->custom_fan_mode).append("'");
+  out.append("\n");
+
+  out.append("  has_preset: ");
+  out.append(YESNO(this->has_preset));
+  out.append("\n");
+
+  out.append("  preset: ");
+  out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
+  out.append("\n");
+
+  out.append("  has_custom_preset: ");
+  out.append(YESNO(this->has_custom_preset));
+  out.append("\n");
+
+  out.append("  custom_preset: ");
+  out.append("'").append(this->custom_preset).append("'");
+  out.append("\n");
+
+  out.append("  has_target_humidity: ");
+  out.append(YESNO(this->has_target_humidity));
+  out.append("\n");
+
+  out.append("  target_humidity: ");
+  sprintf(buffer, "%g", this->target_humidity);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesNumberResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 9: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 12: {
+      this->mode = value.as_enum<enums::NumberMode>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesNumberResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 11: {
+      this->unit_of_measurement = value.as_string();
+      return true;
+    }
+    case 13: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesNumberResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 6: {
+      this->min_value = value.as_float();
+      return true;
+    }
+    case 7: {
+      this->max_value = value.as_float();
+      return true;
+    }
+    case 8: {
+      this->step = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_float(6, this->min_value);
+  buffer.encode_float(7, this->max_value);
+  buffer.encode_float(8, this->step);
+  buffer.encode_bool(9, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(10, this->entity_category);
+  buffer.encode_string(11, this->unit_of_measurement);
+  buffer.encode_enum<enums::NumberMode>(12, this->mode);
+  buffer.encode_string(13, this->device_class);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesNumberResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesNumberResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  min_value: ");
+  sprintf(buffer, "%g", this->min_value);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  max_value: ");
+  sprintf(buffer, "%g", this->max_value);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  step: ");
+  sprintf(buffer, "%g", this->step);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  unit_of_measurement: ");
+  out.append("'").append(this->unit_of_measurement).append("'");
+  out.append("\n");
+
+  out.append("  mode: ");
+  out.append(proto_enum_to_string<enums::NumberMode>(this->mode));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool NumberStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool NumberStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 2: {
+      this->state = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_float(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void NumberStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("NumberStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  sprintf(buffer, "%g", this->state);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 2: {
+      this->state = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_float(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void NumberCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("NumberCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  sprintf(buffer, "%g", this->state);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesSelectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 7: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSelectResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 6: {
+      this->options.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesSelectResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  for (auto &it : this->options) {
+    buffer.encode_string(6, it, true);
+  }
+  buffer.encode_bool(7, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(8, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesSelectResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesSelectResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->options) {
+    out.append("  options: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SelectStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SelectStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SelectStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SelectStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SelectStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SelectCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SelectCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesLockResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 8: {
+      this->assumed_state = value.as_bool();
+      return true;
+    }
+    case 9: {
+      this->supports_open = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->requires_code = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesLockResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 11: {
+      this->code_format = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesLockResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_bool(8, this->assumed_state);
+  buffer.encode_bool(9, this->supports_open);
+  buffer.encode_bool(10, this->requires_code);
+  buffer.encode_string(11, this->code_format);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesLockResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesLockResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  assumed_state: ");
+  out.append(YESNO(this->assumed_state));
+  out.append("\n");
+
+  out.append("  supports_open: ");
+  out.append(YESNO(this->supports_open));
+  out.append("\n");
+
+  out.append("  requires_code: ");
+  out.append(YESNO(this->requires_code));
+  out.append("\n");
+
+  out.append("  code_format: ");
+  out.append("'").append(this->code_format).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool LockStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_enum<enums::LockState>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LockStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void LockStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::LockState>(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void LockStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("LockStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(proto_enum_to_string<enums::LockState>(this->state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->command = value.as_enum<enums::LockCommand>();
+      return true;
+    }
+    case 3: {
+      this->has_code = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LockCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 4: {
+      this->code = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::LockCommand>(2, this->command);
+  buffer.encode_bool(3, this->has_code);
+  buffer.encode_string(4, this->code);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void LockCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("LockCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::LockCommand>(this->command));
+  out.append("\n");
+
+  out.append("  has_code: ");
+  out.append(YESNO(this->has_code));
+  out.append("\n");
+
+  out.append("  code: ");
+  out.append("'").append(this->code).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesButtonResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesButtonResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesButtonResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesButtonResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesButtonResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->key); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ButtonCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ButtonCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->sample_rate = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->num_channels = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->purpose = value.as_enum<enums::MediaPlayerFormatPurpose>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool MediaPlayerSupportedFormat::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->format = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->format);
+  buffer.encode_uint32(2, this->sample_rate);
+  buffer.encode_uint32(3, this->num_channels);
+  buffer.encode_enum<enums::MediaPlayerFormatPurpose>(4, this->purpose);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("MediaPlayerSupportedFormat {\n");
+  out.append("  format: ");
+  out.append("'").append(this->format).append("'");
+  out.append("\n");
+
+  out.append("  sample_rate: ");
+  sprintf(buffer, "%" PRIu32, this->sample_rate);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  num_channels: ");
+  sprintf(buffer, "%" PRIu32, this->num_channels);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  purpose: ");
+  out.append(proto_enum_to_string<enums::MediaPlayerFormatPurpose>(this->purpose));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesMediaPlayerResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 8: {
+      this->supports_pause = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesMediaPlayerResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->supported_formats.push_back(value.as_message<MediaPlayerSupportedFormat>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesMediaPlayerResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_bool(8, this->supports_pause);
+  for (auto &it : this->supported_formats) {
+    buffer.encode_message<MediaPlayerSupportedFormat>(9, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesMediaPlayerResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  supports_pause: ");
+  out.append(YESNO(this->supports_pause));
+  out.append("\n");
+
+  for (const auto &it : this->supported_formats) {
+    out.append("  supported_formats: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool MediaPlayerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_enum<enums::MediaPlayerState>();
+      return true;
+    }
+    case 4: {
+      this->muted = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool MediaPlayerStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->volume = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void MediaPlayerStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::MediaPlayerState>(2, this->state);
+  buffer.encode_float(3, this->volume);
+  buffer.encode_bool(4, this->muted);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void MediaPlayerStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("MediaPlayerStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(proto_enum_to_string<enums::MediaPlayerState>(this->state));
+  out.append("\n");
+
+  out.append("  volume: ");
+  sprintf(buffer, "%g", this->volume);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  muted: ");
+  out.append(YESNO(this->muted));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_command = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->command = value.as_enum<enums::MediaPlayerCommand>();
+      return true;
+    }
+    case 4: {
+      this->has_volume = value.as_bool();
+      return true;
+    }
+    case 6: {
+      this->has_media_url = value.as_bool();
+      return true;
+    }
+    case 8: {
+      this->has_announcement = value.as_bool();
+      return true;
+    }
+    case 9: {
+      this->announcement = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool MediaPlayerCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 7: {
+      this->media_url = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->volume = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_command);
+  buffer.encode_enum<enums::MediaPlayerCommand>(3, this->command);
+  buffer.encode_bool(4, this->has_volume);
+  buffer.encode_float(5, this->volume);
+  buffer.encode_bool(6, this->has_media_url);
+  buffer.encode_string(7, this->media_url);
+  buffer.encode_bool(8, this->has_announcement);
+  buffer.encode_bool(9, this->announcement);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void MediaPlayerCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("MediaPlayerCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_command: ");
+  out.append(YESNO(this->has_command));
+  out.append("\n");
+
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::MediaPlayerCommand>(this->command));
+  out.append("\n");
+
+  out.append("  has_volume: ");
+  out.append(YESNO(this->has_volume));
+  out.append("\n");
+
+  out.append("  volume: ");
+  sprintf(buffer, "%g", this->volume);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_media_url: ");
+  out.append(YESNO(this->has_media_url));
+  out.append("\n");
+
+  out.append("  media_url: ");
+  out.append("'").append(this->media_url).append("'");
+  out.append("\n");
+
+  out.append("  has_announcement: ");
+  out.append(YESNO(this->has_announcement));
+  out.append("\n");
+
+  out.append("  announcement: ");
+  out.append(YESNO(this->announcement));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->flags = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint32(1, this->flags);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SubscribeBluetoothLEAdvertisementsRequest {\n");
+  out.append("  flags: ");
+  sprintf(buffer, "%" PRIu32, this->flags);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothServiceData::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->legacy_data.push_back(value.as_uint32());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothServiceData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->uuid = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothServiceData::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->uuid);
+  for (auto &it : this->legacy_data) {
+    buffer.encode_uint32(2, it, true);
+  }
+  buffer.encode_string(3, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothServiceData::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothServiceData {\n");
+  out.append("  uuid: ");
+  out.append("'").append(this->uuid).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->legacy_data) {
+    out.append("  legacy_data: ");
+    sprintf(buffer, "%" PRIu32, it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothLEAdvertisementResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 3: {
+      this->rssi = value.as_sint32();
+      return true;
+    }
+    case 7: {
+      this->address_type = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothLEAdvertisementResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->service_uuids.push_back(value.as_string());
+      return true;
+    }
+    case 5: {
+      this->service_data.push_back(value.as_message<BluetoothServiceData>());
+      return true;
+    }
+    case 6: {
+      this->manufacturer_data.push_back(value.as_message<BluetoothServiceData>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothLEAdvertisementResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_string(2, this->name);
+  buffer.encode_sint32(3, this->rssi);
+  for (auto &it : this->service_uuids) {
+    buffer.encode_string(4, it, true);
+  }
+  for (auto &it : this->service_data) {
+    buffer.encode_message<BluetoothServiceData>(5, it, true);
+  }
+  for (auto &it : this->manufacturer_data) {
+    buffer.encode_message<BluetoothServiceData>(6, it, true);
+  }
+  buffer.encode_uint32(7, this->address_type);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothLEAdvertisementResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  rssi: ");
+  sprintf(buffer, "%" PRId32, this->rssi);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->service_uuids) {
+    out.append("  service_uuids: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  for (const auto &it : this->service_data) {
+    out.append("  service_data: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  for (const auto &it : this->manufacturer_data) {
+    out.append("  manufacturer_data: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  out.append("  address_type: ");
+  sprintf(buffer, "%" PRIu32, this->address_type);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothLERawAdvertisement::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->rssi = value.as_sint32();
+      return true;
+    }
+    case 3: {
+      this->address_type = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothLERawAdvertisement::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 4: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothLERawAdvertisement::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_sint32(2, this->rssi);
+  buffer.encode_uint32(3, this->address_type);
+  buffer.encode_string(4, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothLERawAdvertisement {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  rssi: ");
+  sprintf(buffer, "%" PRId32, this->rssi);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  address_type: ");
+  sprintf(buffer, "%" PRIu32, this->address_type);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->advertisements.push_back(value.as_message<BluetoothLERawAdvertisement>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->advertisements) {
+    buffer.encode_message<BluetoothLERawAdvertisement>(1, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothLERawAdvertisementsResponse {\n");
+  for (const auto &it : this->advertisements) {
+    out.append("  advertisements: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->request_type = value.as_enum<enums::BluetoothDeviceRequestType>();
+      return true;
+    }
+    case 3: {
+      this->has_address_type = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->address_type = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDeviceRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_enum<enums::BluetoothDeviceRequestType>(2, this->request_type);
+  buffer.encode_bool(3, this->has_address_type);
+  buffer.encode_uint32(4, this->address_type);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDeviceRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDeviceRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  request_type: ");
+  out.append(proto_enum_to_string<enums::BluetoothDeviceRequestType>(this->request_type));
+  out.append("\n");
+
+  out.append("  has_address_type: ");
+  out.append(YESNO(this->has_address_type));
+  out.append("\n");
+
+  out.append("  address_type: ");
+  sprintf(buffer, "%" PRIu32, this->address_type);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothDeviceConnectionResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->connected = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->mtu = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDeviceConnectionResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_bool(2, this->connected);
+  buffer.encode_uint32(3, this->mtu);
+  buffer.encode_int32(4, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDeviceConnectionResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  connected: ");
+  out.append(YESNO(this->connected));
+  out.append("\n");
+
+  out.append("  mtu: ");
+  sprintf(buffer, "%" PRIu32, this->mtu);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%" PRId32, this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTGetServicesRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_uint64(1, this->address); }
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTGetServicesRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTDescriptor::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->uuid.push_back(value.as_uint64());
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->uuid) {
+    buffer.encode_uint64(1, it, true);
+  }
+  buffer.encode_uint32(2, this->handle);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTDescriptor::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTDescriptor {\n");
+  for (const auto &it : this->uuid) {
+    out.append("  uuid: ");
+    sprintf(buffer, "%llu", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTCharacteristic::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->uuid.push_back(value.as_uint64());
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->properties = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTCharacteristic::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 4: {
+      this->descriptors.push_back(value.as_message<BluetoothGATTDescriptor>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->uuid) {
+    buffer.encode_uint64(1, it, true);
+  }
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_uint32(3, this->properties);
+  for (auto &it : this->descriptors) {
+    buffer.encode_message<BluetoothGATTDescriptor>(4, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTCharacteristic {\n");
+  for (const auto &it : this->uuid) {
+    out.append("  uuid: ");
+    sprintf(buffer, "%llu", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  properties: ");
+  sprintf(buffer, "%" PRIu32, this->properties);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->descriptors) {
+    out.append("  descriptors: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool BluetoothGATTService::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->uuid.push_back(value.as_uint64());
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTService::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->characteristics.push_back(value.as_message<BluetoothGATTCharacteristic>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->uuid) {
+    buffer.encode_uint64(1, it, true);
+  }
+  buffer.encode_uint32(2, this->handle);
+  for (auto &it : this->characteristics) {
+    buffer.encode_message<BluetoothGATTCharacteristic>(3, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTService::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTService {\n");
+  for (const auto &it : this->uuid) {
+    out.append("  uuid: ");
+    sprintf(buffer, "%llu", it);
+    out.append(buffer);
+    out.append("\n");
+  }
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->characteristics) {
+    out.append("  characteristics: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool BluetoothGATTGetServicesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTGetServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->services.push_back(value.as_message<BluetoothGATTService>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  for (auto &it : this->services) {
+    buffer.encode_message<BluetoothGATTService>(2, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTGetServicesResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  for (const auto &it : this->services) {
+    out.append("  services: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool BluetoothGATTGetServicesDoneResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTGetServicesDoneResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTGetServicesDoneResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTReadRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTReadRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTReadRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTReadResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTReadResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTReadResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_string(3, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTReadResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTReadResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->response = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 4: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTWriteRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_bool(3, this->response);
+  buffer.encode_string(4, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTWriteRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  response: ");
+  out.append(YESNO(this->response));
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTReadDescriptorRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTReadDescriptorRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTWriteDescriptorRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_string(3, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTWriteDescriptorRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->enable = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTNotifyRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_bool(3, this->enable);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTNotifyRequest {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  enable: ");
+  out.append(YESNO(this->enable));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTNotifyDataResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool BluetoothGATTNotifyDataResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTNotifyDataResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_string(3, this->data);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTNotifyDataResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void SubscribeBluetoothConnectionsFreeRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
+  out.append("SubscribeBluetoothConnectionsFreeRequest {}");
+}
+#endif
+bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->free = value.as_uint32();
+      return true;
+    }
+    case 2: {
+      this->limit = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothConnectionsFreeResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint32(1, this->free);
+  buffer.encode_uint32(2, this->limit);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothConnectionsFreeResponse {\n");
+  out.append("  free: ");
+  sprintf(buffer, "%" PRIu32, this->free);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  limit: ");
+  sprintf(buffer, "%" PRIu32, this->limit);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTErrorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTErrorResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+  buffer.encode_int32(3, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTErrorResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%" PRId32, this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTWriteResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTWriteResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTWriteResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothGATTNotifyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->handle = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothGATTNotifyResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_uint32(2, this->handle);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothGATTNotifyResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  handle: ");
+  sprintf(buffer, "%" PRIu32, this->handle);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothDevicePairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->paired = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDevicePairingResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_bool(2, this->paired);
+  buffer.encode_int32(3, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDevicePairingResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  paired: ");
+  out.append(YESNO(this->paired));
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%" PRId32, this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool BluetoothDeviceUnpairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->success = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDeviceUnpairingResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_bool(2, this->success);
+  buffer.encode_int32(3, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDeviceUnpairingResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  success: ");
+  out.append(YESNO(this->success));
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%" PRId32, this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+void UnsubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
+  out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
+}
+#endif
+bool BluetoothDeviceClearCacheResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->address = value.as_uint64();
+      return true;
+    }
+    case 2: {
+      this->success = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->error = value.as_int32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void BluetoothDeviceClearCacheResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_bool(2, this->success);
+  buffer.encode_int32(3, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("BluetoothDeviceClearCacheResponse {\n");
+  out.append("  address: ");
+  sprintf(buffer, "%llu", this->address);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  success: ");
+  out.append(YESNO(this->success));
+  out.append("\n");
+
+  out.append("  error: ");
+  sprintf(buffer, "%" PRId32, this->error);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->subscribe = value.as_bool();
+      return true;
+    }
+    case 2: {
+      this->flags = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void SubscribeVoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_bool(1, this->subscribe);
+  buffer.encode_uint32(2, this->flags);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("SubscribeVoiceAssistantRequest {\n");
+  out.append("  subscribe: ");
+  out.append(YESNO(this->subscribe));
+  out.append("\n");
+
+  out.append("  flags: ");
+  sprintf(buffer, "%" PRIu32, this->flags);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantAudioSettings::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->noise_suppression_level = value.as_uint32();
+      return true;
+    }
+    case 2: {
+      this->auto_gain = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantAudioSettings::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 3: {
+      this->volume_multiplier = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAudioSettings::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint32(1, this->noise_suppression_level);
+  buffer.encode_uint32(2, this->auto_gain);
+  buffer.encode_float(3, this->volume_multiplier);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAudioSettings {\n");
+  out.append("  noise_suppression_level: ");
+  sprintf(buffer, "%" PRIu32, this->noise_suppression_level);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  auto_gain: ");
+  sprintf(buffer, "%" PRIu32, this->auto_gain);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  volume_multiplier: ");
+  sprintf(buffer, "%g", this->volume_multiplier);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->start = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->flags = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->conversation_id = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->audio_settings = value.as_message<VoiceAssistantAudioSettings>();
+      return true;
+    }
+    case 5: {
+      this->wake_word_phrase = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_bool(1, this->start);
+  buffer.encode_string(2, this->conversation_id);
+  buffer.encode_uint32(3, this->flags);
+  buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
+  buffer.encode_string(5, this->wake_word_phrase);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantRequest {\n");
+  out.append("  start: ");
+  out.append(YESNO(this->start));
+  out.append("\n");
+
+  out.append("  conversation_id: ");
+  out.append("'").append(this->conversation_id).append("'");
+  out.append("\n");
+
+  out.append("  flags: ");
+  sprintf(buffer, "%" PRIu32, this->flags);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  audio_settings: ");
+  this->audio_settings.dump_to(out);
+  out.append("\n");
+
+  out.append("  wake_word_phrase: ");
+  out.append("'").append(this->wake_word_phrase).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->port = value.as_uint32();
+      return true;
+    }
+    case 2: {
+      this->error = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_uint32(1, this->port);
+  buffer.encode_bool(2, this->error);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantResponse {\n");
+  out.append("  port: ");
+  sprintf(buffer, "%" PRIu32, this->port);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  error: ");
+  out.append(YESNO(this->error));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->value = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantEventData::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->name);
+  buffer.encode_string(2, this->value);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantEventData::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantEventData {\n");
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  value: ");
+  out.append("'").append(this->value).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->event_type = value.as_enum<enums::VoiceAssistantEvent>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->data.push_back(value.as_message<VoiceAssistantEventData>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::VoiceAssistantEvent>(1, this->event_type);
+  for (auto &it : this->data) {
+    buffer.encode_message<VoiceAssistantEventData>(2, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantEventResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantEventResponse {\n");
+  out.append("  event_type: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantEvent>(this->event_type));
+  out.append("\n");
+
+  for (const auto &it : this->data) {
+    out.append("  data: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->end = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantAudio::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->data = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAudio::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->data);
+  buffer.encode_bool(2, this->end);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantAudio::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAudio {\n");
+  out.append("  data: ");
+  out.append("'").append(this->data).append("'");
+  out.append("\n");
+
+  out.append("  end: ");
+  out.append(YESNO(this->end));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->event_type = value.as_enum<enums::VoiceAssistantTimerEvent>();
+      return true;
+    }
+    case 4: {
+      this->total_seconds = value.as_uint32();
+      return true;
+    }
+    case 5: {
+      this->seconds_left = value.as_uint32();
+      return true;
+    }
+    case 6: {
+      this->is_active = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->timer_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantTimerEventResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::VoiceAssistantTimerEvent>(1, this->event_type);
+  buffer.encode_string(2, this->timer_id);
+  buffer.encode_string(3, this->name);
+  buffer.encode_uint32(4, this->total_seconds);
+  buffer.encode_uint32(5, this->seconds_left);
+  buffer.encode_bool(6, this->is_active);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantTimerEventResponse {\n");
+  out.append("  event_type: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantTimerEvent>(this->event_type));
+  out.append("\n");
+
+  out.append("  timer_id: ");
+  out.append("'").append(this->timer_id).append("'");
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  total_seconds: ");
+  sprintf(buffer, "%" PRIu32, this->total_seconds);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  seconds_left: ");
+  sprintf(buffer, "%" PRIu32, this->seconds_left);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  is_active: ");
+  out.append(YESNO(this->is_active));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 8: {
+      this->supported_features = value.as_uint32();
+      return true;
+    }
+    case 9: {
+      this->requires_code = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->requires_code_to_arm = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesAlarmControlPanelResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesAlarmControlPanelResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_uint32(8, this->supported_features);
+  buffer.encode_bool(9, this->requires_code);
+  buffer.encode_bool(10, this->requires_code_to_arm);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesAlarmControlPanelResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  supported_features: ");
+  sprintf(buffer, "%" PRIu32, this->supported_features);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  requires_code: ");
+  out.append(YESNO(this->requires_code));
+  out.append("\n");
+
+  out.append("  requires_code_to_arm: ");
+  out.append(YESNO(this->requires_code_to_arm));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool AlarmControlPanelStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_enum<enums::AlarmControlPanelState>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool AlarmControlPanelStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::AlarmControlPanelState>(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("AlarmControlPanelStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append(proto_enum_to_string<enums::AlarmControlPanelState>(this->state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->command = value.as_enum<enums::AlarmControlPanelStateCommand>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool AlarmControlPanelCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->code = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::AlarmControlPanelStateCommand>(2, this->command);
+  buffer.encode_string(3, this->code);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("AlarmControlPanelCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::AlarmControlPanelStateCommand>(this->command));
+  out.append("\n");
+
+  out.append("  code: ");
+  out.append("'").append(this->code).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesTextResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 8: {
+      this->min_length = value.as_uint32();
+      return true;
+    }
+    case 9: {
+      this->max_length = value.as_uint32();
+      return true;
+    }
+    case 11: {
+      this->mode = value.as_enum<enums::TextMode>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTextResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 10: {
+      this->pattern = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTextResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_uint32(8, this->min_length);
+  buffer.encode_uint32(9, this->max_length);
+  buffer.encode_string(10, this->pattern);
+  buffer.encode_enum<enums::TextMode>(11, this->mode);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesTextResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesTextResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  min_length: ");
+  sprintf(buffer, "%" PRIu32, this->min_length);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  max_length: ");
+  sprintf(buffer, "%" PRIu32, this->max_length);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  pattern: ");
+  out.append("'").append(this->pattern).append("'");
+  out.append("\n");
+
+  out.append("  mode: ");
+  out.append(proto_enum_to_string<enums::TextMode>(this->mode));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool TextStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TextStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TextStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+  buffer.encode_bool(3, this->missing_state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void TextStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("TextStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->state = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void TextCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->state);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void TextCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("TextCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  state: ");
+  out.append("'").append(this->state).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesDateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesDateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesDateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesDateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesDateResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool DateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->year = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->month = value.as_uint32();
+      return true;
+    }
+    case 5: {
+      this->day = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool DateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void DateStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->missing_state);
+  buffer.encode_uint32(3, this->year);
+  buffer.encode_uint32(4, this->month);
+  buffer.encode_uint32(5, this->day);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DateStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("DateStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+
+  out.append("  year: ");
+  sprintf(buffer, "%" PRIu32, this->year);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  month: ");
+  sprintf(buffer, "%" PRIu32, this->month);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  day: ");
+  sprintf(buffer, "%" PRIu32, this->day);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->year = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->month = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->day = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void DateCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_uint32(2, this->year);
+  buffer.encode_uint32(3, this->month);
+  buffer.encode_uint32(4, this->day);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DateCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("DateCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  year: ");
+  sprintf(buffer, "%" PRIu32, this->year);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  month: ");
+  sprintf(buffer, "%" PRIu32, this->month);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  day: ");
+  sprintf(buffer, "%" PRIu32, this->day);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesTimeResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesTimeResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool TimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->hour = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->minute = value.as_uint32();
+      return true;
+    }
+    case 5: {
+      this->second = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TimeStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void TimeStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->missing_state);
+  buffer.encode_uint32(3, this->hour);
+  buffer.encode_uint32(4, this->minute);
+  buffer.encode_uint32(5, this->second);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void TimeStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("TimeStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+
+  out.append("  hour: ");
+  sprintf(buffer, "%" PRIu32, this->hour);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  minute: ");
+  sprintf(buffer, "%" PRIu32, this->minute);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  second: ");
+  sprintf(buffer, "%" PRIu32, this->second);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->hour = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->minute = value.as_uint32();
+      return true;
+    }
+    case 4: {
+      this->second = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void TimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_uint32(2, this->hour);
+  buffer.encode_uint32(3, this->minute);
+  buffer.encode_uint32(4, this->second);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void TimeCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("TimeCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  hour: ");
+  sprintf(buffer, "%" PRIu32, this->hour);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  minute: ");
+  sprintf(buffer, "%" PRIu32, this->minute);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  second: ");
+  sprintf(buffer, "%" PRIu32, this->second);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->event_types.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesEventResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
+  for (auto &it : this->event_types) {
+    buffer.encode_string(9, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesEventResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesEventResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->event_types) {
+    out.append("  event_types: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool EventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->event_type = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool EventResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void EventResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_string(2, this->event_type);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void EventResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("EventResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  event_type: ");
+  out.append("'").append(this->event_type).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesValveResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    case 9: {
+      this->assumed_state = value.as_bool();
+      return true;
+    }
+    case 10: {
+      this->supports_position = value.as_bool();
+      return true;
+    }
+    case 11: {
+      this->supports_stop = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesValveResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesValveResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
+  buffer.encode_bool(9, this->assumed_state);
+  buffer.encode_bool(10, this->supports_position);
+  buffer.encode_bool(11, this->supports_stop);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesValveResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesValveResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+
+  out.append("  assumed_state: ");
+  out.append(YESNO(this->assumed_state));
+  out.append("\n");
+
+  out.append("  supports_position: ");
+  out.append(YESNO(this->supports_position));
+  out.append("\n");
+
+  out.append("  supports_stop: ");
+  out.append(YESNO(this->supports_stop));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ValveStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->current_operation = value.as_enum<enums::ValveOperation>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ValveStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 2: {
+      this->position = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ValveStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_float(2, this->position);
+  buffer.encode_enum<enums::ValveOperation>(3, this->current_operation);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ValveStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ValveStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  position: ");
+  sprintf(buffer, "%g", this->position);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  current_operation: ");
+  out.append(proto_enum_to_string<enums::ValveOperation>(this->current_operation));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->has_position = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->stop = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->position = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ValveCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->has_position);
+  buffer.encode_float(3, this->position);
+  buffer.encode_bool(4, this->stop);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ValveCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ValveCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  has_position: ");
+  out.append(YESNO(this->has_position));
+  out.append("\n");
+
+  out.append("  position: ");
+  sprintf(buffer, "%g", this->position);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  stop: ");
+  out.append(YESNO(this->stop));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesDateTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesDateTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesDateTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesDateTimeResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool DateTimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool DateTimeStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 3: {
+      this->epoch_seconds = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void DateTimeStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->missing_state);
+  buffer.encode_fixed32(3, this->epoch_seconds);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DateTimeStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("DateTimeStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+
+  out.append("  epoch_seconds: ");
+  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 2: {
+      this->epoch_seconds = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void DateTimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(2, this->epoch_seconds);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void DateTimeCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("DateTimeCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  epoch_seconds: ");
+  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  out.append(buffer);
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool ListEntitiesUpdateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 6: {
+      this->disabled_by_default = value.as_bool();
+      return true;
+    }
+    case 7: {
+      this->entity_category = value.as_enum<enums::EntityCategory>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesUpdateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->object_id = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->name = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->unique_id = value.as_string();
+      return true;
+    }
+    case 5: {
+      this->icon = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool ListEntitiesUpdateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 2: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->object_id);
+  buffer.encode_fixed32(2, this->key);
+  buffer.encode_string(3, this->name);
+  buffer.encode_string(4, this->unique_id);
+  buffer.encode_string(5, this->icon);
+  buffer.encode_bool(6, this->disabled_by_default);
+  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("ListEntitiesUpdateResponse {\n");
+  out.append("  object_id: ");
+  out.append("'").append(this->object_id).append("'");
+  out.append("\n");
+
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  name: ");
+  out.append("'").append(this->name).append("'");
+  out.append("\n");
+
+  out.append("  unique_id: ");
+  out.append("'").append(this->unique_id).append("'");
+  out.append("\n");
+
+  out.append("  icon: ");
+  out.append("'").append(this->icon).append("'");
+  out.append("\n");
+
+  out.append("  disabled_by_default: ");
+  out.append(YESNO(this->disabled_by_default));
+  out.append("\n");
+
+  out.append("  entity_category: ");
+  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
+  out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool UpdateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->missing_state = value.as_bool();
+      return true;
+    }
+    case 3: {
+      this->in_progress = value.as_bool();
+      return true;
+    }
+    case 4: {
+      this->has_progress = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool UpdateStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 6: {
+      this->current_version = value.as_string();
+      return true;
+    }
+    case 7: {
+      this->latest_version = value.as_string();
+      return true;
+    }
+    case 8: {
+      this->title = value.as_string();
+      return true;
+    }
+    case 9: {
+      this->release_summary = value.as_string();
+      return true;
+    }
+    case 10: {
+      this->release_url = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool UpdateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    case 5: {
+      this->progress = value.as_float();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void UpdateStateResponse::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_bool(2, this->missing_state);
+  buffer.encode_bool(3, this->in_progress);
+  buffer.encode_bool(4, this->has_progress);
+  buffer.encode_float(5, this->progress);
+  buffer.encode_string(6, this->current_version);
+  buffer.encode_string(7, this->latest_version);
+  buffer.encode_string(8, this->title);
+  buffer.encode_string(9, this->release_summary);
+  buffer.encode_string(10, this->release_url);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void UpdateStateResponse::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("UpdateStateResponse {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  missing_state: ");
+  out.append(YESNO(this->missing_state));
+  out.append("\n");
+
+  out.append("  in_progress: ");
+  out.append(YESNO(this->in_progress));
+  out.append("\n");
+
+  out.append("  has_progress: ");
+  out.append(YESNO(this->has_progress));
+  out.append("\n");
+
+  out.append("  progress: ");
+  sprintf(buffer, "%g", this->progress);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  current_version: ");
+  out.append("'").append(this->current_version).append("'");
+  out.append("\n");
+
+  out.append("  latest_version: ");
+  out.append("'").append(this->latest_version).append("'");
+  out.append("\n");
+
+  out.append("  title: ");
+  out.append("'").append(this->title).append("'");
+  out.append("\n");
+
+  out.append("  release_summary: ");
+  out.append("'").append(this->release_summary).append("'");
+  out.append("\n");
+
+  out.append("  release_url: ");
+  out.append("'").append(this->release_url).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->command = value.as_enum<enums::UpdateCommand>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
+  switch (field_id) {
+    case 1: {
+      this->key = value.as_fixed32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_enum<enums::UpdateCommand>(2, this->command);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void UpdateCommandRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("UpdateCommandRequest {\n");
+  out.append("  key: ");
+  sprintf(buffer, "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::UpdateCommand>(this->command));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+
+    }  // namespace api
+    }  // namespace esphome
+    

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1,0 +1,2218 @@
+// This file was automatically generated with a tool.
+// See scripts/api_protobuf/api_protobuf.py
+    #pragma once
+
+    #include "proto.h"
+
+    namespace esphome {
+    namespace api {
+
+    namespace enums {
+
+enum EntityCategory : uint32_t {
+  ENTITY_CATEGORY_NONE = 0,
+  ENTITY_CATEGORY_CONFIG = 1,
+  ENTITY_CATEGORY_DIAGNOSTIC = 2,
+};
+enum LegacyCoverState : uint32_t {
+  LEGACY_COVER_STATE_OPEN = 0,
+  LEGACY_COVER_STATE_CLOSED = 1,
+};
+enum CoverOperation : uint32_t {
+  COVER_OPERATION_IDLE = 0,
+  COVER_OPERATION_IS_OPENING = 1,
+  COVER_OPERATION_IS_CLOSING = 2,
+};
+enum LegacyCoverCommand : uint32_t {
+  LEGACY_COVER_COMMAND_OPEN = 0,
+  LEGACY_COVER_COMMAND_CLOSE = 1,
+  LEGACY_COVER_COMMAND_STOP = 2,
+};
+enum FanSpeed : uint32_t {
+  FAN_SPEED_LOW = 0,
+  FAN_SPEED_MEDIUM = 1,
+  FAN_SPEED_HIGH = 2,
+};
+enum FanDirection : uint32_t {
+  FAN_DIRECTION_FORWARD = 0,
+  FAN_DIRECTION_REVERSE = 1,
+};
+enum ColorMode : uint32_t {
+  COLOR_MODE_UNKNOWN = 0,
+  COLOR_MODE_ON_OFF = 1,
+  COLOR_MODE_BRIGHTNESS = 2,
+  COLOR_MODE_WHITE = 7,
+  COLOR_MODE_COLOR_TEMPERATURE = 11,
+  COLOR_MODE_COLD_WARM_WHITE = 19,
+  COLOR_MODE_RGB = 35,
+  COLOR_MODE_RGB_WHITE = 39,
+  COLOR_MODE_RGB_COLOR_TEMPERATURE = 47,
+  COLOR_MODE_RGB_COLD_WARM_WHITE = 51,
+};
+enum SensorStateClass : uint32_t {
+  STATE_CLASS_NONE = 0,
+  STATE_CLASS_MEASUREMENT = 1,
+  STATE_CLASS_TOTAL_INCREASING = 2,
+  STATE_CLASS_TOTAL = 3,
+};
+enum SensorLastResetType : uint32_t {
+  LAST_RESET_NONE = 0,
+  LAST_RESET_NEVER = 1,
+  LAST_RESET_AUTO = 2,
+};
+enum LogLevel : uint32_t {
+  LOG_LEVEL_NONE = 0,
+  LOG_LEVEL_ERROR = 1,
+  LOG_LEVEL_WARN = 2,
+  LOG_LEVEL_INFO = 3,
+  LOG_LEVEL_CONFIG = 4,
+  LOG_LEVEL_DEBUG = 5,
+  LOG_LEVEL_VERBOSE = 6,
+  LOG_LEVEL_VERY_VERBOSE = 7,
+};
+enum ServiceArgType : uint32_t {
+  SERVICE_ARG_TYPE_BOOL = 0,
+  SERVICE_ARG_TYPE_INT = 1,
+  SERVICE_ARG_TYPE_FLOAT = 2,
+  SERVICE_ARG_TYPE_STRING = 3,
+  SERVICE_ARG_TYPE_BOOL_ARRAY = 4,
+  SERVICE_ARG_TYPE_INT_ARRAY = 5,
+  SERVICE_ARG_TYPE_FLOAT_ARRAY = 6,
+  SERVICE_ARG_TYPE_STRING_ARRAY = 7,
+};
+enum ClimateMode : uint32_t {
+  CLIMATE_MODE_OFF = 0,
+  CLIMATE_MODE_HEAT_COOL = 1,
+  CLIMATE_MODE_COOL = 2,
+  CLIMATE_MODE_HEAT = 3,
+  CLIMATE_MODE_FAN_ONLY = 4,
+  CLIMATE_MODE_DRY = 5,
+  CLIMATE_MODE_AUTO = 6,
+};
+enum ClimateFanMode : uint32_t {
+  CLIMATE_FAN_ON = 0,
+  CLIMATE_FAN_OFF = 1,
+  CLIMATE_FAN_AUTO = 2,
+  CLIMATE_FAN_LOW = 3,
+  CLIMATE_FAN_MEDIUM = 4,
+  CLIMATE_FAN_HIGH = 5,
+  CLIMATE_FAN_MIDDLE = 6,
+  CLIMATE_FAN_FOCUS = 7,
+  CLIMATE_FAN_DIFFUSE = 8,
+  CLIMATE_FAN_QUIET = 9,
+};
+enum ClimateSwingMode : uint32_t {
+  CLIMATE_SWING_OFF = 0,
+  CLIMATE_SWING_BOTH = 1,
+  CLIMATE_SWING_VERTICAL = 2,
+  CLIMATE_SWING_HORIZONTAL = 3,
+};
+enum ClimateAction : uint32_t {
+  CLIMATE_ACTION_OFF = 0,
+  CLIMATE_ACTION_COOLING = 2,
+  CLIMATE_ACTION_HEATING = 3,
+  CLIMATE_ACTION_IDLE = 4,
+  CLIMATE_ACTION_DRYING = 5,
+  CLIMATE_ACTION_FAN = 6,
+};
+enum ClimatePreset : uint32_t {
+  CLIMATE_PRESET_NONE = 0,
+  CLIMATE_PRESET_HOME = 1,
+  CLIMATE_PRESET_AWAY = 2,
+  CLIMATE_PRESET_BOOST = 3,
+  CLIMATE_PRESET_COMFORT = 4,
+  CLIMATE_PRESET_ECO = 5,
+  CLIMATE_PRESET_SLEEP = 6,
+  CLIMATE_PRESET_ACTIVITY = 7,
+};
+enum NumberMode : uint32_t {
+  NUMBER_MODE_AUTO = 0,
+  NUMBER_MODE_BOX = 1,
+  NUMBER_MODE_SLIDER = 2,
+};
+enum LockState : uint32_t {
+  LOCK_STATE_NONE = 0,
+  LOCK_STATE_LOCKED = 1,
+  LOCK_STATE_UNLOCKED = 2,
+  LOCK_STATE_JAMMED = 3,
+  LOCK_STATE_LOCKING = 4,
+  LOCK_STATE_UNLOCKING = 5,
+};
+enum LockCommand : uint32_t {
+  LOCK_UNLOCK = 0,
+  LOCK_LOCK = 1,
+  LOCK_OPEN = 2,
+};
+enum MediaPlayerState : uint32_t {
+  MEDIA_PLAYER_STATE_NONE = 0,
+  MEDIA_PLAYER_STATE_IDLE = 1,
+  MEDIA_PLAYER_STATE_PLAYING = 2,
+  MEDIA_PLAYER_STATE_PAUSED = 3,
+};
+enum MediaPlayerCommand : uint32_t {
+  MEDIA_PLAYER_COMMAND_PLAY = 0,
+  MEDIA_PLAYER_COMMAND_PAUSE = 1,
+  MEDIA_PLAYER_COMMAND_STOP = 2,
+  MEDIA_PLAYER_COMMAND_MUTE = 3,
+  MEDIA_PLAYER_COMMAND_UNMUTE = 4,
+};
+enum MediaPlayerFormatPurpose : uint32_t {
+  MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT = 0,
+  MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT = 1,
+};
+enum BluetoothDeviceRequestType : uint32_t {
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT = 0,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT = 1,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR = 2,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR = 3,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE = 4,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE = 5,
+  BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE = 6,
+};
+enum VoiceAssistantSubscribeFlag : uint32_t {
+  VOICE_ASSISTANT_SUBSCRIBE_NONE = 0,
+  VOICE_ASSISTANT_SUBSCRIBE_API_AUDIO = 1,
+};
+enum VoiceAssistantRequestFlag : uint32_t {
+  VOICE_ASSISTANT_REQUEST_NONE = 0,
+  VOICE_ASSISTANT_REQUEST_USE_VAD = 1,
+  VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2,
+};
+enum VoiceAssistantEvent : uint32_t {
+  VOICE_ASSISTANT_ERROR = 0,
+  VOICE_ASSISTANT_RUN_START = 1,
+  VOICE_ASSISTANT_RUN_END = 2,
+  VOICE_ASSISTANT_STT_START = 3,
+  VOICE_ASSISTANT_STT_END = 4,
+  VOICE_ASSISTANT_INTENT_START = 5,
+  VOICE_ASSISTANT_INTENT_END = 6,
+  VOICE_ASSISTANT_TTS_START = 7,
+  VOICE_ASSISTANT_TTS_END = 8,
+  VOICE_ASSISTANT_WAKE_WORD_START = 9,
+  VOICE_ASSISTANT_WAKE_WORD_END = 10,
+  VOICE_ASSISTANT_STT_VAD_START = 11,
+  VOICE_ASSISTANT_STT_VAD_END = 12,
+  VOICE_ASSISTANT_TTS_STREAM_START = 98,
+  VOICE_ASSISTANT_TTS_STREAM_END = 99,
+};
+enum VoiceAssistantTimerEvent : uint32_t {
+  VOICE_ASSISTANT_TIMER_STARTED = 0,
+  VOICE_ASSISTANT_TIMER_UPDATED = 1,
+  VOICE_ASSISTANT_TIMER_CANCELLED = 2,
+  VOICE_ASSISTANT_TIMER_FINISHED = 3,
+};
+enum AlarmControlPanelState : uint32_t {
+  ALARM_STATE_DISARMED = 0,
+  ALARM_STATE_ARMED_HOME = 1,
+  ALARM_STATE_ARMED_AWAY = 2,
+  ALARM_STATE_ARMED_NIGHT = 3,
+  ALARM_STATE_ARMED_VACATION = 4,
+  ALARM_STATE_ARMED_CUSTOM_BYPASS = 5,
+  ALARM_STATE_PENDING = 6,
+  ALARM_STATE_ARMING = 7,
+  ALARM_STATE_DISARMING = 8,
+  ALARM_STATE_TRIGGERED = 9,
+};
+enum AlarmControlPanelStateCommand : uint32_t {
+  ALARM_CONTROL_PANEL_DISARM = 0,
+  ALARM_CONTROL_PANEL_ARM_AWAY = 1,
+  ALARM_CONTROL_PANEL_ARM_HOME = 2,
+  ALARM_CONTROL_PANEL_ARM_NIGHT = 3,
+  ALARM_CONTROL_PANEL_ARM_VACATION = 4,
+  ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS = 5,
+  ALARM_CONTROL_PANEL_TRIGGER = 6,
+};
+enum TextMode : uint32_t {
+  TEXT_MODE_TEXT = 0,
+  TEXT_MODE_PASSWORD = 1,
+};
+enum ValveOperation : uint32_t {
+  VALVE_OPERATION_IDLE = 0,
+  VALVE_OPERATION_IS_OPENING = 1,
+  VALVE_OPERATION_IS_CLOSING = 2,
+};
+enum UpdateCommand : uint32_t {
+  UPDATE_COMMAND_NONE = 0,
+  UPDATE_COMMAND_UPDATE = 1,
+  UPDATE_COMMAND_CHECK = 2,
+};
+
+}  // namespace enums
+
+class HelloRequest : public ProtoMessage {
+ public:
+  std::string client_info{};
+  uint32_t api_version_major{0};
+  uint32_t api_version_minor{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class HelloResponse : public ProtoMessage {
+ public:
+  uint32_t api_version_major{0};
+  uint32_t api_version_minor{0};
+  std::string server_info{};
+  std::string name{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ConnectRequest : public ProtoMessage {
+ public:
+  std::string password{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ConnectResponse : public ProtoMessage {
+ public:
+  bool invalid_password{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class DisconnectRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class DisconnectResponse : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class PingRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class PingResponse : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class DeviceInfoRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class DeviceInfoResponse : public ProtoMessage {
+ public:
+  bool uses_password{false};
+  std::string name{};
+  std::string mac_address{};
+  std::string esphome_version{};
+  std::string compilation_time{};
+  std::string model{};
+  bool has_deep_sleep{false};
+  std::string project_name{};
+  std::string project_version{};
+  uint32_t webserver_port{0};
+  uint32_t legacy_bluetooth_proxy_version{0};
+  uint32_t bluetooth_proxy_feature_flags{0};
+  std::string manufacturer{};
+  std::string friendly_name{};
+  uint32_t legacy_voice_assistant_version{0};
+  uint32_t voice_assistant_feature_flags{0};
+  std::string suggested_area{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class ListEntitiesDoneResponse : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class SubscribeStatesRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class ListEntitiesBinarySensorResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string device_class{};
+  bool is_status_binary_sensor{false};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BinarySensorStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool state{false};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesCoverResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool assumed_state{false};
+  bool supports_position{false};
+  bool supports_tilt{false};
+  std::string device_class{};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  bool supports_stop{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class CoverStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::LegacyCoverState legacy_state{};
+  float position{0.0f};
+  float tilt{0.0f};
+  enums::CoverOperation current_operation{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class CoverCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_legacy_command{false};
+  enums::LegacyCoverCommand legacy_command{};
+  bool has_position{false};
+  float position{0.0f};
+  bool has_tilt{false};
+  float tilt{0.0f};
+  bool stop{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesFanResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool supports_oscillation{false};
+  bool supports_speed{false};
+  bool supports_direction{false};
+  int32_t supported_speed_count{0};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  std::vector<std::string> supported_preset_modes{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class FanStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool state{false};
+  bool oscillating{false};
+  enums::FanSpeed speed{};
+  enums::FanDirection direction{};
+  int32_t speed_level{0};
+  std::string preset_mode{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class FanCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_state{false};
+  bool state{false};
+  bool has_speed{false};
+  enums::FanSpeed speed{};
+  bool has_oscillating{false};
+  bool oscillating{false};
+  bool has_direction{false};
+  enums::FanDirection direction{};
+  bool has_speed_level{false};
+  int32_t speed_level{0};
+  bool has_preset_mode{false};
+  std::string preset_mode{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesLightResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::vector<enums::ColorMode> supported_color_modes{};
+  bool legacy_supports_brightness{false};
+  bool legacy_supports_rgb{false};
+  bool legacy_supports_white_value{false};
+  bool legacy_supports_color_temperature{false};
+  float min_mireds{0.0f};
+  float max_mireds{0.0f};
+  std::vector<std::string> effects{};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class LightStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool state{false};
+  float brightness{0.0f};
+  enums::ColorMode color_mode{};
+  float color_brightness{0.0f};
+  float red{0.0f};
+  float green{0.0f};
+  float blue{0.0f};
+  float white{0.0f};
+  float color_temperature{0.0f};
+  float cold_white{0.0f};
+  float warm_white{0.0f};
+  std::string effect{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class LightCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_state{false};
+  bool state{false};
+  bool has_brightness{false};
+  float brightness{0.0f};
+  bool has_color_mode{false};
+  enums::ColorMode color_mode{};
+  bool has_color_brightness{false};
+  float color_brightness{0.0f};
+  bool has_rgb{false};
+  float red{0.0f};
+  float green{0.0f};
+  float blue{0.0f};
+  bool has_white{false};
+  float white{0.0f};
+  bool has_color_temperature{false};
+  float color_temperature{0.0f};
+  bool has_cold_white{false};
+  float cold_white{0.0f};
+  bool has_warm_white{false};
+  float warm_white{0.0f};
+  bool has_transition_length{false};
+  uint32_t transition_length{0};
+  bool has_flash_length{false};
+  uint32_t flash_length{0};
+  bool has_effect{false};
+  std::string effect{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesSensorResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  std::string unit_of_measurement{};
+  int32_t accuracy_decimals{0};
+  bool force_update{false};
+  std::string device_class{};
+  enums::SensorStateClass state_class{};
+  enums::SensorLastResetType legacy_last_reset_type{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SensorStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  float state{0.0f};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesSwitchResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool assumed_state{false};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SwitchStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SwitchCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesTextSensorResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class TextSensorStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeLogsRequest : public ProtoMessage {
+ public:
+  enums::LogLevel level{};
+  bool dump_config{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeLogsResponse : public ProtoMessage {
+ public:
+  enums::LogLevel level{};
+  std::string message{};
+  bool send_failed{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeHomeassistantServicesRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class HomeassistantServiceMap : public ProtoMessage {
+ public:
+  std::string key{};
+  std::string value{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class HomeassistantServiceResponse : public ProtoMessage {
+ public:
+  std::string service{};
+  std::vector<HomeassistantServiceMap> data{};
+  std::vector<HomeassistantServiceMap> data_template{};
+  std::vector<HomeassistantServiceMap> variables{};
+  bool is_event{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class SubscribeHomeAssistantStateResponse : public ProtoMessage {
+ public:
+  std::string entity_id{};
+  std::string attribute{};
+  bool once{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class HomeAssistantStateResponse : public ProtoMessage {
+ public:
+  std::string entity_id{};
+  std::string state{};
+  std::string attribute{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class GetTimeRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class GetTimeResponse : public ProtoMessage {
+ public:
+  uint32_t epoch_seconds{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+};
+class ListEntitiesServicesArgument : public ProtoMessage {
+ public:
+  std::string name{};
+  enums::ServiceArgType type{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesServicesResponse : public ProtoMessage {
+ public:
+  std::string name{};
+  uint32_t key{0};
+  std::vector<ListEntitiesServicesArgument> args{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ExecuteServiceArgument : public ProtoMessage {
+ public:
+  bool bool_{false};
+  int32_t legacy_int{0};
+  float float_{0.0f};
+  std::string string_{};
+  int32_t int_{0};
+  std::vector<bool> bool_array{};
+  std::vector<int32_t> int_array{};
+  std::vector<float> float_array{};
+  std::vector<std::string> string_array{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ExecuteServiceRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::vector<ExecuteServiceArgument> args{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ListEntitiesCameraResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class CameraImageResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string data{};
+  bool done{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class CameraImageRequest : public ProtoMessage {
+ public:
+  bool single{false};
+  bool stream{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesClimateResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  bool supports_current_temperature{false};
+  bool supports_two_point_target_temperature{false};
+  std::vector<enums::ClimateMode> supported_modes{};
+  float visual_min_temperature{0.0f};
+  float visual_max_temperature{0.0f};
+  float visual_target_temperature_step{0.0f};
+  bool legacy_supports_away{false};
+  bool supports_action{false};
+  std::vector<enums::ClimateFanMode> supported_fan_modes{};
+  std::vector<enums::ClimateSwingMode> supported_swing_modes{};
+  std::vector<std::string> supported_custom_fan_modes{};
+  std::vector<enums::ClimatePreset> supported_presets{};
+  std::vector<std::string> supported_custom_presets{};
+  bool disabled_by_default{false};
+  std::string icon{};
+  enums::EntityCategory entity_category{};
+  float visual_current_temperature_step{0.0f};
+  bool supports_current_humidity{false};
+  bool supports_target_humidity{false};
+  float visual_min_humidity{0.0f};
+  float visual_max_humidity{0.0f};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ClimateStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::ClimateMode mode{};
+  float current_temperature{0.0f};
+  float target_temperature{0.0f};
+  float target_temperature_low{0.0f};
+  float target_temperature_high{0.0f};
+  bool unused_legacy_away{false};
+  enums::ClimateAction action{};
+  enums::ClimateFanMode fan_mode{};
+  enums::ClimateSwingMode swing_mode{};
+  std::string custom_fan_mode{};
+  enums::ClimatePreset preset{};
+  std::string custom_preset{};
+  float current_humidity{0.0f};
+  float target_humidity{0.0f};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ClimateCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_mode{false};
+  enums::ClimateMode mode{};
+  bool has_target_temperature{false};
+  float target_temperature{0.0f};
+  bool has_target_temperature_low{false};
+  float target_temperature_low{0.0f};
+  bool has_target_temperature_high{false};
+  float target_temperature_high{0.0f};
+  bool unused_has_legacy_away{false};
+  bool unused_legacy_away{false};
+  bool has_fan_mode{false};
+  enums::ClimateFanMode fan_mode{};
+  bool has_swing_mode{false};
+  enums::ClimateSwingMode swing_mode{};
+  bool has_custom_fan_mode{false};
+  std::string custom_fan_mode{};
+  bool has_preset{false};
+  enums::ClimatePreset preset{};
+  bool has_custom_preset{false};
+  std::string custom_preset{};
+  bool has_target_humidity{false};
+  float target_humidity{0.0f};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesNumberResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  float min_value{0.0f};
+  float max_value{0.0f};
+  float step{0.0f};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string unit_of_measurement{};
+  enums::NumberMode mode{};
+  std::string device_class{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class NumberStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  float state{0.0f};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class NumberCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  float state{0.0f};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+};
+class ListEntitiesSelectResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  std::vector<std::string> options{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SelectStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SelectCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ListEntitiesLockResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  bool assumed_state{false};
+  bool supports_open{false};
+  bool requires_code{false};
+  std::string code_format{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class LockStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::LockState state{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class LockCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::LockCommand command{};
+  bool has_code{false};
+  std::string code{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesButtonResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ButtonCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+};
+class MediaPlayerSupportedFormat : public ProtoMessage {
+ public:
+  std::string format{};
+  uint32_t sample_rate{0};
+  uint32_t num_channels{0};
+  enums::MediaPlayerFormatPurpose purpose{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesMediaPlayerResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  bool supports_pause{false};
+  std::vector<MediaPlayerSupportedFormat> supported_formats{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class MediaPlayerStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::MediaPlayerState state{};
+  float volume{0.0f};
+  bool muted{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class MediaPlayerCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_command{false};
+  enums::MediaPlayerCommand command{};
+  bool has_volume{false};
+  float volume{0.0f};
+  bool has_media_url{false};
+  std::string media_url{};
+  bool has_announcement{false};
+  bool announcement{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+ public:
+  uint32_t flags{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothServiceData : public ProtoMessage {
+ public:
+  std::string uuid{};
+  std::vector<uint32_t> legacy_data{};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothLEAdvertisementResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  std::string name{};
+  int32_t rssi{0};
+  std::vector<std::string> service_uuids{};
+  std::vector<BluetoothServiceData> service_data{};
+  std::vector<BluetoothServiceData> manufacturer_data{};
+  uint32_t address_type{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothLERawAdvertisement : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  int32_t rssi{0};
+  uint32_t address_type{0};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
+ public:
+  std::vector<BluetoothLERawAdvertisement> advertisements{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class BluetoothDeviceRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  enums::BluetoothDeviceRequestType request_type{};
+  bool has_address_type{false};
+  uint32_t address_type{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothDeviceConnectionResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  bool connected{false};
+  uint32_t mtu{0};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTGetServicesRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTDescriptor : public ProtoMessage {
+ public:
+  std::vector<uint64_t> uuid{};
+  uint32_t handle{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTCharacteristic : public ProtoMessage {
+ public:
+  std::vector<uint64_t> uuid{};
+  uint32_t handle{0};
+  uint32_t properties{0};
+  std::vector<BluetoothGATTDescriptor> descriptors{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTService : public ProtoMessage {
+ public:
+  std::vector<uint64_t> uuid{};
+  uint32_t handle{0};
+  std::vector<BluetoothGATTCharacteristic> characteristics{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTGetServicesResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  std::vector<BluetoothGATTService> services{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTReadRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTReadResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTWriteRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  bool response{false};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTNotifyRequest : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  bool enable{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTNotifyDataResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  std::string data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class BluetoothConnectionsFreeResponse : public ProtoMessage {
+ public:
+  uint32_t free{0};
+  uint32_t limit{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTErrorResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTWriteResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothGATTNotifyResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  uint32_t handle{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothDevicePairingResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  bool paired{false};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothDeviceUnpairingResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  bool success{false};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+ public:
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+};
+class BluetoothDeviceClearCacheResponse : public ProtoMessage {
+ public:
+  uint64_t address{0};
+  bool success{false};
+  int32_t error{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SubscribeVoiceAssistantRequest : public ProtoMessage {
+ public:
+  bool subscribe{false};
+  uint32_t flags{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantAudioSettings : public ProtoMessage {
+ public:
+  uint32_t noise_suppression_level{0};
+  uint32_t auto_gain{0};
+  float volume_multiplier{0.0f};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantRequest : public ProtoMessage {
+ public:
+  bool start{false};
+  std::string conversation_id{};
+  uint32_t flags{0};
+  VoiceAssistantAudioSettings audio_settings{};
+  std::string wake_word_phrase{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantResponse : public ProtoMessage {
+ public:
+  uint32_t port{0};
+  bool error{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantEventData : public ProtoMessage {
+ public:
+  std::string name{};
+  std::string value{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantEventResponse : public ProtoMessage {
+ public:
+  enums::VoiceAssistantEvent event_type{};
+  std::vector<VoiceAssistantEventData> data{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantAudio : public ProtoMessage {
+ public:
+  std::string data{};
+  bool end{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantTimerEventResponse : public ProtoMessage {
+ public:
+  enums::VoiceAssistantTimerEvent event_type{};
+  std::string timer_id{};
+  std::string name{};
+  uint32_t total_seconds{0};
+  uint32_t seconds_left{0};
+  bool is_active{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  uint32_t supported_features{0};
+  bool requires_code{false};
+  bool requires_code_to_arm{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class AlarmControlPanelStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::AlarmControlPanelState state{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class AlarmControlPanelCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::AlarmControlPanelStateCommand command{};
+  std::string code{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesTextResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  uint32_t min_length{0};
+  uint32_t max_length{0};
+  std::string pattern{};
+  enums::TextMode mode{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class TextStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  bool missing_state{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class TextCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string state{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ListEntitiesDateResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class DateStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool missing_state{false};
+  uint32_t year{0};
+  uint32_t month{0};
+  uint32_t day{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class DateCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  uint32_t year{0};
+  uint32_t month{0};
+  uint32_t day{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesTimeResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class TimeStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool missing_state{false};
+  uint32_t hour{0};
+  uint32_t minute{0};
+  uint32_t second{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class TimeCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  uint32_t hour{0};
+  uint32_t minute{0};
+  uint32_t second{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesEventResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  std::vector<std::string> event_types{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class EventResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  std::string event_type{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class ListEntitiesValveResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  bool assumed_state{false};
+  bool supports_position{false};
+  bool supports_stop{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ValveStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  float position{0.0f};
+  enums::ValveOperation current_operation{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ValveCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool has_position{false};
+  float position{0.0f};
+  bool stop{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class ListEntitiesDateTimeResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class DateTimeStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool missing_state{false};
+  uint32_t epoch_seconds{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class DateTimeCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  uint32_t epoch_seconds{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+};
+class ListEntitiesUpdateResponse : public ProtoMessage {
+ public:
+  std::string object_id{};
+  uint32_t key{0};
+  std::string name{};
+  std::string unique_id{};
+  std::string icon{};
+  bool disabled_by_default{false};
+  enums::EntityCategory entity_category{};
+  std::string device_class{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class UpdateStateResponse : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  bool missing_state{false};
+  bool in_progress{false};
+  bool has_progress{false};
+  float progress{0.0f};
+  std::string current_version{};
+  std::string latest_version{};
+  std::string title{};
+  std::string release_summary{};
+  std::string release_url{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class UpdateCommandRequest : public ProtoMessage {
+ public:
+  uint32_t key{0};
+  enums::UpdateCommand command{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+
+    }  // namespace api
+    }  // namespace esphome
+    

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -1,0 +1,1655 @@
+// This file was automatically generated with a tool.
+// See scripts/api_protobuf/api_protobuf.py
+    #include "api_pb2_service.h"
+    #include "esphome/core/log.h"
+
+    namespace esphome {
+    namespace api {
+
+    static const char *const TAG = "api.service";
+
+    bool APIServerConnectionBase::send_hello_response(const HelloResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_hello_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<HelloResponse>(msg, 2);
+}
+bool APIServerConnectionBase::send_connect_response(const ConnectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_connect_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ConnectResponse>(msg, 4);
+}
+bool APIServerConnectionBase::send_disconnect_request(const DisconnectRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_disconnect_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DisconnectRequest>(msg, 5);
+}
+bool APIServerConnectionBase::send_disconnect_response(const DisconnectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_disconnect_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DisconnectResponse>(msg, 6);
+}
+bool APIServerConnectionBase::send_ping_request(const PingRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_ping_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<PingRequest>(msg, 7);
+}
+bool APIServerConnectionBase::send_ping_response(const PingResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_ping_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<PingResponse>(msg, 8);
+}
+bool APIServerConnectionBase::send_device_info_response(const DeviceInfoResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_device_info_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DeviceInfoResponse>(msg, 10);
+}
+bool APIServerConnectionBase::send_list_entities_done_response(const ListEntitiesDoneResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_done_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesDoneResponse>(msg, 19);
+}
+#ifdef USE_BINARY_SENSOR
+bool APIServerConnectionBase::send_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_binary_sensor_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesBinarySensorResponse>(msg, 12);
+}
+#endif
+#ifdef USE_BINARY_SENSOR
+bool APIServerConnectionBase::send_binary_sensor_state_response(const BinarySensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_binary_sensor_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BinarySensorStateResponse>(msg, 21);
+}
+#endif
+#ifdef USE_COVER
+bool APIServerConnectionBase::send_list_entities_cover_response(const ListEntitiesCoverResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_cover_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesCoverResponse>(msg, 13);
+}
+#endif
+#ifdef USE_COVER
+bool APIServerConnectionBase::send_cover_state_response(const CoverStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_cover_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<CoverStateResponse>(msg, 22);
+}
+#endif
+#ifdef USE_COVER
+#endif
+#ifdef USE_FAN
+bool APIServerConnectionBase::send_list_entities_fan_response(const ListEntitiesFanResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_fan_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesFanResponse>(msg, 14);
+}
+#endif
+#ifdef USE_FAN
+bool APIServerConnectionBase::send_fan_state_response(const FanStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_fan_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<FanStateResponse>(msg, 23);
+}
+#endif
+#ifdef USE_FAN
+#endif
+#ifdef USE_LIGHT
+bool APIServerConnectionBase::send_list_entities_light_response(const ListEntitiesLightResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_light_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesLightResponse>(msg, 15);
+}
+#endif
+#ifdef USE_LIGHT
+bool APIServerConnectionBase::send_light_state_response(const LightStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_light_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<LightStateResponse>(msg, 24);
+}
+#endif
+#ifdef USE_LIGHT
+#endif
+#ifdef USE_SENSOR
+bool APIServerConnectionBase::send_list_entities_sensor_response(const ListEntitiesSensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_sensor_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesSensorResponse>(msg, 16);
+}
+#endif
+#ifdef USE_SENSOR
+bool APIServerConnectionBase::send_sensor_state_response(const SensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_sensor_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SensorStateResponse>(msg, 25);
+}
+#endif
+#ifdef USE_SWITCH
+bool APIServerConnectionBase::send_list_entities_switch_response(const ListEntitiesSwitchResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_switch_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesSwitchResponse>(msg, 17);
+}
+#endif
+#ifdef USE_SWITCH
+bool APIServerConnectionBase::send_switch_state_response(const SwitchStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_switch_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SwitchStateResponse>(msg, 26);
+}
+#endif
+#ifdef USE_SWITCH
+#endif
+#ifdef USE_TEXT_SENSOR
+bool APIServerConnectionBase::send_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_text_sensor_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesTextSensorResponse>(msg, 18);
+}
+#endif
+#ifdef USE_TEXT_SENSOR
+bool APIServerConnectionBase::send_text_sensor_state_response(const TextSensorStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_text_sensor_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<TextSensorStateResponse>(msg, 27);
+}
+#endif
+bool APIServerConnectionBase::send_subscribe_logs_response(const SubscribeLogsResponse &msg) {
+  return this->send_message_<SubscribeLogsResponse>(msg, 29);
+}
+bool APIServerConnectionBase::send_homeassistant_service_response(const HomeassistantServiceResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_homeassistant_service_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<HomeassistantServiceResponse>(msg, 35);
+}
+bool APIServerConnectionBase::send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_subscribe_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SubscribeHomeAssistantStateResponse>(msg, 39);
+}
+bool APIServerConnectionBase::send_get_time_request(const GetTimeRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_get_time_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<GetTimeRequest>(msg, 36);
+}
+bool APIServerConnectionBase::send_get_time_response(const GetTimeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_get_time_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<GetTimeResponse>(msg, 37);
+}
+bool APIServerConnectionBase::send_list_entities_services_response(const ListEntitiesServicesResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_services_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesServicesResponse>(msg, 41);
+}
+#ifdef USE_ESP32_CAMERA
+bool APIServerConnectionBase::send_list_entities_camera_response(const ListEntitiesCameraResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_camera_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesCameraResponse>(msg, 43);
+}
+#endif
+#ifdef USE_ESP32_CAMERA
+bool APIServerConnectionBase::send_camera_image_response(const CameraImageResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_camera_image_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<CameraImageResponse>(msg, 44);
+}
+#endif
+#ifdef USE_ESP32_CAMERA
+#endif
+#ifdef USE_CLIMATE
+bool APIServerConnectionBase::send_list_entities_climate_response(const ListEntitiesClimateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_climate_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesClimateResponse>(msg, 46);
+}
+#endif
+#ifdef USE_CLIMATE
+bool APIServerConnectionBase::send_climate_state_response(const ClimateStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_climate_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ClimateStateResponse>(msg, 47);
+}
+#endif
+#ifdef USE_CLIMATE
+#endif
+#ifdef USE_NUMBER
+bool APIServerConnectionBase::send_list_entities_number_response(const ListEntitiesNumberResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_number_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesNumberResponse>(msg, 49);
+}
+#endif
+#ifdef USE_NUMBER
+bool APIServerConnectionBase::send_number_state_response(const NumberStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_number_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<NumberStateResponse>(msg, 50);
+}
+#endif
+#ifdef USE_NUMBER
+#endif
+#ifdef USE_SELECT
+bool APIServerConnectionBase::send_list_entities_select_response(const ListEntitiesSelectResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_select_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesSelectResponse>(msg, 52);
+}
+#endif
+#ifdef USE_SELECT
+bool APIServerConnectionBase::send_select_state_response(const SelectStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_select_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<SelectStateResponse>(msg, 53);
+}
+#endif
+#ifdef USE_SELECT
+#endif
+#ifdef USE_LOCK
+bool APIServerConnectionBase::send_list_entities_lock_response(const ListEntitiesLockResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_lock_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesLockResponse>(msg, 58);
+}
+#endif
+#ifdef USE_LOCK
+bool APIServerConnectionBase::send_lock_state_response(const LockStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_lock_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<LockStateResponse>(msg, 59);
+}
+#endif
+#ifdef USE_LOCK
+#endif
+#ifdef USE_BUTTON
+bool APIServerConnectionBase::send_list_entities_button_response(const ListEntitiesButtonResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_button_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesButtonResponse>(msg, 61);
+}
+#endif
+#ifdef USE_BUTTON
+#endif
+#ifdef USE_MEDIA_PLAYER
+bool APIServerConnectionBase::send_media_player_supported_format(const MediaPlayerSupportedFormat &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_media_player_supported_format: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<MediaPlayerSupportedFormat>(msg, 119);
+}
+#endif
+#ifdef USE_MEDIA_PLAYER
+bool APIServerConnectionBase::send_list_entities_media_player_response(const ListEntitiesMediaPlayerResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_media_player_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesMediaPlayerResponse>(msg, 63);
+}
+#endif
+#ifdef USE_MEDIA_PLAYER
+bool APIServerConnectionBase::send_media_player_state_response(const MediaPlayerStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_media_player_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<MediaPlayerStateResponse>(msg, 64);
+}
+#endif
+#ifdef USE_MEDIA_PLAYER
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_le_advertisement_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothLEAdvertisementResponse>(msg, 67);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_le_raw_advertisements_response(const BluetoothLERawAdvertisementsResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_le_raw_advertisements_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothLERawAdvertisementsResponse>(msg, 93);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_device_connection_response(const BluetoothDeviceConnectionResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_device_connection_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothDeviceConnectionResponse>(msg, 69);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_get_services_response(const BluetoothGATTGetServicesResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_get_services_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTGetServicesResponse>(msg, 71);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_get_services_done_response(const BluetoothGATTGetServicesDoneResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_get_services_done_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTGetServicesDoneResponse>(msg, 72);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_read_response(const BluetoothGATTReadResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_read_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTReadResponse>(msg, 74);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_notify_data_response(const BluetoothGATTNotifyDataResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_notify_data_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTNotifyDataResponse>(msg, 79);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_connections_free_response(const BluetoothConnectionsFreeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_connections_free_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothConnectionsFreeResponse>(msg, 81);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_error_response(const BluetoothGATTErrorResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_error_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTErrorResponse>(msg, 82);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_write_response(const BluetoothGATTWriteResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_write_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTWriteResponse>(msg, 83);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_gatt_notify_response(const BluetoothGATTNotifyResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_gatt_notify_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothGATTNotifyResponse>(msg, 84);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_device_pairing_response(const BluetoothDevicePairingResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_device_pairing_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothDevicePairingResponse>(msg, 85);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_device_unpairing_response(const BluetoothDeviceUnpairingResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_device_unpairing_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothDeviceUnpairingResponse>(msg, 86);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool APIServerConnectionBase::send_bluetooth_device_clear_cache_response(const BluetoothDeviceClearCacheResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_bluetooth_device_clear_cache_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<BluetoothDeviceClearCacheResponse>(msg, 88);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_request(const VoiceAssistantRequest &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_request: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantRequest>(msg, 90);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_audio(const VoiceAssistantAudio &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_audio: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantAudio>(msg, 106);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_alarm_control_panel_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesAlarmControlPanelResponse>(msg, 94);
+}
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+bool APIServerConnectionBase::send_alarm_control_panel_state_response(const AlarmControlPanelStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_alarm_control_panel_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<AlarmControlPanelStateResponse>(msg, 95);
+}
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+#endif
+#ifdef USE_TEXT
+bool APIServerConnectionBase::send_list_entities_text_response(const ListEntitiesTextResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_text_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesTextResponse>(msg, 97);
+}
+#endif
+#ifdef USE_TEXT
+bool APIServerConnectionBase::send_text_state_response(const TextStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_text_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<TextStateResponse>(msg, 98);
+}
+#endif
+#ifdef USE_TEXT
+#endif
+#ifdef USE_DATETIME_DATE
+bool APIServerConnectionBase::send_list_entities_date_response(const ListEntitiesDateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_date_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesDateResponse>(msg, 100);
+}
+#endif
+#ifdef USE_DATETIME_DATE
+bool APIServerConnectionBase::send_date_state_response(const DateStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_date_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DateStateResponse>(msg, 101);
+}
+#endif
+#ifdef USE_DATETIME_DATE
+#endif
+#ifdef USE_DATETIME_TIME
+bool APIServerConnectionBase::send_list_entities_time_response(const ListEntitiesTimeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_time_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesTimeResponse>(msg, 103);
+}
+#endif
+#ifdef USE_DATETIME_TIME
+bool APIServerConnectionBase::send_time_state_response(const TimeStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_time_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<TimeStateResponse>(msg, 104);
+}
+#endif
+#ifdef USE_DATETIME_TIME
+#endif
+#ifdef USE_EVENT
+bool APIServerConnectionBase::send_list_entities_event_response(const ListEntitiesEventResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_event_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesEventResponse>(msg, 107);
+}
+#endif
+#ifdef USE_EVENT
+bool APIServerConnectionBase::send_event_response(const EventResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_event_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<EventResponse>(msg, 108);
+}
+#endif
+#ifdef USE_VALVE
+bool APIServerConnectionBase::send_list_entities_valve_response(const ListEntitiesValveResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_valve_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesValveResponse>(msg, 109);
+}
+#endif
+#ifdef USE_VALVE
+bool APIServerConnectionBase::send_valve_state_response(const ValveStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_valve_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ValveStateResponse>(msg, 110);
+}
+#endif
+#ifdef USE_VALVE
+#endif
+#ifdef USE_DATETIME_DATETIME
+bool APIServerConnectionBase::send_list_entities_date_time_response(const ListEntitiesDateTimeResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_date_time_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesDateTimeResponse>(msg, 112);
+}
+#endif
+#ifdef USE_DATETIME_DATETIME
+bool APIServerConnectionBase::send_date_time_state_response(const DateTimeStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_date_time_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<DateTimeStateResponse>(msg, 113);
+}
+#endif
+#ifdef USE_DATETIME_DATETIME
+#endif
+#ifdef USE_UPDATE
+bool APIServerConnectionBase::send_list_entities_update_response(const ListEntitiesUpdateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_list_entities_update_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<ListEntitiesUpdateResponse>(msg, 116);
+}
+#endif
+#ifdef USE_UPDATE
+bool APIServerConnectionBase::send_update_state_response(const UpdateStateResponse &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_update_state_response: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<UpdateStateResponse>(msg, 117);
+}
+#endif
+#ifdef USE_UPDATE
+#endif
+bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
+  switch (msg_type) {
+    case 1: {
+      HelloRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump().c_str());
+#endif
+      this->on_hello_request(msg);
+      break;
+    }
+    case 3: {
+      ConnectRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_connect_request: %s", msg.dump().c_str());
+#endif
+      this->on_connect_request(msg);
+      break;
+    }
+    case 5: {
+      DisconnectRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump().c_str());
+#endif
+      this->on_disconnect_request(msg);
+      break;
+    }
+    case 6: {
+      DisconnectResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump().c_str());
+#endif
+      this->on_disconnect_response(msg);
+      break;
+    }
+    case 7: {
+      PingRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump().c_str());
+#endif
+      this->on_ping_request(msg);
+      break;
+    }
+    case 8: {
+      PingResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump().c_str());
+#endif
+      this->on_ping_response(msg);
+      break;
+    }
+    case 9: {
+      DeviceInfoRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump().c_str());
+#endif
+      this->on_device_info_request(msg);
+      break;
+    }
+    case 11: {
+      ListEntitiesRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump().c_str());
+#endif
+      this->on_list_entities_request(msg);
+      break;
+    }
+    case 20: {
+      SubscribeStatesRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_states_request(msg);
+      break;
+    }
+    case 28: {
+      SubscribeLogsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_logs_request(msg);
+      break;
+    }
+    case 30: {
+#ifdef USE_COVER
+      CoverCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_cover_command_request(msg);
+#endif
+      break;
+    }
+    case 31: {
+#ifdef USE_FAN
+      FanCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_fan_command_request(msg);
+#endif
+      break;
+    }
+    case 32: {
+#ifdef USE_LIGHT
+      LightCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_light_command_request(msg);
+#endif
+      break;
+    }
+    case 33: {
+#ifdef USE_SWITCH
+      SwitchCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_switch_command_request(msg);
+#endif
+      break;
+    }
+    case 34: {
+      SubscribeHomeassistantServicesRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_homeassistant_services_request(msg);
+      break;
+    }
+    case 36: {
+      GetTimeRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_get_time_request: %s", msg.dump().c_str());
+#endif
+      this->on_get_time_request(msg);
+      break;
+    }
+    case 37: {
+      GetTimeResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump().c_str());
+#endif
+      this->on_get_time_response(msg);
+      break;
+    }
+    case 38: {
+      SubscribeHomeAssistantStatesRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_home_assistant_states_request(msg);
+      break;
+    }
+    case 40: {
+      HomeAssistantStateResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump().c_str());
+#endif
+      this->on_home_assistant_state_response(msg);
+      break;
+    }
+    case 42: {
+      ExecuteServiceRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump().c_str());
+#endif
+      this->on_execute_service_request(msg);
+      break;
+    }
+    case 45: {
+#ifdef USE_ESP32_CAMERA
+      CameraImageRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump().c_str());
+#endif
+      this->on_camera_image_request(msg);
+#endif
+      break;
+    }
+    case 48: {
+#ifdef USE_CLIMATE
+      ClimateCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_climate_command_request(msg);
+#endif
+      break;
+    }
+    case 51: {
+#ifdef USE_NUMBER
+      NumberCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_number_command_request(msg);
+#endif
+      break;
+    }
+    case 54: {
+#ifdef USE_SELECT
+      SelectCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_select_command_request(msg);
+#endif
+      break;
+    }
+    case 60: {
+#ifdef USE_LOCK
+      LockCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_lock_command_request(msg);
+#endif
+      break;
+    }
+    case 62: {
+#ifdef USE_BUTTON
+      ButtonCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_button_command_request(msg);
+#endif
+      break;
+    }
+    case 65: {
+#ifdef USE_MEDIA_PLAYER
+      MediaPlayerCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_media_player_command_request(msg);
+#endif
+      break;
+    }
+    case 66: {
+#ifdef USE_BLUETOOTH_PROXY
+      SubscribeBluetoothLEAdvertisementsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_bluetooth_le_advertisements_request(msg);
+#endif
+      break;
+    }
+    case 68: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothDeviceRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_device_request(msg);
+#endif
+      break;
+    }
+    case 70: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTGetServicesRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_get_services_request(msg);
+#endif
+      break;
+    }
+    case 73: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTReadRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_read_request(msg);
+#endif
+      break;
+    }
+    case 75: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTWriteRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_write_request(msg);
+#endif
+      break;
+    }
+    case 76: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTReadDescriptorRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_read_descriptor_request(msg);
+#endif
+      break;
+    }
+    case 77: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTWriteDescriptorRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_write_descriptor_request(msg);
+#endif
+      break;
+    }
+    case 78: {
+#ifdef USE_BLUETOOTH_PROXY
+      BluetoothGATTNotifyRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump().c_str());
+#endif
+      this->on_bluetooth_gatt_notify_request(msg);
+#endif
+      break;
+    }
+    case 80: {
+#ifdef USE_BLUETOOTH_PROXY
+      SubscribeBluetoothConnectionsFreeRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_bluetooth_connections_free_request(msg);
+#endif
+      break;
+    }
+    case 87: {
+#ifdef USE_BLUETOOTH_PROXY
+      UnsubscribeBluetoothLEAdvertisementsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
+#endif
+      this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
+#endif
+      break;
+    }
+    case 89: {
+#ifdef USE_VOICE_ASSISTANT
+      SubscribeVoiceAssistantRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump().c_str());
+#endif
+      this->on_subscribe_voice_assistant_request(msg);
+#endif
+      break;
+    }
+    case 91: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_response(msg);
+#endif
+      break;
+    }
+    case 92: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantEventResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_event_response(msg);
+#endif
+      break;
+    }
+    case 96: {
+#ifdef USE_ALARM_CONTROL_PANEL
+      AlarmControlPanelCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_alarm_control_panel_command_request(msg);
+#endif
+      break;
+    }
+    case 99: {
+#ifdef USE_TEXT
+      TextCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_text_command_request(msg);
+#endif
+      break;
+    }
+    case 102: {
+#ifdef USE_DATETIME_DATE
+      DateCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_date_command_request(msg);
+#endif
+      break;
+    }
+    case 105: {
+#ifdef USE_DATETIME_TIME
+      TimeCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_time_command_request(msg);
+#endif
+      break;
+    }
+    case 106: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantAudio msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_audio(msg);
+#endif
+      break;
+    }
+    case 111: {
+#ifdef USE_VALVE
+      ValveCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_valve_command_request(msg);
+#endif
+      break;
+    }
+    case 114: {
+#ifdef USE_DATETIME_DATETIME
+      DateTimeCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_date_time_command_request(msg);
+#endif
+      break;
+    }
+    case 115: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantTimerEventResponse msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_timer_event_response(msg);
+#endif
+      break;
+    }
+    case 118: {
+#ifdef USE_UPDATE
+      UpdateCommandRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump().c_str());
+#endif
+      this->on_update_command_request(msg);
+#endif
+      break;
+    }
+    case 119: {
+#ifdef USE_MEDIA_PLAYER
+      MediaPlayerSupportedFormat msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
+#endif
+      this->on_media_player_supported_format(msg);
+#endif
+      break;
+    }
+    default:
+      return false;
+  }
+  return true;
+}
+
+void APIServerConnection::on_hello_request(const HelloRequest &msg) {
+  HelloResponse ret = this->hello(msg);
+  if (!this->send_hello_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_connect_request(const ConnectRequest &msg) {
+  ConnectResponse ret = this->connect(msg);
+  if (!this->send_connect_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_disconnect_request(const DisconnectRequest &msg) {
+  DisconnectResponse ret = this->disconnect(msg);
+  if (!this->send_disconnect_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_ping_request(const PingRequest &msg) {
+  PingResponse ret = this->ping(msg);
+  if (!this->send_ping_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  DeviceInfoResponse ret = this->device_info(msg);
+  if (!this->send_device_info_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_list_entities_request(const ListEntitiesRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->list_entities(msg);
+}
+void APIServerConnection::on_subscribe_states_request(const SubscribeStatesRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_states(msg);
+}
+void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_logs(msg);
+}
+void APIServerConnection::on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_homeassistant_services(msg);
+}
+void APIServerConnection::on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_home_assistant_states(msg);
+}
+void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  GetTimeResponse ret = this->get_time(msg);
+  if (!this->send_get_time_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->execute_service(msg);
+}
+#ifdef USE_COVER
+void APIServerConnection::on_cover_command_request(const CoverCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->cover_command(msg);
+}
+#endif
+#ifdef USE_FAN
+void APIServerConnection::on_fan_command_request(const FanCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->fan_command(msg);
+}
+#endif
+#ifdef USE_LIGHT
+void APIServerConnection::on_light_command_request(const LightCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->light_command(msg);
+}
+#endif
+#ifdef USE_SWITCH
+void APIServerConnection::on_switch_command_request(const SwitchCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->switch_command(msg);
+}
+#endif
+#ifdef USE_ESP32_CAMERA
+void APIServerConnection::on_camera_image_request(const CameraImageRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->camera_image(msg);
+}
+#endif
+#ifdef USE_CLIMATE
+void APIServerConnection::on_climate_command_request(const ClimateCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->climate_command(msg);
+}
+#endif
+#ifdef USE_NUMBER
+void APIServerConnection::on_number_command_request(const NumberCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->number_command(msg);
+}
+#endif
+#ifdef USE_TEXT
+void APIServerConnection::on_text_command_request(const TextCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->text_command(msg);
+}
+#endif
+#ifdef USE_SELECT
+void APIServerConnection::on_select_command_request(const SelectCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->select_command(msg);
+}
+#endif
+#ifdef USE_BUTTON
+void APIServerConnection::on_button_command_request(const ButtonCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->button_command(msg);
+}
+#endif
+#ifdef USE_LOCK
+void APIServerConnection::on_lock_command_request(const LockCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->lock_command(msg);
+}
+#endif
+#ifdef USE_VALVE
+void APIServerConnection::on_valve_command_request(const ValveCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->valve_command(msg);
+}
+#endif
+#ifdef USE_MEDIA_PLAYER
+void APIServerConnection::on_media_player_command_request(const MediaPlayerCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->media_player_command(msg);
+}
+#endif
+#ifdef USE_DATETIME_DATE
+void APIServerConnection::on_date_command_request(const DateCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->date_command(msg);
+}
+#endif
+#ifdef USE_DATETIME_TIME
+void APIServerConnection::on_time_command_request(const TimeCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->time_command(msg);
+}
+#endif
+#ifdef USE_DATETIME_DATETIME
+void APIServerConnection::on_date_time_command_request(const DateTimeCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->datetime_command(msg);
+}
+#endif
+#ifdef USE_UPDATE
+void APIServerConnection::on_update_command_request(const UpdateCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->update_command(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_bluetooth_le_advertisements(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_device_request(const BluetoothDeviceRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_device_request(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_get_services_request(const BluetoothGATTGetServicesRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_get_services(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_read_request(const BluetoothGATTReadRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_read(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_write_request(const BluetoothGATTWriteRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_write(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_read_descriptor_request(const BluetoothGATTReadDescriptorRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_read_descriptor(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_write_descriptor_request(const BluetoothGATTWriteDescriptorRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_write_descriptor(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNotifyRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->bluetooth_gatt_notify(msg);
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
+  if (!this->send_bluetooth_connections_free_response(ret)) {
+    this->on_fatal_error();
+  }
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->unsubscribe_bluetooth_le_advertisements(msg);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVoiceAssistantRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->subscribe_voice_assistant(msg);
+}
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+void APIServerConnection::on_alarm_control_panel_command_request(const AlarmControlPanelCommandRequest &msg) {
+  if (!this->is_connection_setup()) {
+    this->on_no_setup_connection();
+    return;
+  }
+  if (!this->is_authenticated()) {
+    this->on_unauthenticated_access();
+    return;
+  }
+  this->alarm_control_panel_command(msg);
+}
+#endif
+
+    }  // namespace api
+    }  // namespace esphome
+    

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -1,0 +1,530 @@
+// This file was automatically generated with a tool.
+// See scripts/api_protobuf/api_protobuf.py
+    #pragma once
+
+    #include "api_pb2.h"
+    #include "esphome/core/defines.h"
+
+    namespace esphome {
+    namespace api {
+
+    class APIServerConnectionBase : public ProtoService {
+ public:
+  virtual void on_hello_request(const HelloRequest &value){};
+  bool send_hello_response(const HelloResponse &msg);
+  virtual void on_connect_request(const ConnectRequest &value){};
+  bool send_connect_response(const ConnectResponse &msg);
+  bool send_disconnect_request(const DisconnectRequest &msg);
+  virtual void on_disconnect_request(const DisconnectRequest &value){};
+  bool send_disconnect_response(const DisconnectResponse &msg);
+  virtual void on_disconnect_response(const DisconnectResponse &value){};
+  bool send_ping_request(const PingRequest &msg);
+  virtual void on_ping_request(const PingRequest &value){};
+  bool send_ping_response(const PingResponse &msg);
+  virtual void on_ping_response(const PingResponse &value){};
+  virtual void on_device_info_request(const DeviceInfoRequest &value){};
+  bool send_device_info_response(const DeviceInfoResponse &msg);
+  virtual void on_list_entities_request(const ListEntitiesRequest &value){};
+  bool send_list_entities_done_response(const ListEntitiesDoneResponse &msg);
+  virtual void on_subscribe_states_request(const SubscribeStatesRequest &value){};
+#ifdef USE_BINARY_SENSOR
+  bool send_list_entities_binary_sensor_response(const ListEntitiesBinarySensorResponse &msg);
+#endif
+#ifdef USE_BINARY_SENSOR
+  bool send_binary_sensor_state_response(const BinarySensorStateResponse &msg);
+#endif
+#ifdef USE_COVER
+  bool send_list_entities_cover_response(const ListEntitiesCoverResponse &msg);
+#endif
+#ifdef USE_COVER
+  bool send_cover_state_response(const CoverStateResponse &msg);
+#endif
+#ifdef USE_COVER
+  virtual void on_cover_command_request(const CoverCommandRequest &value){};
+#endif
+#ifdef USE_FAN
+  bool send_list_entities_fan_response(const ListEntitiesFanResponse &msg);
+#endif
+#ifdef USE_FAN
+  bool send_fan_state_response(const FanStateResponse &msg);
+#endif
+#ifdef USE_FAN
+  virtual void on_fan_command_request(const FanCommandRequest &value){};
+#endif
+#ifdef USE_LIGHT
+  bool send_list_entities_light_response(const ListEntitiesLightResponse &msg);
+#endif
+#ifdef USE_LIGHT
+  bool send_light_state_response(const LightStateResponse &msg);
+#endif
+#ifdef USE_LIGHT
+  virtual void on_light_command_request(const LightCommandRequest &value){};
+#endif
+#ifdef USE_SENSOR
+  bool send_list_entities_sensor_response(const ListEntitiesSensorResponse &msg);
+#endif
+#ifdef USE_SENSOR
+  bool send_sensor_state_response(const SensorStateResponse &msg);
+#endif
+#ifdef USE_SWITCH
+  bool send_list_entities_switch_response(const ListEntitiesSwitchResponse &msg);
+#endif
+#ifdef USE_SWITCH
+  bool send_switch_state_response(const SwitchStateResponse &msg);
+#endif
+#ifdef USE_SWITCH
+  virtual void on_switch_command_request(const SwitchCommandRequest &value){};
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool send_list_entities_text_sensor_response(const ListEntitiesTextSensorResponse &msg);
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool send_text_sensor_state_response(const TextSensorStateResponse &msg);
+#endif
+  virtual void on_subscribe_logs_request(const SubscribeLogsRequest &value){};
+  bool send_subscribe_logs_response(const SubscribeLogsResponse &msg);
+  virtual void on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &value){};
+  bool send_homeassistant_service_response(const HomeassistantServiceResponse &msg);
+  virtual void on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &value){};
+  bool send_subscribe_home_assistant_state_response(const SubscribeHomeAssistantStateResponse &msg);
+  virtual void on_home_assistant_state_response(const HomeAssistantStateResponse &value){};
+  bool send_get_time_request(const GetTimeRequest &msg);
+  virtual void on_get_time_request(const GetTimeRequest &value){};
+  bool send_get_time_response(const GetTimeResponse &msg);
+  virtual void on_get_time_response(const GetTimeResponse &value){};
+  bool send_list_entities_services_response(const ListEntitiesServicesResponse &msg);
+  virtual void on_execute_service_request(const ExecuteServiceRequest &value){};
+#ifdef USE_ESP32_CAMERA
+  bool send_list_entities_camera_response(const ListEntitiesCameraResponse &msg);
+#endif
+#ifdef USE_ESP32_CAMERA
+  bool send_camera_image_response(const CameraImageResponse &msg);
+#endif
+#ifdef USE_ESP32_CAMERA
+  virtual void on_camera_image_request(const CameraImageRequest &value){};
+#endif
+#ifdef USE_CLIMATE
+  bool send_list_entities_climate_response(const ListEntitiesClimateResponse &msg);
+#endif
+#ifdef USE_CLIMATE
+  bool send_climate_state_response(const ClimateStateResponse &msg);
+#endif
+#ifdef USE_CLIMATE
+  virtual void on_climate_command_request(const ClimateCommandRequest &value){};
+#endif
+#ifdef USE_NUMBER
+  bool send_list_entities_number_response(const ListEntitiesNumberResponse &msg);
+#endif
+#ifdef USE_NUMBER
+  bool send_number_state_response(const NumberStateResponse &msg);
+#endif
+#ifdef USE_NUMBER
+  virtual void on_number_command_request(const NumberCommandRequest &value){};
+#endif
+#ifdef USE_SELECT
+  bool send_list_entities_select_response(const ListEntitiesSelectResponse &msg);
+#endif
+#ifdef USE_SELECT
+  bool send_select_state_response(const SelectStateResponse &msg);
+#endif
+#ifdef USE_SELECT
+  virtual void on_select_command_request(const SelectCommandRequest &value){};
+#endif
+#ifdef USE_LOCK
+  bool send_list_entities_lock_response(const ListEntitiesLockResponse &msg);
+#endif
+#ifdef USE_LOCK
+  bool send_lock_state_response(const LockStateResponse &msg);
+#endif
+#ifdef USE_LOCK
+  virtual void on_lock_command_request(const LockCommandRequest &value){};
+#endif
+#ifdef USE_BUTTON
+  bool send_list_entities_button_response(const ListEntitiesButtonResponse &msg);
+#endif
+#ifdef USE_BUTTON
+  virtual void on_button_command_request(const ButtonCommandRequest &value){};
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool send_media_player_supported_format(const MediaPlayerSupportedFormat &msg);
+  virtual void on_media_player_supported_format(const MediaPlayerSupportedFormat &value){};
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool send_list_entities_media_player_response(const ListEntitiesMediaPlayerResponse &msg);
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool send_media_player_state_response(const MediaPlayerStateResponse &msg);
+#endif
+#ifdef USE_MEDIA_PLAYER
+  virtual void on_media_player_command_request(const MediaPlayerCommandRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_le_advertisement_response(const BluetoothLEAdvertisementResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_le_raw_advertisements_response(const BluetoothLERawAdvertisementsResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_device_request(const BluetoothDeviceRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_device_connection_response(const BluetoothDeviceConnectionResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_get_services_request(const BluetoothGATTGetServicesRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_get_services_response(const BluetoothGATTGetServicesResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_get_services_done_response(const BluetoothGATTGetServicesDoneResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_read_request(const BluetoothGATTReadRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_read_response(const BluetoothGATTReadResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_write_request(const BluetoothGATTWriteRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_read_descriptor_request(const BluetoothGATTReadDescriptorRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_write_descriptor_request(const BluetoothGATTWriteDescriptorRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_gatt_notify_request(const BluetoothGATTNotifyRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_notify_data_response(const BluetoothGATTNotifyDataResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_connections_free_response(const BluetoothConnectionsFreeResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_error_response(const BluetoothGATTErrorResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_write_response(const BluetoothGATTWriteResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_gatt_notify_response(const BluetoothGATTNotifyResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_device_pairing_response(const BluetoothDevicePairingResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_device_unpairing_response(const BluetoothDeviceUnpairingResponse &msg);
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_unsubscribe_bluetooth_le_advertisements_request(const UnsubscribeBluetoothLEAdvertisementsRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  bool send_bluetooth_device_clear_cache_response(const BluetoothDeviceClearCacheResponse &msg);
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_subscribe_voice_assistant_request(const SubscribeVoiceAssistantRequest &value){};
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_request(const VoiceAssistantRequest &msg);
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_voice_assistant_response(const VoiceAssistantResponse &value){};
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_voice_assistant_event_response(const VoiceAssistantEventResponse &value){};
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_audio(const VoiceAssistantAudio &msg);
+  virtual void on_voice_assistant_audio(const VoiceAssistantAudio &value){};
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &value){};
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  bool send_alarm_control_panel_state_response(const AlarmControlPanelStateResponse &msg);
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  virtual void on_alarm_control_panel_command_request(const AlarmControlPanelCommandRequest &value){};
+#endif
+#ifdef USE_TEXT
+  bool send_list_entities_text_response(const ListEntitiesTextResponse &msg);
+#endif
+#ifdef USE_TEXT
+  bool send_text_state_response(const TextStateResponse &msg);
+#endif
+#ifdef USE_TEXT
+  virtual void on_text_command_request(const TextCommandRequest &value){};
+#endif
+#ifdef USE_DATETIME_DATE
+  bool send_list_entities_date_response(const ListEntitiesDateResponse &msg);
+#endif
+#ifdef USE_DATETIME_DATE
+  bool send_date_state_response(const DateStateResponse &msg);
+#endif
+#ifdef USE_DATETIME_DATE
+  virtual void on_date_command_request(const DateCommandRequest &value){};
+#endif
+#ifdef USE_DATETIME_TIME
+  bool send_list_entities_time_response(const ListEntitiesTimeResponse &msg);
+#endif
+#ifdef USE_DATETIME_TIME
+  bool send_time_state_response(const TimeStateResponse &msg);
+#endif
+#ifdef USE_DATETIME_TIME
+  virtual void on_time_command_request(const TimeCommandRequest &value){};
+#endif
+#ifdef USE_EVENT
+  bool send_list_entities_event_response(const ListEntitiesEventResponse &msg);
+#endif
+#ifdef USE_EVENT
+  bool send_event_response(const EventResponse &msg);
+#endif
+#ifdef USE_VALVE
+  bool send_list_entities_valve_response(const ListEntitiesValveResponse &msg);
+#endif
+#ifdef USE_VALVE
+  bool send_valve_state_response(const ValveStateResponse &msg);
+#endif
+#ifdef USE_VALVE
+  virtual void on_valve_command_request(const ValveCommandRequest &value){};
+#endif
+#ifdef USE_DATETIME_DATETIME
+  bool send_list_entities_date_time_response(const ListEntitiesDateTimeResponse &msg);
+#endif
+#ifdef USE_DATETIME_DATETIME
+  bool send_date_time_state_response(const DateTimeStateResponse &msg);
+#endif
+#ifdef USE_DATETIME_DATETIME
+  virtual void on_date_time_command_request(const DateTimeCommandRequest &value){};
+#endif
+#ifdef USE_UPDATE
+  bool send_list_entities_update_response(const ListEntitiesUpdateResponse &msg);
+#endif
+#ifdef USE_UPDATE
+  bool send_update_state_response(const UpdateStateResponse &msg);
+#endif
+#ifdef USE_UPDATE
+  virtual void on_update_command_request(const UpdateCommandRequest &value){};
+#endif
+ protected:
+  bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
+};
+
+class APIServerConnection : public APIServerConnectionBase {
+ public:
+  virtual HelloResponse hello(const HelloRequest &msg) = 0;
+  virtual ConnectResponse connect(const ConnectRequest &msg) = 0;
+  virtual DisconnectResponse disconnect(const DisconnectRequest &msg) = 0;
+  virtual PingResponse ping(const PingRequest &msg) = 0;
+  virtual DeviceInfoResponse device_info(const DeviceInfoRequest &msg) = 0;
+  virtual void list_entities(const ListEntitiesRequest &msg) = 0;
+  virtual void subscribe_states(const SubscribeStatesRequest &msg) = 0;
+  virtual void subscribe_logs(const SubscribeLogsRequest &msg) = 0;
+  virtual void subscribe_homeassistant_services(const SubscribeHomeassistantServicesRequest &msg) = 0;
+  virtual void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) = 0;
+  virtual GetTimeResponse get_time(const GetTimeRequest &msg) = 0;
+  virtual void execute_service(const ExecuteServiceRequest &msg) = 0;
+#ifdef USE_COVER
+  virtual void cover_command(const CoverCommandRequest &msg) = 0;
+#endif
+#ifdef USE_FAN
+  virtual void fan_command(const FanCommandRequest &msg) = 0;
+#endif
+#ifdef USE_LIGHT
+  virtual void light_command(const LightCommandRequest &msg) = 0;
+#endif
+#ifdef USE_SWITCH
+  virtual void switch_command(const SwitchCommandRequest &msg) = 0;
+#endif
+#ifdef USE_ESP32_CAMERA
+  virtual void camera_image(const CameraImageRequest &msg) = 0;
+#endif
+#ifdef USE_CLIMATE
+  virtual void climate_command(const ClimateCommandRequest &msg) = 0;
+#endif
+#ifdef USE_NUMBER
+  virtual void number_command(const NumberCommandRequest &msg) = 0;
+#endif
+#ifdef USE_TEXT
+  virtual void text_command(const TextCommandRequest &msg) = 0;
+#endif
+#ifdef USE_SELECT
+  virtual void select_command(const SelectCommandRequest &msg) = 0;
+#endif
+#ifdef USE_BUTTON
+  virtual void button_command(const ButtonCommandRequest &msg) = 0;
+#endif
+#ifdef USE_LOCK
+  virtual void lock_command(const LockCommandRequest &msg) = 0;
+#endif
+#ifdef USE_VALVE
+  virtual void valve_command(const ValveCommandRequest &msg) = 0;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  virtual void media_player_command(const MediaPlayerCommandRequest &msg) = 0;
+#endif
+#ifdef USE_DATETIME_DATE
+  virtual void date_command(const DateCommandRequest &msg) = 0;
+#endif
+#ifdef USE_DATETIME_TIME
+  virtual void time_command(const TimeCommandRequest &msg) = 0;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  virtual void datetime_command(const DateTimeCommandRequest &msg) = 0;
+#endif
+#ifdef USE_UPDATE
+  virtual void update_command(const UpdateCommandRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_device_request(const BluetoothDeviceRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_get_services(const BluetoothGATTGetServicesRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_read(const BluetoothGATTReadRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_write(const BluetoothGATTWriteRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_read_descriptor(const BluetoothGATTReadDescriptorRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_write_descriptor(const BluetoothGATTWriteDescriptorRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void unsubscribe_bluetooth_le_advertisements(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) = 0;
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void subscribe_voice_assistant(const SubscribeVoiceAssistantRequest &msg) = 0;
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  virtual void alarm_control_panel_command(const AlarmControlPanelCommandRequest &msg) = 0;
+#endif
+ protected:
+  void on_hello_request(const HelloRequest &msg) override;
+  void on_connect_request(const ConnectRequest &msg) override;
+  void on_disconnect_request(const DisconnectRequest &msg) override;
+  void on_ping_request(const PingRequest &msg) override;
+  void on_device_info_request(const DeviceInfoRequest &msg) override;
+  void on_list_entities_request(const ListEntitiesRequest &msg) override;
+  void on_subscribe_states_request(const SubscribeStatesRequest &msg) override;
+  void on_subscribe_logs_request(const SubscribeLogsRequest &msg) override;
+  void on_subscribe_homeassistant_services_request(const SubscribeHomeassistantServicesRequest &msg) override;
+  void on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) override;
+  void on_get_time_request(const GetTimeRequest &msg) override;
+  void on_execute_service_request(const ExecuteServiceRequest &msg) override;
+#ifdef USE_COVER
+  void on_cover_command_request(const CoverCommandRequest &msg) override;
+#endif
+#ifdef USE_FAN
+  void on_fan_command_request(const FanCommandRequest &msg) override;
+#endif
+#ifdef USE_LIGHT
+  void on_light_command_request(const LightCommandRequest &msg) override;
+#endif
+#ifdef USE_SWITCH
+  void on_switch_command_request(const SwitchCommandRequest &msg) override;
+#endif
+#ifdef USE_ESP32_CAMERA
+  void on_camera_image_request(const CameraImageRequest &msg) override;
+#endif
+#ifdef USE_CLIMATE
+  void on_climate_command_request(const ClimateCommandRequest &msg) override;
+#endif
+#ifdef USE_NUMBER
+  void on_number_command_request(const NumberCommandRequest &msg) override;
+#endif
+#ifdef USE_TEXT
+  void on_text_command_request(const TextCommandRequest &msg) override;
+#endif
+#ifdef USE_SELECT
+  void on_select_command_request(const SelectCommandRequest &msg) override;
+#endif
+#ifdef USE_BUTTON
+  void on_button_command_request(const ButtonCommandRequest &msg) override;
+#endif
+#ifdef USE_LOCK
+  void on_lock_command_request(const LockCommandRequest &msg) override;
+#endif
+#ifdef USE_VALVE
+  void on_valve_command_request(const ValveCommandRequest &msg) override;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  void on_media_player_command_request(const MediaPlayerCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_DATE
+  void on_date_command_request(const DateCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_TIME
+  void on_time_command_request(const TimeCommandRequest &msg) override;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  void on_date_time_command_request(const DateTimeCommandRequest &msg) override;
+#endif
+#ifdef USE_UPDATE
+  void on_update_command_request(const UpdateCommandRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_device_request(const BluetoothDeviceRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_get_services_request(const BluetoothGATTGetServicesRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_read_request(const BluetoothGATTReadRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_write_request(const BluetoothGATTWriteRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_read_descriptor_request(const BluetoothGATTReadDescriptorRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_write_descriptor_request(const BluetoothGATTWriteDescriptorRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_bluetooth_gatt_notify_request(const BluetoothGATTNotifyRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_subscribe_bluetooth_connections_free_request(const SubscribeBluetoothConnectionsFreeRequest &msg) override;
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  void on_unsubscribe_bluetooth_le_advertisements_request(const UnsubscribeBluetoothLEAdvertisementsRequest &msg) override;
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  void on_subscribe_voice_assistant_request(const SubscribeVoiceAssistantRequest &msg) override;
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  void on_alarm_control_panel_command_request(const AlarmControlPanelCommandRequest &msg) override;
+#endif
+};
+
+    }  // namespace api
+    }  // namespace esphome
+    

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -1,0 +1,405 @@
+#include "api_server.h"
+#include <cerrno>
+#include "api_connection.h"
+#include "esphome/components/network/util.h"
+#include "esphome/core/application.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
+#include "esphome/core/version.h"
+
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
+
+#include <algorithm>
+
+namespace esphome {
+namespace api {
+
+static const char *const TAG = "api";
+
+// APIServer
+void APIServer::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
+  this->setup_controller();
+  socket_ = socket::socket_ip(SOCK_STREAM, 0);
+  if (socket_ == nullptr) {
+    ESP_LOGW(TAG, "Could not create socket.");
+    this->mark_failed();
+    return;
+  }
+  int enable = 1;
+  int err = socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to set reuseaddr: errno %d", err);
+    // we can still continue
+  }
+  err = socket_->setblocking(false);
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to set nonblocking mode: errno %d", err);
+    this->mark_failed();
+    return;
+  }
+
+  struct sockaddr_storage server;
+
+  socklen_t sl = socket::set_sockaddr_any((struct sockaddr *) &server, sizeof(server), this->port_);
+  if (sl == 0) {
+    ESP_LOGW(TAG, "Socket unable to set sockaddr: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+  err = socket_->bind((struct sockaddr *) &server, sl);
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to bind: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+  err = socket_->listen(4);
+  if (err != 0) {
+    ESP_LOGW(TAG, "Socket unable to listen: errno %d", errno);
+    this->mark_failed();
+    return;
+  }
+
+#ifdef USE_LOGGER
+  if (logger::global_logger != nullptr) {
+    logger::global_logger->add_on_log_callback([this](int level, const char *tag, const char *message) {
+      for (auto &c : this->clients_) {
+        if (!c->remove_)
+          c->send_log_message(level, tag, message);
+      }
+    });
+  }
+#endif
+
+  this->last_connected_ = millis();
+
+#ifdef USE_ESP32_CAMERA
+  if (esp32_camera::global_esp32_camera != nullptr && !esp32_camera::global_esp32_camera->is_internal()) {
+    esp32_camera::global_esp32_camera->add_image_callback(
+        [this](const std::shared_ptr<esp32_camera::CameraImage> &image) {
+          for (auto &c : this->clients_) {
+            if (!c->remove_)
+              c->send_camera_state(image);
+          }
+        });
+  }
+#endif
+}
+void APIServer::loop() {
+  // Accept new clients
+  while (true) {
+    struct sockaddr_storage source_addr;
+    socklen_t addr_len = sizeof(source_addr);
+    auto sock = socket_->accept((struct sockaddr *) &source_addr, &addr_len);
+    if (!sock)
+      break;
+    ESP_LOGD(TAG, "Accepted %s", sock->getpeername().c_str());
+
+    auto *conn = new APIConnection(std::move(sock), this);
+    clients_.emplace_back(conn);
+    conn->start();
+  }
+
+  // Partition clients into remove and active
+  auto new_end = std::partition(this->clients_.begin(), this->clients_.end(),
+                                [](const std::unique_ptr<APIConnection> &conn) { return !conn->remove_; });
+  // print disconnection messages
+  for (auto it = new_end; it != this->clients_.end(); ++it) {
+    this->client_disconnected_trigger_->trigger((*it)->client_info_, (*it)->client_peername_);
+    ESP_LOGV(TAG, "Removing connection to %s", (*it)->client_info_.c_str());
+  }
+  // resize vector
+  this->clients_.erase(new_end, this->clients_.end());
+
+  for (auto &client : this->clients_) {
+    client->loop();
+  }
+
+  if (this->reboot_timeout_ != 0) {
+    const uint32_t now = millis();
+    if (!this->is_connected()) {
+      if (now - this->last_connected_ > this->reboot_timeout_) {
+        ESP_LOGE(TAG, "No client connected to API. Rebooting...");
+        App.reboot();
+      }
+      this->status_set_warning();
+    } else {
+      this->last_connected_ = now;
+      this->status_clear_warning();
+    }
+  }
+}
+void APIServer::dump_config() {
+  ESP_LOGCONFIG(TAG, "API Server:");
+  ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
+#ifdef USE_API_NOISE
+  ESP_LOGCONFIG(TAG, "  Using noise encryption: YES");
+#else
+  ESP_LOGCONFIG(TAG, "  Using noise encryption: NO");
+#endif
+}
+bool APIServer::uses_password() const { return !this->password_.empty(); }
+bool APIServer::check_password(const std::string &password) const {
+  // depend only on input password length
+  const char *a = this->password_.c_str();
+  uint32_t len_a = this->password_.length();
+  const char *b = password.c_str();
+  uint32_t len_b = password.length();
+
+  // disable optimization with volatile
+  volatile uint32_t length = len_b;
+  volatile const char *left = nullptr;
+  volatile const char *right = b;
+  uint8_t result = 0;
+
+  if (len_a == length) {
+    left = *((volatile const char **) &a);
+    result = 0;
+  }
+  if (len_a != length) {
+    left = b;
+    result = 1;
+  }
+
+  for (size_t i = 0; i < length; i++) {
+    result |= *left++ ^ *right++;  // NOLINT
+  }
+
+  return result == 0;
+}
+void APIServer::handle_disconnect(APIConnection *conn) {}
+#ifdef USE_BINARY_SENSOR
+void APIServer::on_binary_sensor_update(binary_sensor::BinarySensor *obj, bool state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_binary_sensor_state(obj, state);
+}
+#endif
+
+#ifdef USE_COVER
+void APIServer::on_cover_update(cover::Cover *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_cover_state(obj);
+}
+#endif
+
+#ifdef USE_FAN
+void APIServer::on_fan_update(fan::Fan *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_fan_state(obj);
+}
+#endif
+
+#ifdef USE_LIGHT
+void APIServer::on_light_update(light::LightState *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_light_state(obj);
+}
+#endif
+
+#ifdef USE_SENSOR
+void APIServer::on_sensor_update(sensor::Sensor *obj, float state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_sensor_state(obj, state);
+}
+#endif
+
+#ifdef USE_SWITCH
+void APIServer::on_switch_update(switch_::Switch *obj, bool state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_switch_state(obj, state);
+}
+#endif
+
+#ifdef USE_TEXT_SENSOR
+void APIServer::on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_text_sensor_state(obj, state);
+}
+#endif
+
+#ifdef USE_CLIMATE
+void APIServer::on_climate_update(climate::Climate *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_climate_state(obj);
+}
+#endif
+
+#ifdef USE_NUMBER
+void APIServer::on_number_update(number::Number *obj, float state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_number_state(obj, state);
+}
+#endif
+
+#ifdef USE_DATETIME_DATE
+void APIServer::on_date_update(datetime::DateEntity *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_date_state(obj);
+}
+#endif
+
+#ifdef USE_DATETIME_TIME
+void APIServer::on_time_update(datetime::TimeEntity *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_time_state(obj);
+}
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+void APIServer::on_datetime_update(datetime::DateTimeEntity *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_datetime_state(obj);
+}
+#endif
+
+#ifdef USE_TEXT
+void APIServer::on_text_update(text::Text *obj, const std::string &state) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_text_state(obj, state);
+}
+#endif
+
+#ifdef USE_SELECT
+void APIServer::on_select_update(select::Select *obj, const std::string &state, size_t index) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_select_state(obj, state);
+}
+#endif
+
+#ifdef USE_LOCK
+void APIServer::on_lock_update(lock::Lock *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_lock_state(obj, obj->state);
+}
+#endif
+
+#ifdef USE_VALVE
+void APIServer::on_valve_update(valve::Valve *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_valve_state(obj);
+}
+#endif
+
+#ifdef USE_MEDIA_PLAYER
+void APIServer::on_media_player_update(media_player::MediaPlayer *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_media_player_state(obj);
+}
+#endif
+
+#ifdef USE_EVENT
+void APIServer::on_event(event::Event *obj, const std::string &event_type) {
+  for (auto &c : this->clients_)
+    c->send_event(obj, event_type);
+}
+#endif
+
+#ifdef USE_UPDATE
+void APIServer::on_update(update::UpdateEntity *obj) {
+  for (auto &c : this->clients_)
+    c->send_update_state(obj);
+}
+#endif
+
+float APIServer::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
+void APIServer::set_port(uint16_t port) { this->port_ = port; }
+APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+void APIServer::set_password(const std::string &password) { this->password_ = password; }
+void APIServer::send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
+  for (auto &client : this->clients_) {
+    client->send_homeassistant_service_call(call);
+  }
+}
+
+APIServer::APIServer() { global_api_server = this; }
+void APIServer::subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
+                                               std::function<void(std::string)> f) {
+  this->state_subs_.push_back(HomeAssistantStateSubscription{
+      .entity_id = std::move(entity_id),
+      .attribute = std::move(attribute),
+      .callback = std::move(f),
+      .once = false,
+  });
+}
+void APIServer::get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
+                                         std::function<void(std::string)> f) {
+  this->state_subs_.push_back(HomeAssistantStateSubscription{
+      .entity_id = std::move(entity_id),
+      .attribute = std::move(attribute),
+      .callback = std::move(f),
+      .once = true,
+  });
+};
+const std::vector<APIServer::HomeAssistantStateSubscription> &APIServer::get_state_subs() const {
+  return this->state_subs_;
+}
+uint16_t APIServer::get_port() const { return this->port_; }
+void APIServer::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
+#ifdef USE_HOMEASSISTANT_TIME
+void APIServer::request_time() {
+  for (auto &client : this->clients_) {
+    if (!client->remove_ && client->is_authenticated())
+      client->send_time_request();
+  }
+}
+#endif
+bool APIServer::is_connected() const { return !this->clients_.empty(); }
+void APIServer::on_shutdown() {
+  for (auto &c : this->clients_) {
+    c->send_disconnect_request(DisconnectRequest());
+  }
+  delay(10);
+}
+
+#ifdef USE_ALARM_CONTROL_PANEL
+void APIServer::on_alarm_control_panel_update(alarm_control_panel::AlarmControlPanel *obj) {
+  if (obj->is_internal())
+    return;
+  for (auto &c : this->clients_)
+    c->send_alarm_control_panel_state(obj);
+}
+#endif
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include "api_noise_context.h"
+#include "api_pb2.h"
+#include "api_pb2_service.h"
+#include "esphome/components/socket/socket.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/controller.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/log.h"
+#include "list_entities.h"
+#include "subscribe_state.h"
+#include "user_services.h"
+
+#include <vector>
+
+namespace esphome {
+namespace api {
+
+class APIServer : public Component, public Controller {
+ public:
+  APIServer();
+  void setup() override;
+  uint16_t get_port() const;
+  float get_setup_priority() const override;
+  void loop() override;
+  void dump_config() override;
+  void on_shutdown() override;
+  bool check_password(const std::string &password) const;
+  bool uses_password() const;
+  void set_port(uint16_t port);
+  void set_password(const std::string &password);
+  void set_reboot_timeout(uint32_t reboot_timeout);
+
+#ifdef USE_API_NOISE
+  void set_noise_psk(psk_t psk) { noise_ctx_->set_psk(psk); }
+  std::shared_ptr<APINoiseContext> get_noise_ctx() { return noise_ctx_; }
+#endif  // USE_API_NOISE
+
+  void handle_disconnect(APIConnection *conn);
+#ifdef USE_BINARY_SENSOR
+  void on_binary_sensor_update(binary_sensor::BinarySensor *obj, bool state) override;
+#endif
+#ifdef USE_COVER
+  void on_cover_update(cover::Cover *obj) override;
+#endif
+#ifdef USE_FAN
+  void on_fan_update(fan::Fan *obj) override;
+#endif
+#ifdef USE_LIGHT
+  void on_light_update(light::LightState *obj) override;
+#endif
+#ifdef USE_SENSOR
+  void on_sensor_update(sensor::Sensor *obj, float state) override;
+#endif
+#ifdef USE_SWITCH
+  void on_switch_update(switch_::Switch *obj, bool state) override;
+#endif
+#ifdef USE_TEXT_SENSOR
+  void on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) override;
+#endif
+#ifdef USE_CLIMATE
+  void on_climate_update(climate::Climate *obj) override;
+#endif
+#ifdef USE_NUMBER
+  void on_number_update(number::Number *obj, float state) override;
+#endif
+#ifdef USE_DATETIME_DATE
+  void on_date_update(datetime::DateEntity *obj) override;
+#endif
+#ifdef USE_DATETIME_TIME
+  void on_time_update(datetime::TimeEntity *obj) override;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  void on_datetime_update(datetime::DateTimeEntity *obj) override;
+#endif
+#ifdef USE_TEXT
+  void on_text_update(text::Text *obj, const std::string &state) override;
+#endif
+#ifdef USE_SELECT
+  void on_select_update(select::Select *obj, const std::string &state, size_t index) override;
+#endif
+#ifdef USE_LOCK
+  void on_lock_update(lock::Lock *obj) override;
+#endif
+#ifdef USE_VALVE
+  void on_valve_update(valve::Valve *obj) override;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  void on_media_player_update(media_player::MediaPlayer *obj) override;
+#endif
+  void send_homeassistant_service_call(const HomeassistantServiceResponse &call);
+  void register_user_service(UserServiceDescriptor *descriptor) { this->user_services_.push_back(descriptor); }
+#ifdef USE_HOMEASSISTANT_TIME
+  void request_time();
+#endif
+
+#ifdef USE_ALARM_CONTROL_PANEL
+  void on_alarm_control_panel_update(alarm_control_panel::AlarmControlPanel *obj) override;
+#endif
+#ifdef USE_EVENT
+  void on_event(event::Event *obj, const std::string &event_type) override;
+#endif
+#ifdef USE_UPDATE
+  void on_update(update::UpdateEntity *obj) override;
+#endif
+
+  bool is_connected() const;
+
+  struct HomeAssistantStateSubscription {
+    std::string entity_id;
+    optional<std::string> attribute;
+    std::function<void(std::string)> callback;
+    bool once;
+  };
+
+  void subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
+                                      std::function<void(std::string)> f);
+  void get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
+                                std::function<void(std::string)> f);
+  const std::vector<HomeAssistantStateSubscription> &get_state_subs() const;
+  const std::vector<UserServiceDescriptor *> &get_user_services() const { return this->user_services_; }
+
+  Trigger<std::string, std::string> *get_client_connected_trigger() const { return this->client_connected_trigger_; }
+  Trigger<std::string, std::string> *get_client_disconnected_trigger() const {
+    return this->client_disconnected_trigger_;
+  }
+
+ protected:
+  std::unique_ptr<socket::Socket> socket_ = nullptr;
+  uint16_t port_{6053};
+  uint32_t reboot_timeout_{300000};
+  uint32_t last_connected_{0};
+  std::vector<std::unique_ptr<APIConnection>> clients_;
+  std::string password_;
+  std::vector<HomeAssistantStateSubscription> state_subs_;
+  std::vector<UserServiceDescriptor *> user_services_;
+  Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();
+
+#ifdef USE_API_NOISE
+  std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();
+#endif  // USE_API_NOISE
+};
+
+extern APIServer *global_api_server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
+ public:
+  bool check(Ts... x) override { return global_api_server->is_connected(); }
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any
+
+from aioesphomeapi import APIClient
+from aioesphomeapi.api_pb2 import SubscribeLogsResponse
+from aioesphomeapi.log_runner import async_run
+
+from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
+from esphome.core import CORE
+
+from . import CONF_ENCRYPTION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_run_logs(config: dict[str, Any], address: str) -> None:
+    """Run the logs command in the event loop."""
+    conf = config["api"]
+    name = config["esphome"]["name"]
+    port: int = int(conf[CONF_PORT])
+    password: str = conf[CONF_PASSWORD]
+    noise_psk: str | None = None
+    if CONF_ENCRYPTION in conf:
+        noise_psk = conf[CONF_ENCRYPTION][CONF_KEY]
+    _LOGGER.info("Starting log output from %s using esphome API", address)
+    cli = APIClient(
+        address,
+        port,
+        password,
+        client_info=f"ESPHome Logs {__version__}",
+        noise_psk=noise_psk,
+    )
+    dashboard = CORE.dashboard
+
+    def on_log(msg: SubscribeLogsResponse) -> None:
+        """Handle a new log message."""
+        time_ = datetime.now()
+        message: bytes = msg.message
+        text = message.decode("utf8", "backslashreplace")
+        if dashboard:
+            text = text.replace("\033", "\\033")
+        print(f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]{text}")
+
+    stop = await async_run(cli, on_log, name=name)
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await stop()
+
+
+def run_logs(config: dict[str, Any], address: str) -> None:
+    """Run the logs command."""
+    try:
+        asyncio.run(async_run_logs(config, address))
+    except KeyboardInterrupt:
+        pass

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -1,0 +1,218 @@
+#pragma once
+
+#include <map>
+#include "user_services.h"
+#include "api_server.h"
+
+namespace esphome {
+namespace api {
+
+template<typename T, typename... Ts> class CustomAPIDeviceService : public UserServiceBase<Ts...> {
+ public:
+  CustomAPIDeviceService(const std::string &name, const std::array<std::string, sizeof...(Ts)> &arg_names, T *obj,
+                         void (T::*callback)(Ts...))
+      : UserServiceBase<Ts...>(name, arg_names), obj_(obj), callback_(callback) {}
+
+ protected:
+  void execute(Ts... x) override { (this->obj_->*this->callback_)(x...); }  // NOLINT
+
+  T *obj_;
+  void (T::*callback_)(Ts...);
+};
+
+class CustomAPIDevice {
+ public:
+  /// Return if a client (such as Home Assistant) is connected to the native API.
+  bool is_connected() const { return global_api_server->is_connected(); }
+
+  /** Register a custom native API service that will show up in Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * void setup() override {
+   *   register_service(&CustomNativeAPI::on_start_washer_cycle, "start_washer_cycle",
+   *                    {"cycle_length"});
+   * }
+   *
+   * void on_start_washer_cycle(int cycle_length) {
+   *   // Start washer cycle.
+   * }
+   * ```
+   *
+   * @tparam T The class type creating the service, automatically deduced from the function pointer.
+   * @tparam Ts The argument types for the service, automatically deduced from the function arguments.
+   * @param callback The member function to call when the service is triggered.
+   * @param name The name of the service to register.
+   * @param arg_names The name of the arguments for the service, must match the arguments of the function.
+   */
+  template<typename T, typename... Ts>
+  void register_service(void (T::*callback)(Ts...), const std::string &name,
+                        const std::array<std::string, sizeof...(Ts)> &arg_names) {
+    auto *service = new CustomAPIDeviceService<T, Ts...>(name, arg_names, (T *) this, callback);  // NOLINT
+    global_api_server->register_user_service(service);
+  }
+
+  /** Register a custom native API service that will show up in Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * void setup() override {
+   *   register_service(&CustomNativeAPI::on_hello_world, "hello_world");
+   * }
+   *
+   * void on_hello_world() {
+   *   // Hello World service called.
+   * }
+   * ```
+   *
+   * @tparam T The class type creating the service, automatically deduced from the function pointer.
+   * @param callback The member function to call when the service is triggered.
+   * @param name The name of the arguments for the service, must match the arguments of the function.
+   */
+  template<typename T> void register_service(void (T::*callback)(), const std::string &name) {
+    auto *service = new CustomAPIDeviceService<T>(name, {}, (T *) this, callback);  // NOLINT
+    global_api_server->register_user_service(service);
+  }
+
+  /** Subscribe to the state (or attribute state) of an entity from Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * void setup() override {
+   *   subscribe_homeassistant_state(&CustomNativeAPI::on_state_changed, "climate.kitchen", "current_temperature");
+   * }
+   *
+   * void on_state_changed(std::string state) {
+   *   // State of sensor.weather_forecast is `state`
+   * }
+   * ```
+   *
+   * @tparam T The class type creating the service, automatically deduced from the function pointer.
+   * @param callback The member function to call when the entity state changes.
+   * @param entity_id The entity_id to track.
+   * @param attribute The entity state attribute to track.
+   */
+  template<typename T>
+  void subscribe_homeassistant_state(void (T::*callback)(std::string), const std::string &entity_id,
+                                     const std::string &attribute = "") {
+    auto f = std::bind(callback, (T *) this, std::placeholders::_1);
+    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute), f);
+  }
+
+  /** Subscribe to the state (or attribute state) of an entity from Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * void setup() override {
+   *   subscribe_homeassistant_state(&CustomNativeAPI::on_state_changed, "sensor.weather_forecast");
+   * }
+   *
+   * void on_state_changed(std::string entity_id, std::string state) {
+   *   // State of `entity_id` is `state`
+   * }
+   * ```
+   *
+   * @tparam T The class type creating the service, automatically deduced from the function pointer.
+   * @param callback The member function to call when the entity state changes.
+   * @param entity_id The entity_id to track.
+   * @param attribute The entity state attribute to track.
+   */
+  template<typename T>
+  void subscribe_homeassistant_state(void (T::*callback)(std::string, std::string), const std::string &entity_id,
+                                     const std::string &attribute = "") {
+    auto f = std::bind(callback, (T *) this, entity_id, std::placeholders::_1);
+    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute), f);
+  }
+
+  /** Call a Home Assistant service from ESPHome.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * call_homeassistant_service("homeassistant.restart");
+   * ```
+   *
+   * @param service_name The service to call.
+   */
+  void call_homeassistant_service(const std::string &service_name) {
+    HomeassistantServiceResponse resp;
+    resp.service = service_name;
+    global_api_server->send_homeassistant_service_call(resp);
+  }
+
+  /** Call a Home Assistant service from ESPHome.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * call_homeassistant_service("light.turn_on", {
+   *   {"entity_id", "light.my_light"},
+   *   {"brightness", "127"},
+   * });
+   * ```
+   *
+   * @param service_name The service to call.
+   * @param data The data for the service call, mapping from string to string.
+   */
+  void call_homeassistant_service(const std::string &service_name, const std::map<std::string, std::string> &data) {
+    HomeassistantServiceResponse resp;
+    resp.service = service_name;
+    for (auto &it : data) {
+      HomeassistantServiceMap kv;
+      kv.key = it.first;
+      kv.value = it.second;
+      resp.data.push_back(kv);
+    }
+    global_api_server->send_homeassistant_service_call(resp);
+  }
+
+  /** Fire an ESPHome event in Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * fire_homeassistant_event("esphome.something_happened");
+   * ```
+   *
+   * @param event_name The event to fire.
+   */
+  void fire_homeassistant_event(const std::string &event_name) {
+    HomeassistantServiceResponse resp;
+    resp.service = event_name;
+    resp.is_event = true;
+    global_api_server->send_homeassistant_service_call(resp);
+  }
+
+  /** Fire an ESPHome event in Home Assistant.
+   *
+   * Usage:
+   *
+   * ```cpp
+   * fire_homeassistant_event("esphome.something_happened", {
+   *   {"my_value", "500"},
+   * });
+   * ```
+   *
+   * @param event_name The event to fire.
+   * @param data The data for the event, mapping from string to string.
+   */
+  void fire_homeassistant_event(const std::string &service_name, const std::map<std::string, std::string> &data) {
+    HomeassistantServiceResponse resp;
+    resp.service = service_name;
+    resp.is_event = true;
+    for (auto &it : data) {
+      HomeassistantServiceMap kv;
+      kv.key = it.first;
+      kv.value = it.second;
+      resp.data.push_back(kv);
+    }
+    global_api_server->send_homeassistant_service_call(resp);
+  }
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/automation.h"
+#include "api_pb2.h"
+#include "api_server.h"
+
+#include <vector>
+
+namespace esphome {
+namespace api {
+
+template<typename... X> class TemplatableStringValue : public TemplatableValue<std::string, X...> {
+ public:
+  TemplatableStringValue() : TemplatableValue<std::string, X...>() {}
+
+  template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
+  TemplatableStringValue(F value) : TemplatableValue<std::string, X...>(value) {}
+
+  template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
+  TemplatableStringValue(F f)
+      : TemplatableValue<std::string, X...>([f](X... x) -> std::string { return to_string(f(x...)); }) {}
+};
+
+template<typename... Ts> class TemplatableKeyValuePair {
+ public:
+  template<typename T> TemplatableKeyValuePair(std::string key, T value) : key(std::move(key)), value(value) {}
+  std::string key;
+  TemplatableStringValue<Ts...> value;
+};
+
+template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts...> {
+ public:
+  explicit HomeAssistantServiceCallAction(APIServer *parent, bool is_event) : parent_(parent), is_event_(is_event) {}
+
+  template<typename T> void set_service(T service) { this->service_ = service; }
+
+  template<typename T> void add_data(std::string key, T value) {
+    this->data_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
+  }
+  template<typename T> void add_data_template(std::string key, T value) {
+    this->data_template_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
+  }
+  template<typename T> void add_variable(std::string key, T value) {
+    this->variables_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
+  }
+
+  void play(Ts... x) override {
+    HomeassistantServiceResponse resp;
+    resp.service = this->service_.value(x...);
+    resp.is_event = this->is_event_;
+    for (auto &it : this->data_) {
+      HomeassistantServiceMap kv;
+      kv.key = it.key;
+      kv.value = it.value.value(x...);
+      resp.data.push_back(kv);
+    }
+    for (auto &it : this->data_template_) {
+      HomeassistantServiceMap kv;
+      kv.key = it.key;
+      kv.value = it.value.value(x...);
+      resp.data_template.push_back(kv);
+    }
+    for (auto &it : this->variables_) {
+      HomeassistantServiceMap kv;
+      kv.key = it.key;
+      kv.value = it.value.value(x...);
+      resp.variables.push_back(kv);
+    }
+    this->parent_->send_homeassistant_service_call(resp);
+  }
+
+ protected:
+  APIServer *parent_;
+  bool is_event_;
+  TemplatableStringValue<Ts...> service_{};
+  std::vector<TemplatableKeyValuePair<Ts...>> data_;
+  std::vector<TemplatableKeyValuePair<Ts...>> data_template_;
+  std::vector<TemplatableKeyValuePair<Ts...>> variables_;
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/list_entities.cpp
+++ b/esphome/components/api/list_entities.cpp
@@ -1,0 +1,106 @@
+#include "list_entities.h"
+#include "api_connection.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
+
+namespace esphome {
+namespace api {
+
+#ifdef USE_BINARY_SENSOR
+bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
+  return this->client_->send_binary_sensor_info(binary_sensor);
+}
+#endif
+#ifdef USE_COVER
+bool ListEntitiesIterator::on_cover(cover::Cover *cover) { return this->client_->send_cover_info(cover); }
+#endif
+#ifdef USE_FAN
+bool ListEntitiesIterator::on_fan(fan::Fan *fan) { return this->client_->send_fan_info(fan); }
+#endif
+#ifdef USE_LIGHT
+bool ListEntitiesIterator::on_light(light::LightState *light) { return this->client_->send_light_info(light); }
+#endif
+#ifdef USE_SENSOR
+bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) { return this->client_->send_sensor_info(sensor); }
+#endif
+#ifdef USE_SWITCH
+bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) { return this->client_->send_switch_info(a_switch); }
+#endif
+#ifdef USE_BUTTON
+bool ListEntitiesIterator::on_button(button::Button *button) { return this->client_->send_button_info(button); }
+#endif
+#ifdef USE_TEXT_SENSOR
+bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
+  return this->client_->send_text_sensor_info(text_sensor);
+}
+#endif
+#ifdef USE_LOCK
+bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) { return this->client_->send_lock_info(a_lock); }
+#endif
+#ifdef USE_VALVE
+bool ListEntitiesIterator::on_valve(valve::Valve *valve) { return this->client_->send_valve_info(valve); }
+#endif
+
+bool ListEntitiesIterator::on_end() { return this->client_->send_list_info_done(); }
+ListEntitiesIterator::ListEntitiesIterator(APIConnection *client) : client_(client) {}
+bool ListEntitiesIterator::on_service(UserServiceDescriptor *service) {
+  auto resp = service->encode_list_service_response();
+  return this->client_->send_list_entities_services_response(resp);
+}
+
+#ifdef USE_ESP32_CAMERA
+bool ListEntitiesIterator::on_camera(esp32_camera::ESP32Camera *camera) {
+  return this->client_->send_camera_info(camera);
+}
+#endif
+
+#ifdef USE_CLIMATE
+bool ListEntitiesIterator::on_climate(climate::Climate *climate) { return this->client_->send_climate_info(climate); }
+#endif
+
+#ifdef USE_NUMBER
+bool ListEntitiesIterator::on_number(number::Number *number) { return this->client_->send_number_info(number); }
+#endif
+
+#ifdef USE_DATETIME_DATE
+bool ListEntitiesIterator::on_date(datetime::DateEntity *date) { return this->client_->send_date_info(date); }
+#endif
+
+#ifdef USE_DATETIME_TIME
+bool ListEntitiesIterator::on_time(datetime::TimeEntity *time) { return this->client_->send_time_info(time); }
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *datetime) {
+  return this->client_->send_datetime_info(datetime);
+}
+#endif
+
+#ifdef USE_TEXT
+bool ListEntitiesIterator::on_text(text::Text *text) { return this->client_->send_text_info(text); }
+#endif
+
+#ifdef USE_SELECT
+bool ListEntitiesIterator::on_select(select::Select *select) { return this->client_->send_select_info(select); }
+#endif
+
+#ifdef USE_MEDIA_PLAYER
+bool ListEntitiesIterator::on_media_player(media_player::MediaPlayer *media_player) {
+  return this->client_->send_media_player_info(media_player);
+}
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
+  return this->client_->send_alarm_control_panel_info(a_alarm_control_panel);
+}
+#endif
+#ifdef USE_EVENT
+bool ListEntitiesIterator::on_event(event::Event *event) { return this->client_->send_event_info(event); }
+#endif
+#ifdef USE_UPDATE
+bool ListEntitiesIterator::on_update(update::UpdateEntity *update) { return this->client_->send_update_info(update); }
+#endif
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
+#include "esphome/core/defines.h"
+
+namespace esphome {
+namespace api {
+
+class APIConnection;
+
+class ListEntitiesIterator : public ComponentIterator {
+ public:
+  ListEntitiesIterator(APIConnection *client);
+#ifdef USE_BINARY_SENSOR
+  bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
+#endif
+#ifdef USE_COVER
+  bool on_cover(cover::Cover *cover) override;
+#endif
+#ifdef USE_FAN
+  bool on_fan(fan::Fan *fan) override;
+#endif
+#ifdef USE_LIGHT
+  bool on_light(light::LightState *light) override;
+#endif
+#ifdef USE_SENSOR
+  bool on_sensor(sensor::Sensor *sensor) override;
+#endif
+#ifdef USE_SWITCH
+  bool on_switch(switch_::Switch *a_switch) override;
+#endif
+#ifdef USE_BUTTON
+  bool on_button(button::Button *button) override;
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool on_text_sensor(text_sensor::TextSensor *text_sensor) override;
+#endif
+  bool on_service(UserServiceDescriptor *service) override;
+#ifdef USE_ESP32_CAMERA
+  bool on_camera(esp32_camera::ESP32Camera *camera) override;
+#endif
+#ifdef USE_CLIMATE
+  bool on_climate(climate::Climate *climate) override;
+#endif
+#ifdef USE_NUMBER
+  bool on_number(number::Number *number) override;
+#endif
+#ifdef USE_DATETIME_DATE
+  bool on_date(datetime::DateEntity *date) override;
+#endif
+#ifdef USE_DATETIME_TIME
+  bool on_time(datetime::TimeEntity *time) override;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  bool on_datetime(datetime::DateTimeEntity *datetime) override;
+#endif
+#ifdef USE_TEXT
+  bool on_text(text::Text *text) override;
+#endif
+#ifdef USE_SELECT
+  bool on_select(select::Select *select) override;
+#endif
+#ifdef USE_LOCK
+  bool on_lock(lock::Lock *a_lock) override;
+#endif
+#ifdef USE_VALVE
+  bool on_valve(valve::Valve *valve) override;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool on_media_player(media_player::MediaPlayer *media_player) override;
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  bool on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) override;
+#endif
+#ifdef USE_EVENT
+  bool on_event(event::Event *event) override;
+#endif
+#ifdef USE_UPDATE
+  bool on_update(update::UpdateEntity *update) override;
+#endif
+  bool on_end() override;
+
+ protected:
+  APIConnection *client_;
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -1,0 +1,92 @@
+#include "proto.h"
+#include <cinttypes>
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace api {
+
+static const char *const TAG = "api.proto";
+
+void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
+  uint32_t i = 0;
+  bool error = false;
+  while (i < length) {
+    uint32_t consumed;
+    auto res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+    if (!res.has_value()) {
+      ESP_LOGV(TAG, "Invalid field start at %" PRIu32, i);
+      break;
+    }
+
+    uint32_t field_type = (res->as_uint32()) & 0b111;
+    uint32_t field_id = (res->as_uint32()) >> 3;
+    i += consumed;
+
+    switch (field_type) {
+      case 0: {  // VarInt
+        res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+        if (!res.has_value()) {
+          ESP_LOGV(TAG, "Invalid VarInt at %" PRIu32, i);
+          error = true;
+          break;
+        }
+        if (!this->decode_varint(field_id, *res)) {
+          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res->as_uint32());
+        }
+        i += consumed;
+        break;
+      }
+      case 2: {  // Length-delimited
+        res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+        if (!res.has_value()) {
+          ESP_LOGV(TAG, "Invalid Length Delimited at %" PRIu32, i);
+          error = true;
+          break;
+        }
+        uint32_t field_length = res->as_uint32();
+        i += consumed;
+        if (field_length > length - i) {
+          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at %" PRIu32, i);
+          error = true;
+          break;
+        }
+        if (!this->decode_length(field_id, ProtoLengthDelimited(&buffer[i], field_length))) {
+          ESP_LOGV(TAG, "Cannot decode Length Delimited field %" PRIu32 "!", field_id);
+        }
+        i += field_length;
+        break;
+      }
+      case 5: {  // 32-bit
+        if (length - i < 4) {
+          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at %" PRIu32, i);
+          error = true;
+          break;
+        }
+        uint32_t val = encode_uint32(buffer[i + 3], buffer[i + 2], buffer[i + 1], buffer[i]);
+        if (!this->decode_32bit(field_id, Proto32Bit(val))) {
+          ESP_LOGV(TAG, "Cannot decode 32-bit field %" PRIu32 " with value %" PRIu32 "!", field_id, val);
+        }
+        i += 4;
+        break;
+      }
+      default:
+        ESP_LOGV(TAG, "Invalid field type at %" PRIu32, i);
+        error = true;
+        break;
+    }
+    if (error) {
+      break;
+    }
+  }
+}
+
+#ifdef HAS_PROTO_MESSAGE_DUMP
+std::string ProtoMessage::dump() const {
+  std::string out;
+  this->dump_to(out);
+  return out;
+}
+#endif
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+#include <vector>
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+#define HAS_PROTO_MESSAGE_DUMP
+#endif
+
+namespace esphome {
+namespace api {
+
+/// Representation of a VarInt - in ProtoBuf should be 64bit but we only use 32bit
+class ProtoVarInt {
+ public:
+  ProtoVarInt() : value_(0) {}
+  explicit ProtoVarInt(uint64_t value) : value_(value) {}
+
+  static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
+    if (consumed != nullptr)
+      *consumed = 0;
+
+    if (len == 0)
+      return {};
+
+    uint64_t result = 0;
+    uint8_t bitpos = 0;
+
+    for (uint32_t i = 0; i < len; i++) {
+      uint8_t val = buffer[i];
+      result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
+      bitpos += 7;
+      if ((val & 0x80) == 0) {
+        if (consumed != nullptr)
+          *consumed = i + 1;
+        return ProtoVarInt(result);
+      }
+    }
+
+    return {};
+  }
+
+  uint32_t as_uint32() const { return this->value_; }
+  uint64_t as_uint64() const { return this->value_; }
+  bool as_bool() const { return this->value_; }
+  template<typename T> T as_enum() const { return static_cast<T>(this->as_uint32()); }
+  int32_t as_int32() const {
+    // Not ZigZag encoded
+    return static_cast<int32_t>(this->as_int64());
+  }
+  int64_t as_int64() const {
+    // Not ZigZag encoded
+    return static_cast<int64_t>(this->value_);
+  }
+  int32_t as_sint32() const {
+    // with ZigZag encoding
+    if (this->value_ & 1) {
+      return static_cast<int32_t>(~(this->value_ >> 1));
+    } else {
+      return static_cast<int32_t>(this->value_ >> 1);
+    }
+  }
+  int64_t as_sint64() const {
+    // with ZigZag encoding
+    if (this->value_ & 1) {
+      return static_cast<int64_t>(~(this->value_ >> 1));
+    } else {
+      return static_cast<int64_t>(this->value_ >> 1);
+    }
+  }
+  void encode(std::vector<uint8_t> &out) {
+    uint64_t val = this->value_;
+    if (val <= 0x7F) {
+      out.push_back(val);
+      return;
+    }
+    while (val) {
+      uint8_t temp = val & 0x7F;
+      val >>= 7;
+      if (val) {
+        out.push_back(temp | 0x80);
+      } else {
+        out.push_back(temp);
+      }
+    }
+  }
+
+ protected:
+  uint64_t value_;
+};
+
+class ProtoLengthDelimited {
+ public:
+  explicit ProtoLengthDelimited(const uint8_t *value, size_t length) : value_(value), length_(length) {}
+  std::string as_string() const { return std::string(reinterpret_cast<const char *>(this->value_), this->length_); }
+  template<class C> C as_message() const {
+    auto msg = C();
+    msg.decode(this->value_, this->length_);
+    return msg;
+  }
+
+ protected:
+  const uint8_t *const value_;
+  const size_t length_;
+};
+
+class Proto32Bit {
+ public:
+  explicit Proto32Bit(uint32_t value) : value_(value) {}
+  uint32_t as_fixed32() const { return this->value_; }
+  int32_t as_sfixed32() const { return static_cast<int32_t>(this->value_); }
+  float as_float() const {
+    union {
+      uint32_t raw;
+      float value;
+    } s{};
+    s.raw = this->value_;
+    return s.value;
+  }
+
+ protected:
+  const uint32_t value_;
+};
+
+class Proto64Bit {
+ public:
+  explicit Proto64Bit(uint64_t value) : value_(value) {}
+  uint64_t as_fixed64() const { return this->value_; }
+  int64_t as_sfixed64() const { return static_cast<int64_t>(this->value_); }
+  double as_double() const {
+    union {
+      uint64_t raw;
+      double value;
+    } s{};
+    s.raw = this->value_;
+    return s.value;
+  }
+
+ protected:
+  const uint64_t value_;
+};
+
+class ProtoWriteBuffer {
+ public:
+  ProtoWriteBuffer(std::vector<uint8_t> *buffer) : buffer_(buffer) {}
+  void write(uint8_t value) { this->buffer_->push_back(value); }
+  void encode_varint_raw(ProtoVarInt value) { value.encode(*this->buffer_); }
+  void encode_varint_raw(uint32_t value) { this->encode_varint_raw(ProtoVarInt(value)); }
+  void encode_field_raw(uint32_t field_id, uint32_t type) {
+    uint32_t val = (field_id << 3) | (type & 0b111);
+    this->encode_varint_raw(val);
+  }
+  void encode_string(uint32_t field_id, const char *string, size_t len, bool force = false) {
+    if (len == 0 && !force)
+      return;
+
+    this->encode_field_raw(field_id, 2);
+    this->encode_varint_raw(len);
+    auto *data = reinterpret_cast<const uint8_t *>(string);
+    this->buffer_->insert(this->buffer_->end(), data, data + len);
+  }
+  void encode_string(uint32_t field_id, const std::string &value, bool force = false) {
+    this->encode_string(field_id, value.data(), value.size());
+  }
+  void encode_bytes(uint32_t field_id, const uint8_t *data, size_t len, bool force = false) {
+    this->encode_string(field_id, reinterpret_cast<const char *>(data), len, force);
+  }
+  void encode_uint32(uint32_t field_id, uint32_t value, bool force = false) {
+    if (value == 0 && !force)
+      return;
+    this->encode_field_raw(field_id, 0);
+    this->encode_varint_raw(value);
+  }
+  void encode_uint64(uint32_t field_id, uint64_t value, bool force = false) {
+    if (value == 0 && !force)
+      return;
+    this->encode_field_raw(field_id, 0);
+    this->encode_varint_raw(ProtoVarInt(value));
+  }
+  void encode_bool(uint32_t field_id, bool value, bool force = false) {
+    if (!value && !force)
+      return;
+    this->encode_field_raw(field_id, 0);
+    this->write(0x01);
+  }
+  void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
+    if (value == 0 && !force)
+      return;
+
+    this->encode_field_raw(field_id, 5);
+    this->write((value >> 0) & 0xFF);
+    this->write((value >> 8) & 0xFF);
+    this->write((value >> 16) & 0xFF);
+    this->write((value >> 24) & 0xFF);
+  }
+  void encode_fixed64(uint32_t field_id, uint64_t value, bool force = false) {
+    if (value == 0 && !force)
+      return;
+
+    this->encode_field_raw(field_id, 5);
+    this->write((value >> 0) & 0xFF);
+    this->write((value >> 8) & 0xFF);
+    this->write((value >> 16) & 0xFF);
+    this->write((value >> 24) & 0xFF);
+    this->write((value >> 32) & 0xFF);
+    this->write((value >> 40) & 0xFF);
+    this->write((value >> 48) & 0xFF);
+    this->write((value >> 56) & 0xFF);
+  }
+  template<typename T> void encode_enum(uint32_t field_id, T value, bool force = false) {
+    this->encode_uint32(field_id, static_cast<uint32_t>(value), force);
+  }
+  void encode_float(uint32_t field_id, float value, bool force = false) {
+    if (value == 0.0f && !force)
+      return;
+
+    union {
+      float value;
+      uint32_t raw;
+    } val{};
+    val.value = value;
+    this->encode_fixed32(field_id, val.raw);
+  }
+  void encode_int32(uint32_t field_id, int32_t value, bool force = false) {
+    if (value < 0) {
+      // negative int32 is always 10 byte long
+      this->encode_int64(field_id, value, force);
+      return;
+    }
+    this->encode_uint32(field_id, static_cast<uint32_t>(value), force);
+  }
+  void encode_int64(uint32_t field_id, int64_t value, bool force = false) {
+    this->encode_uint64(field_id, static_cast<uint64_t>(value), force);
+  }
+  void encode_sint32(uint32_t field_id, int32_t value, bool force = false) {
+    uint32_t uvalue;
+    if (value < 0) {
+      uvalue = ~(value << 1);
+    } else {
+      uvalue = value << 1;
+    }
+    this->encode_uint32(field_id, uvalue, force);
+  }
+  void encode_sint64(uint32_t field_id, int64_t value, bool force = false) {
+    uint64_t uvalue;
+    if (value < 0) {
+      uvalue = ~(value << 1);
+    } else {
+      uvalue = value << 1;
+    }
+    this->encode_uint64(field_id, uvalue, force);
+  }
+  template<class C> void encode_message(uint32_t field_id, const C &value, bool force = false) {
+    this->encode_field_raw(field_id, 2);
+    size_t begin = this->buffer_->size();
+
+    value.encode(*this);
+
+    const uint32_t nested_length = this->buffer_->size() - begin;
+    // add size varint
+    std::vector<uint8_t> var;
+    ProtoVarInt(nested_length).encode(var);
+    this->buffer_->insert(this->buffer_->begin() + begin, var.begin(), var.end());
+  }
+  std::vector<uint8_t> *get_buffer() const { return buffer_; }
+
+ protected:
+  std::vector<uint8_t> *buffer_;
+};
+
+class ProtoMessage {
+ public:
+  virtual ~ProtoMessage() = default;
+  virtual void encode(ProtoWriteBuffer buffer) const = 0;
+  void decode(const uint8_t *buffer, size_t length);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  std::string dump() const;
+  virtual void dump_to(std::string &out) const = 0;
+#endif
+
+ protected:
+  virtual bool decode_varint(uint32_t field_id, ProtoVarInt value) { return false; }
+  virtual bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
+  virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
+  virtual bool decode_64bit(uint32_t field_id, Proto64Bit value) { return false; }
+};
+
+template<typename T> const char *proto_enum_to_string(T value);
+
+class ProtoService {
+ public:
+ protected:
+  virtual bool is_authenticated() = 0;
+  virtual bool is_connection_setup() = 0;
+  virtual void on_fatal_error() = 0;
+  virtual void on_unauthenticated_access() = 0;
+  virtual void on_no_setup_connection() = 0;
+  virtual ProtoWriteBuffer create_buffer() = 0;
+  virtual bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) = 0;
+  virtual bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;
+
+  template<class C> bool send_message_(const C &msg, uint32_t message_type) {
+    auto buffer = this->create_buffer();
+    msg.encode(buffer);
+    return this->send_buffer(buffer, message_type);
+  }
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/subscribe_state.cpp
+++ b/esphome/components/api/subscribe_state.cpp
@@ -1,0 +1,86 @@
+#include "subscribe_state.h"
+#include "api_connection.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace api {
+
+#ifdef USE_BINARY_SENSOR
+bool InitialStateIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
+  return this->client_->send_binary_sensor_state(binary_sensor, binary_sensor->state);
+}
+#endif
+#ifdef USE_COVER
+bool InitialStateIterator::on_cover(cover::Cover *cover) { return this->client_->send_cover_state(cover); }
+#endif
+#ifdef USE_FAN
+bool InitialStateIterator::on_fan(fan::Fan *fan) { return this->client_->send_fan_state(fan); }
+#endif
+#ifdef USE_LIGHT
+bool InitialStateIterator::on_light(light::LightState *light) { return this->client_->send_light_state(light); }
+#endif
+#ifdef USE_SENSOR
+bool InitialStateIterator::on_sensor(sensor::Sensor *sensor) {
+  return this->client_->send_sensor_state(sensor, sensor->state);
+}
+#endif
+#ifdef USE_SWITCH
+bool InitialStateIterator::on_switch(switch_::Switch *a_switch) {
+  return this->client_->send_switch_state(a_switch, a_switch->state);
+}
+#endif
+#ifdef USE_TEXT_SENSOR
+bool InitialStateIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
+  return this->client_->send_text_sensor_state(text_sensor, text_sensor->state);
+}
+#endif
+#ifdef USE_CLIMATE
+bool InitialStateIterator::on_climate(climate::Climate *climate) { return this->client_->send_climate_state(climate); }
+#endif
+#ifdef USE_NUMBER
+bool InitialStateIterator::on_number(number::Number *number) {
+  return this->client_->send_number_state(number, number->state);
+}
+#endif
+#ifdef USE_DATETIME_DATE
+bool InitialStateIterator::on_date(datetime::DateEntity *date) { return this->client_->send_date_state(date); }
+#endif
+#ifdef USE_DATETIME_TIME
+bool InitialStateIterator::on_time(datetime::TimeEntity *time) { return this->client_->send_time_state(time); }
+#endif
+#ifdef USE_DATETIME_DATETIME
+bool InitialStateIterator::on_datetime(datetime::DateTimeEntity *datetime) {
+  return this->client_->send_datetime_state(datetime);
+}
+#endif
+#ifdef USE_TEXT
+bool InitialStateIterator::on_text(text::Text *text) { return this->client_->send_text_state(text, text->state); }
+#endif
+#ifdef USE_SELECT
+bool InitialStateIterator::on_select(select::Select *select) {
+  return this->client_->send_select_state(select, select->state);
+}
+#endif
+#ifdef USE_LOCK
+bool InitialStateIterator::on_lock(lock::Lock *a_lock) { return this->client_->send_lock_state(a_lock, a_lock->state); }
+#endif
+#ifdef USE_VALVE
+bool InitialStateIterator::on_valve(valve::Valve *valve) { return this->client_->send_valve_state(valve); }
+#endif
+#ifdef USE_MEDIA_PLAYER
+bool InitialStateIterator::on_media_player(media_player::MediaPlayer *media_player) {
+  return this->client_->send_media_player_state(media_player);
+}
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+bool InitialStateIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
+  return this->client_->send_alarm_control_panel_state(a_alarm_control_panel);
+}
+#endif
+#ifdef USE_UPDATE
+bool InitialStateIterator::on_update(update::UpdateEntity *update) { return this->client_->send_update_state(update); }
+#endif
+InitialStateIterator::InitialStateIterator(APIConnection *client) : client_(client) {}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/component_iterator.h"
+#include "esphome/core/controller.h"
+#include "esphome/core/defines.h"
+
+namespace esphome {
+namespace api {
+
+class APIConnection;
+
+class InitialStateIterator : public ComponentIterator {
+ public:
+  InitialStateIterator(APIConnection *client);
+#ifdef USE_BINARY_SENSOR
+  bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) override;
+#endif
+#ifdef USE_COVER
+  bool on_cover(cover::Cover *cover) override;
+#endif
+#ifdef USE_FAN
+  bool on_fan(fan::Fan *fan) override;
+#endif
+#ifdef USE_LIGHT
+  bool on_light(light::LightState *light) override;
+#endif
+#ifdef USE_SENSOR
+  bool on_sensor(sensor::Sensor *sensor) override;
+#endif
+#ifdef USE_SWITCH
+  bool on_switch(switch_::Switch *a_switch) override;
+#endif
+#ifdef USE_BUTTON
+  bool on_button(button::Button *button) override { return true; };
+#endif
+#ifdef USE_TEXT_SENSOR
+  bool on_text_sensor(text_sensor::TextSensor *text_sensor) override;
+#endif
+#ifdef USE_CLIMATE
+  bool on_climate(climate::Climate *climate) override;
+#endif
+#ifdef USE_NUMBER
+  bool on_number(number::Number *number) override;
+#endif
+#ifdef USE_DATETIME_DATE
+  bool on_date(datetime::DateEntity *date) override;
+#endif
+#ifdef USE_DATETIME_TIME
+  bool on_time(datetime::TimeEntity *time) override;
+#endif
+#ifdef USE_DATETIME_DATETIME
+  bool on_datetime(datetime::DateTimeEntity *datetime) override;
+#endif
+#ifdef USE_TEXT
+  bool on_text(text::Text *text) override;
+#endif
+#ifdef USE_SELECT
+  bool on_select(select::Select *select) override;
+#endif
+#ifdef USE_LOCK
+  bool on_lock(lock::Lock *a_lock) override;
+#endif
+#ifdef USE_VALVE
+  bool on_valve(valve::Valve *valve) override;
+#endif
+#ifdef USE_MEDIA_PLAYER
+  bool on_media_player(media_player::MediaPlayer *media_player) override;
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  bool on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) override;
+#endif
+#ifdef USE_EVENT
+  bool on_event(event::Event *event) override { return true; };
+#endif
+#ifdef USE_UPDATE
+  bool on_update(update::UpdateEntity *update) override;
+#endif
+ protected:
+  APIConnection *client_;
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/user_services.cpp
+++ b/esphome/components/api/user_services.cpp
@@ -1,0 +1,44 @@
+#include "user_services.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace api {
+
+template<> bool get_execute_arg_value<bool>(const ExecuteServiceArgument &arg) { return arg.bool_; }
+template<> int32_t get_execute_arg_value<int32_t>(const ExecuteServiceArgument &arg) {
+  if (arg.legacy_int != 0)
+    return arg.legacy_int;
+  return arg.int_;
+}
+template<> float get_execute_arg_value<float>(const ExecuteServiceArgument &arg) { return arg.float_; }
+template<> std::string get_execute_arg_value<std::string>(const ExecuteServiceArgument &arg) { return arg.string_; }
+template<> std::vector<bool> get_execute_arg_value<std::vector<bool>>(const ExecuteServiceArgument &arg) {
+  return arg.bool_array;
+}
+template<> std::vector<int32_t> get_execute_arg_value<std::vector<int32_t>>(const ExecuteServiceArgument &arg) {
+  return arg.int_array;
+}
+template<> std::vector<float> get_execute_arg_value<std::vector<float>>(const ExecuteServiceArgument &arg) {
+  return arg.float_array;
+}
+template<> std::vector<std::string> get_execute_arg_value<std::vector<std::string>>(const ExecuteServiceArgument &arg) {
+  return arg.string_array;
+}
+
+template<> enums::ServiceArgType to_service_arg_type<bool>() { return enums::SERVICE_ARG_TYPE_BOOL; }
+template<> enums::ServiceArgType to_service_arg_type<int32_t>() { return enums::SERVICE_ARG_TYPE_INT; }
+template<> enums::ServiceArgType to_service_arg_type<float>() { return enums::SERVICE_ARG_TYPE_FLOAT; }
+template<> enums::ServiceArgType to_service_arg_type<std::string>() { return enums::SERVICE_ARG_TYPE_STRING; }
+template<> enums::ServiceArgType to_service_arg_type<std::vector<bool>>() { return enums::SERVICE_ARG_TYPE_BOOL_ARRAY; }
+template<> enums::ServiceArgType to_service_arg_type<std::vector<int32_t>>() {
+  return enums::SERVICE_ARG_TYPE_INT_ARRAY;
+}
+template<> enums::ServiceArgType to_service_arg_type<std::vector<float>>() {
+  return enums::SERVICE_ARG_TYPE_FLOAT_ARRAY;
+}
+template<> enums::ServiceArgType to_service_arg_type<std::vector<std::string>>() {
+  return enums::SERVICE_ARG_TYPE_STRING_ARRAY;
+}
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "api_pb2.h"
+
+namespace esphome {
+namespace api {
+
+class UserServiceDescriptor {
+ public:
+  virtual ListEntitiesServicesResponse encode_list_service_response() = 0;
+
+  virtual bool execute_service(const ExecuteServiceRequest &req) = 0;
+};
+
+template<typename T> T get_execute_arg_value(const ExecuteServiceArgument &arg);
+
+template<typename T> enums::ServiceArgType to_service_arg_type();
+
+template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
+ public:
+  UserServiceBase(std::string name, const std::array<std::string, sizeof...(Ts)> &arg_names)
+      : name_(std::move(name)), arg_names_(arg_names) {
+    this->key_ = fnv1_hash(this->name_);
+  }
+
+  ListEntitiesServicesResponse encode_list_service_response() override {
+    ListEntitiesServicesResponse msg;
+    msg.name = this->name_;
+    msg.key = this->key_;
+    std::array<enums::ServiceArgType, sizeof...(Ts)> arg_types = {to_service_arg_type<Ts>()...};
+    for (int i = 0; i < sizeof...(Ts); i++) {
+      ListEntitiesServicesArgument arg;
+      arg.type = arg_types[i];
+      arg.name = this->arg_names_[i];
+      msg.args.push_back(arg);
+    }
+    return msg;
+  }
+
+  bool execute_service(const ExecuteServiceRequest &req) override {
+    if (req.key != this->key_)
+      return false;
+    if (req.args.size() != this->arg_names_.size())
+      return false;
+    this->execute_(req.args, typename gens<sizeof...(Ts)>::type());
+    return true;
+  }
+
+ protected:
+  virtual void execute(Ts... x) = 0;
+  template<int... S> void execute_(std::vector<ExecuteServiceArgument> args, seq<S...> type) {
+    this->execute((get_execute_arg_value<Ts>(args[S]))...);
+  }
+
+  std::string name_;
+  uint32_t key_{0};
+  std::array<std::string, sizeof...(Ts)> arg_names_;
+};
+
+template<typename... Ts> class UserServiceTrigger : public UserServiceBase<Ts...>, public Trigger<Ts...> {
+ public:
+  UserServiceTrigger(const std::string &name, const std::array<std::string, sizeof...(Ts)> &arg_names)
+      : UserServiceBase<Ts...>(name, arg_names) {}
+
+ protected:
+  void execute(Ts... x) override { this->trigger(x...); }  // NOLINT
+};
+
+}  // namespace api
+}  // namespace esphome

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -51,8 +51,6 @@ struct MediaFile {
   MediaFileType file_type;
 };
 
-<<<<<<< Updated upstream
-=======
 enum class MediaPlayerFormatPurpose : uint8_t {
   DEFAULT = 0,
   ANNOUNCEMENT,
@@ -64,9 +62,6 @@ struct MediaPlayerSupportedFormat {
   uint32_t num_channels;
   MediaPlayerFormatPurpose purpose;
 };
-
-
->>>>>>> Stashed changes
 class MediaPlayer;
 
 class MediaPlayerTraits {

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -51,6 +51,22 @@ struct MediaFile {
   MediaFileType file_type;
 };
 
+<<<<<<< Updated upstream
+=======
+enum class MediaPlayerFormatPurpose : uint8_t {
+  DEFAULT = 0,
+  ANNOUNCEMENT,
+};
+
+struct MediaPlayerSupportedFormat {
+  std::string format;
+  uint32_t sample_rate;
+  uint32_t num_channels;
+  MediaPlayerFormatPurpose purpose;
+};
+
+
+>>>>>>> Stashed changes
 class MediaPlayer;
 
 class MediaPlayerTraits {
@@ -61,8 +77,13 @@ class MediaPlayerTraits {
 
   bool get_supports_pause() const { return this->supports_pause_; }
 
+  std::vector<MediaPlayerSupportedFormat>& get_supported_formats() {
+    return this->supported_formats_;
+  }
+
  protected:
   bool supports_pause_{false};
+  std::vector<MediaPlayerSupportedFormat> supported_formats_{};
 };
 
 class MediaPlayerCall {

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -677,6 +677,18 @@ void NabuMediaPlayer::control(const media_player::MediaPlayerCall &call) {
 media_player::MediaPlayerTraits NabuMediaPlayer::get_traits() {
   auto traits = media_player::MediaPlayerTraits();
   traits.set_supports_pause(true);
+  traits.get_supported_formats().push_back({
+    .format = "flac",
+    .sample_rate = this->sample_rate_,
+    .num_channels = 2,
+    .purpose = media_player::MediaPlayerFormatPurpose::DEFAULT,
+  });
+  traits.get_supported_formats().push_back({
+    .format = "flac",
+    .sample_rate = this->sample_rate_,
+    .num_channels = 1,
+    .purpose = media_player::MediaPlayerFormatPurpose::ANNOUNCEMENT,
+  });
   return traits;
 };
 


### PR DESCRIPTION
Extends the media player info with a list of supported audio formats. This is used in Home Assistant to swap out media URLs going to the ESPHome device with proxy URLs that contain the converted audio.

Also adds supported media formats to the Nabu media player.

Depends on the following PRs:
* https://github.com/home-assistant/core/pull/123254
* https://github.com/esphome/aioesphomeapi/pull/925