### PR TITLE
Initial mWW and VA intercomponent communication

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -17,6 +17,7 @@ enum class TaskEventType : uint8_t {
   IDLE,
   STOPPING,
   STOPPED,
+  MUTED,
   WARNING = 255,
 };
 

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -181,6 +181,8 @@ def _convert_manifest_v1_to_v2(v1_manifest):
     v2_manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE] = 45672
     # Original Inception-based V1 manifest models use a 20 ms feature step size
     v2_manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE] = 20
+    # Original Inception-based V1 manifest models were trained only on TTS English samples
+    v2_manifest[KEY_TRAINED_LANGUAGES] = ['en']
 
     return v2_manifest
 
@@ -503,6 +505,9 @@ async def to_code(config):
                 manifest[KEY_WAKE_WORD],
                 manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
             )
+            
+            for lang in manifest[KEY_TRAINED_LANGUAGES]:
+                cg.add(wake_word_model.add_trained_language(lang))
 
             cg.add(var.add_wake_word_model(wake_word_model))
 

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -176,12 +176,11 @@ def _convert_manifest_v1_to_v2(v1_manifest):
         CONF_SLIDING_WINDOW_AVERAGE_SIZE
     ]
     del v2_manifest[KEY_MICRO][CONF_SLIDING_WINDOW_AVERAGE_SIZE]
-    v2_manifest[KEY_MICRO][
-        CONF_TENSOR_ARENA_SIZE
-    ] = 45672  # Original Inception-based V1 manifest models require a minimum of 45672 bytes
-    v2_manifest[KEY_MICRO][
-        CONF_FEATURE_STEP_SIZE
-    ] = 20  # Original Inception-based V1 manifest models use a 20 ms feature step size
+
+    # Original Inception-based V1 manifest models require a minimum of 45672 bytes
+    v2_manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE] = 45672
+    # Original Inception-based V1 manifest models use a 20 ms feature step size
+    v2_manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE] = 20
 
     return v2_manifest
 
@@ -508,12 +507,7 @@ async def to_code(config):
             cg.add(var.add_wake_word_model(wake_word_model))
 
     cg.add(var.set_features_step_size(manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]))
-    cg.add_library(
-        None,
-        None,
-        "https://github.com/kahrendt/ESPMicroSpeechFeatures.git#psram-allocations",
-    )
-    # cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.0.0")
+    cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.1.0")
 
 
 MICRO_WAKE_WORD_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicroWakeWord)})

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -182,7 +182,7 @@ def _convert_manifest_v1_to_v2(v1_manifest):
     # Original Inception-based V1 manifest models use a 20 ms feature step size
     v2_manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE] = 20
     # Original Inception-based V1 manifest models were trained only on TTS English samples
-    v2_manifest[KEY_TRAINED_LANGUAGES] = ['en']
+    v2_manifest[KEY_TRAINED_LANGUAGES] = ["en"]
 
     return v2_manifest
 
@@ -446,6 +446,8 @@ async def to_code(config):
     mic = await cg.get_variable(config[CONF_MICROPHONE])
     cg.add(var.set_microphone(mic))
 
+    cg.add_define("USE_MICRO_WAKE_WORD")
+
     esp32.add_idf_component(
         name="esp-tflite-micro",
         repo="https://github.com/espressif/esp-tflite-micro",
@@ -505,7 +507,7 @@ async def to_code(config):
                 manifest[KEY_WAKE_WORD],
                 manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
             )
-            
+
             for lang in manifest[KEY_TRAINED_LANGUAGES]:
                 cg.add(wake_word_model.add_trained_language(lang))
 

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -151,8 +151,7 @@ void MicroWakeWord::preprocessor_task_(void *params) {
 
       while (!(xEventGroupGetBits(this_mww->event_group_) & COMMAND_STOP)) {
         while (this_mww->microphone_->available() / sizeof(int16_t) >= new_samples_to_read) {
-          size_t bytes_read =
-              this_mww->microphone_->read(audio_buffer, new_samples_to_read * sizeof(int16_t));
+          size_t bytes_read = this_mww->microphone_->read(audio_buffer, new_samples_to_read * sizeof(int16_t));
           if (bytes_read < new_samples_to_read * sizeof(int16_t)) {
             // This shouldn't ever happen, but if we somehow don't have enough samples, just drop this frame
             continue;
@@ -237,6 +236,9 @@ void MicroWakeWord::inference_task_(void *params) {
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
           DetectionEvent vad_state = this_mww->vad_model_->determine_detected();
+
+          // Atomic write, so thread safe
+          this_mww->vad_status_ = vad_state.detected;
 #endif
 
           for (auto &model : this_mww->wake_word_models_) {

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -241,7 +241,7 @@ void MicroWakeWord::inference_task_(void *params) {
           DetectionEvent vad_state = this_mww->vad_model_->determine_detected();
 
           // Atomic write, so thread safe
-          this_mww->vad_status_ = vad_state.detected;
+          this_mww->vad_state_ = vad_state.detected;
 #endif
 
           for (auto &model : this_mww->wake_word_models_) {

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -155,7 +155,7 @@ void MicroWakeWord::preprocessor_task_(void *params) {
       }
 
       while (!(xEventGroupGetBits(this_mww->event_group_) & COMMAND_STOP)) {
-        size_t bytes_read = this_mww->microphone_->read(audio_buffer, new_samples_to_read * sizeof(int16_t) * 2,
+        size_t bytes_read = this_mww->microphone_->read(audio_buffer, new_samples_to_read * sizeof(int16_t),
                                                         pdMS_TO_TICKS(DATA_TIMEOUT_MS));
         if (bytes_read < new_samples_to_read * sizeof(int16_t)) {
           // This shouldn't ever happen, but if we somehow don't have enough samples, just drop this frame

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -323,6 +323,7 @@ void MicroWakeWord::loop() {
       this->wake_word_detected_trigger_->trigger(*detection_event.wake_word);
 
 #ifdef USE_VOICE_ASSISTANT
+      // TODO: potentially remove, as it currently only logs in the voice assistant component
       if (voice_assistant::global_voice_assistant != nullptr) {
         voice_assistant::global_voice_assistant->on_wake_word(detection_event);
       }

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -7,6 +7,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include "esphome/components/voice_assistant/voice_assistant.h"
+
 #include <frontend.h>
 #include <frontend_util.h>
 
@@ -332,6 +334,12 @@ void MicroWakeWord::loop() {
                (detection_event.max_probability / 255.0f));
       this->wake_word_detected_trigger_->trigger(*detection_event.wake_word);
       xQueueOverwrite(this->wake_word_queue_, &detection_event);
+
+#ifdef USE_VOICE_ASSISTANT
+      if (voice_assistant::global_voice_assistant != nullptr) {
+        voice_assistant::global_voice_assistant->on_wake_word(detection_event);
+      }
+#endif
     }
   }
 }

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -344,6 +344,24 @@ void MicroWakeWord::loop() {
   }
 }
 
+void MicroWakeWord::enable_wake_words(std::vector<std::string> &wake_words_to_enable) {
+  for (auto &model : this->wake_word_models_) {
+    bool enabled_wake_word = false;
+
+    for (auto &wake_word : wake_words_to_enable) {
+      ESP_LOGD(TAG, "wake word model=%s; wake_word_target=%s", model->get_wake_word().c_str(), wake_word.c_str());
+      if (!model->get_wake_word().compare(wake_word)) {
+        model->enable();
+        enabled_wake_word = true;
+      }
+    }
+
+    if (!enabled_wake_word) {
+      model->disable();
+    }
+  }
+}
+
 void MicroWakeWord::start() {
   if (!this->is_ready()) {
     ESP_LOGW(TAG, "Wake word detection can't start as the component hasn't been setup yet");

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -51,7 +51,7 @@ class MicroWakeWord : public Component {
                      size_t tensor_arena_size);
 
   // Intended for the voice assistant component to fetch VAD status
-  bool get_vad_status() { return this->vad_status_; }
+  bool get_vad_state() { return this->vad_state_; }
 #endif
 
   // Intended for the voice assistant component to know which wake words are available
@@ -75,7 +75,7 @@ class MicroWakeWord : public Component {
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
   std::unique_ptr<VADModel> vad_model_;
-  bool vad_status_{false};
+  bool vad_state_{false};
 #endif
 
   // Audio frontend handles generating spectrogram features

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -49,6 +49,7 @@ class MicroWakeWord : public Component {
 #ifdef USE_MICRO_WAKE_WORD_VAD
   void add_vad_model(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
                      size_t tensor_arena_size);
+  bool get_vad_status() { return this->vad_status_; }
 #endif
 
  protected:
@@ -58,10 +59,11 @@ class MicroWakeWord : public Component {
 
   std::unique_ptr<RingBuffer> features_ring_buffer_;
 
-  std::vector<WakeWordModel*> wake_word_models_;
+  std::vector<WakeWordModel *> wake_word_models_;
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
   std::unique_ptr<VADModel> vad_model_;
+  bool vad_status_{false};
 #endif
 
   // Audio frontend handles generating spectrogram features

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -52,6 +52,8 @@ class MicroWakeWord : public Component {
   bool get_vad_status() { return this->vad_status_; }
 #endif
 
+  const std::vector<WakeWordModel *> &get_wake_words() const { return this->wake_word_models_; }
+
  protected:
   microphone::Microphone *microphone_{nullptr};
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -7,7 +7,6 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
-#include "esphome/core/ring_buffer.h"
 
 #include "esphome/components/microphone/microphone.h"
 
@@ -67,7 +66,7 @@ class MicroWakeWord : public Component {
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
   State state_{State::IDLE};
 
-  std::unique_ptr<RingBuffer> features_ring_buffer_;
+
 
   std::vector<WakeWordModel *> wake_word_models_;
 
@@ -103,8 +102,8 @@ class MicroWakeWord : public Component {
   // Used to send messages about the model's states to the main loop
   QueueHandle_t detection_queue_;
 
-  // Used for storing most recent wake word event for the VA component to read
-  QueueHandle_t wake_word_queue_;
+  // Stores spectrogram features for inference
+  QueueHandle_t features_queue_;
 
   static void preprocessor_task_(void *params);
   TaskHandle_t preprocessor_task_handle_{nullptr};

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -64,6 +64,9 @@ class MicroWakeWord : public Component {
   // during the on_detected event
   optional<DetectionEvent> get_wake_word_detection_event();
 
+  // Enables the wake word phrases given as strings in a vector. Disables any wake words not in the vector
+  void enable_wake_words(std::vector<std::string> &wake_words_to_enable);
+
  protected:
   microphone::Microphone *microphone_{nullptr};
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -55,16 +55,11 @@ class MicroWakeWord : public Component {
 #endif
 
   // Intended for the voice assistant component to know which wake words are available
-  // Since these are pointers to the actual WakeWordModel object, the voice assistant component can enable or disable it
+  // Since these are pointers to the WakeWordModel objects, the voice assistant component can enable or disable them
   const std::vector<WakeWordModel *> &get_wake_words() const { return this->wake_word_models_; }
 
-  // Intended for the voice assistant component to poll for wake word events
-  // Returns an empty optional state if there is no wake word detection event in the queue
-  // TODO: This is how the VA will know a wake word has been said rather than calling a start pipeline action
-  // during the on_detected event
-  optional<DetectionEvent> get_wake_word_detection_event();
-
-  // Enables the wake word phrases given as strings in a vector. Disables any wake words not in the vector
+  // Enables the wake word phrases given as strings in a vector. Disables any wake words not listed in the vector
+  // TODO: Should this logic be in the voice_assistant component?
   void enable_wake_words(std::vector<std::string> &wake_words_to_enable);
 
  protected:

--- a/esphome/components/micro_wake_word/preprocessor_settings.h
+++ b/esphome/components/micro_wake_word/preprocessor_settings.h
@@ -7,6 +7,10 @@
 namespace esphome {
 namespace micro_wake_word {
 
+// Settings for controlling the spectrogram feature generation by the preprocessor.
+// These must match the settings used when training a particular model.
+// All microWakeWord models have been trained with these specific paramters.
+
 // The number of features the audio preprocessor generates per slice
 static const uint8_t PREPROCESSOR_FEATURE_SIZE = 40;
 // Duration of each slice used as input into the preprocessor
@@ -14,6 +18,21 @@ static const uint8_t FEATURE_DURATION_MS = 30;
 // Audio sample frequency in hertz
 static const uint16_t AUDIO_SAMPLE_FREQUENCY = 16000;
 
+static const float FILTERBANK_LOWER_BAND_LIMIT = 125.0;
+static const float FILTERBANK_UPPER_BAND_LIMIT = 7500.0;
+
+static const uint8_t NOISE_REDUCTION_SMOOTHING_BITS = 10;
+static const float NOISE_REDUCTION_EVEN_SMOOTHING = 0.025;
+static const float NOISE_REDUCTION_ODD_SMOOTHING = 0.06;
+static const float NOISE_REDUCTION_MIN_SIGNAL_REMAINING = 0.05;
+
+static const bool PCAN_GAIN_CONTROL_ENABLE_PCAN = true;
+static const float PCAN_GAIN_CONTROL_STRENGTH = 0.95;
+static const float PCAN_GAIN_CONTROL_OFFSET = 80.0;
+static const uint8_t PCAN_GAIN_CONTROL_GAIN_BITS = 21;
+
+static const bool LOG_SCALE_ENABLE_LOG = true;
+static const uint8_t LOG_SCALE_SCALE_SHIFT = 6;
 }  // namespace micro_wake_word
 }  // namespace esphome
 

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -51,8 +51,9 @@ bool StreamingModel::load_model_() {
   }
 
   if (this->interpreter_ == nullptr) {
-    this->interpreter_ = make_unique<tflite::MicroInterpreter>(
-        tflite::GetModel(this->model_start_), this->streaming_op_resolver_, this->tensor_arena_, this->tensor_arena_size_, this->mrv_);
+    this->interpreter_ =
+        make_unique<tflite::MicroInterpreter>(tflite::GetModel(this->model_start_), this->streaming_op_resolver_,
+                                              this->tensor_arena_, this->tensor_arena_size_, this->mrv_);
     if (this->interpreter_->AllocateTensors() != kTfLiteOk) {
       ESP_LOGE(TAG, "Failed to allocate tensors for the streaming model");
       return false;
@@ -124,16 +125,15 @@ bool StreamingModel::perform_streaming_inference(const int8_t features[PREPROCES
   if (this->loaded_) {
     TfLiteTensor *input = this->interpreter_->input(0);
 
+    uint8_t stride = this->interpreter_->input(0)->dims->data[1];
+    this->current_stride_step_ = this->current_stride_step_ % stride;
+
     std::memmove(
         (int8_t *) (tflite::GetTensorData<int8_t>(input)) + PREPROCESSOR_FEATURE_SIZE * this->current_stride_step_,
         features, PREPROCESSOR_FEATURE_SIZE);
     ++this->current_stride_step_;
 
-    uint8_t stride = this->interpreter_->input(0)->dims->data[1];
-
     if (this->current_stride_step_ >= stride) {
-      this->current_stride_step_ = 0;
-
       TfLiteStatus invoke_status = this->interpreter_->Invoke();
       if (invoke_status != kTfLiteOk) {
         ESP_LOGW(TAG, "Streaming interpreter invoke failed");
@@ -146,6 +146,7 @@ bool StreamingModel::perform_streaming_inference(const int8_t features[PREPROCES
       if (this->last_n_index_ == this->sliding_window_size_)
         this->last_n_index_ = 0;
       this->recent_streaming_probabilities_[this->last_n_index_] = output->data.uint8[0];  // probability;
+      this->unprocessed_probability_status_ = true;
     }
     this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
   }
@@ -168,6 +169,7 @@ WakeWordModel::WakeWordModel(const uint8_t *model_start, uint8_t probability_cut
   this->wake_word_ = wake_word;
   this->tensor_arena_size_ = tensor_arena_size;
   this->register_streaming_ops_(this->streaming_op_resolver_);
+  this->current_stride_step_ = 0;
 };
 
 DetectionEvent WakeWordModel::determine_detected() {
@@ -190,6 +192,7 @@ DetectionEvent WakeWordModel::determine_detected() {
   detection_event.average_probability = sum / this->sliding_window_size_;
   detection_event.detected = sum > this->probability_cutoff_ * this->sliding_window_size_;
 
+  this->unprocessed_probability_status_ = false;
   return detection_event;
 }
 

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -30,8 +30,8 @@ class StreamingModel {
   virtual DetectionEvent determine_detected() = 0;
 
   // Performs inference on the given features.
-  //  - Will load the model if it is enabled and needed
-  //  - Will unload the model if it is disabled but still laoded
+  //  - If the model is enabled but not loaded, it will load it
+  //  - If the model is disabled but loaded, it will unload it
   // Returns true if sucessful or false if there is an error
   bool perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]);
 
@@ -41,10 +41,10 @@ class StreamingModel {
   /// @brief Destroys the TFLite interpreter and frees the tensor and variable arenas' memory
   void unload_model();
 
-  /// @brief Enable the model
+  /// @brief Enable the model. The next performing_streaming_inference call will load it.
   void enable() { this->enabled_ = true; }
 
-  /// @brief Disable the model
+  /// @brief Disable the model. The next performing_streaming_inference call will unload it.
   void disable() { this->enabled_ = false; }
 
  protected:

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -89,8 +89,12 @@ class WakeWordModel final : public StreamingModel {
 
   const std::string &get_wake_word() const { return this->wake_word_; }
 
+  void add_trained_language(const std::string &language) { this->trained_languages_.push_back(language); }
+  const std::vector<std::string> &get_trained_languages() const { return this->trained_languages_; }
+
  protected:
   std::string wake_word_;
+  std::vector<std::string> trained_languages_;
 };
 
 class VADModel final : public StreamingModel {

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -17,6 +17,7 @@ static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
 struct DetectionEvent {
   std::string *wake_word;
   bool detected;
+  bool partially_detection;  // Set if the most recent probability exceed the threshold, but the sliding window average hasn't yet
   uint8_t max_probability;
   uint8_t average_probability;
   bool blocked_by_vad = false;

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -11,13 +11,14 @@
 namespace esphome {
 namespace micro_wake_word {
 
-static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
+static const uint8_t MIN_SLICES_BEFORE_DETECTION = 100;
 static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
 
 struct DetectionEvent {
   std::string *wake_word;
   bool detected;
-  bool partially_detection;  // Set if the most recent probability exceed the threshold, but the sliding window average hasn't yet
+  bool partially_detection;  // Set if the most recent probability exceed the threshold, but the sliding window average
+                             // hasn't yet
   uint8_t max_probability;
   uint8_t average_probability;
   bool blocked_by_vad = false;
@@ -43,10 +44,14 @@ class StreamingModel {
   void unload_model();
 
   /// @brief Enable the model. The next performing_streaming_inference call will load it.
-  void enable() { this->enabled_ = true; }
+  void enable() {
+    this->enabled_ = true;
+  }
 
   /// @brief Disable the model. The next performing_streaming_inference call will unload it.
   void disable() { this->enabled_ = false; }
+
+  bool get_unprocessed_probability_status() { return this->unprocessed_probability_status_; }
 
  protected:
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
@@ -59,6 +64,7 @@ class StreamingModel {
 
   bool loaded_{false};
   bool enabled_{true};
+  bool unprocessed_probability_status_{false};
   uint8_t current_stride_step_{0};
   int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
 

--- a/esphome/components/microphone/__init__.py
+++ b/esphome/components/microphone/__init__.py
@@ -21,8 +21,14 @@ Microphone = microphone_ns.class_("Microphone")
 CaptureAction = microphone_ns.class_(
     "CaptureAction", automation.Action, cg.Parented.template(Microphone)
 )
+MuteAction = microphone_ns.class_(
+    "MuteAction", automation.Action, cg.Parented.template(Microphone)
+)
 StopCaptureAction = microphone_ns.class_(
     "StopCaptureAction", automation.Action, cg.Parented.template(Microphone)
+)
+UnmuteAction = microphone_ns.class_(
+    "UnmuteAction", automation.Action, cg.Parented.template(Microphone)
 )
 
 
@@ -66,7 +72,7 @@ MICROPHONE_SCHEMA = cv.Schema(
 MICROPHONE_ACTION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(Microphone)})
 
 
-async def media_player_action(config, action_id, template_arg, args):
+async def microphone_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -74,15 +80,23 @@ async def media_player_action(config, action_id, template_arg, args):
 
 automation.register_action(
     "microphone.capture", CaptureAction, MICROPHONE_ACTION_SCHEMA
-)(media_player_action)
+)(microphone_action)
+
+automation.register_action(
+    "microphone.mute", MuteAction, MICROPHONE_ACTION_SCHEMA
+)(microphone_action)
 
 automation.register_action(
     "microphone.stop_capture", StopCaptureAction, MICROPHONE_ACTION_SCHEMA
-)(media_player_action)
+)(microphone_action)
+
+automation.register_action(
+    "microphone.unmute", UnmuteAction, MICROPHONE_ACTION_SCHEMA
+)(microphone_action)
 
 automation.register_condition(
     "microphone.is_capturing", IsCapturingCondition, MICROPHONE_ACTION_SCHEMA
-)(media_player_action)
+)(microphone_action)
 
 
 @coroutine_with_priority(100.0)

--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -12,6 +12,14 @@ template<typename... Ts> class CaptureAction : public Action<Ts...>, public Pare
   void play(Ts... x) override { this->parent_->start(); }
 };
 
+template<typename... Ts> class MuteAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->set_mute_state(true); }
+};
+
+template<typename... Ts> class UnmuteAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->set_mute_state(false); }
+};
+
 template<typename... Ts> class StopCaptureAction : public Action<Ts...>, public Parented<Microphone> {
   void play(Ts... x) override { this->parent_->stop(); }
 };

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -6,10 +6,13 @@
 namespace esphome {
 namespace microphone {
 
+// TODO: The mute state should belong to the microphone, not the parent nabu_microphone
+
 enum State : uint8_t {
   STATE_STOPPED = 0,
   STATE_STARTING,
   STATE_RUNNING,
+  STATE_MUTED,
   STATE_STOPPING,
 };
 
@@ -22,8 +25,10 @@ class Microphone {
   }
   virtual size_t read(int16_t *buf, size_t len) = 0;
 
+  // How many bytes are available in the ring buffer
   virtual size_t available() { return 0; }
 
+  // Reset the ring buffer
   virtual void reset() {}
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -31,8 +31,11 @@ class Microphone {
   // Reset the ring buffer
   virtual void reset() {}
 
+  virtual void set_mute_state(bool mute_state) {};
+
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
+  bool is_muted() const { return this->state_ == STATE_MUTED; }
 
  protected:
   State state_{STATE_STOPPED};

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -23,7 +23,7 @@ class Microphone {
   void add_data_callback(std::function<void(const std::vector<int16_t> &)> &&data_callback) {
     this->data_callbacks_.add(std::move(data_callback));
   }
-  virtual size_t read(int16_t *buf, size_t len) = 0;
+  virtual size_t read(int16_t *buf, size_t len, TickType_t ticks_to_wait = 0) = 0;
 
   // How many bytes are available in the ring buffer
   virtual size_t available() { return 0; }

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -170,7 +170,7 @@ void NabuMicrophone::read_task_(void *params) {
 
       // Note, if we have 16 bit samples incoming, this requires modification
       ExternalRAMAllocator<int32_t> allocator(ExternalRAMAllocator<int32_t>::ALLOW_FAILURE);
-      int32_t *buffer = allocator.allocate(DMA_SAMPLES);
+      int32_t *buffer = allocator.allocate(CHANNELS*DMA_SAMPLES);
 
       std::vector<int16_t, ExternalRAMAllocator<int16_t>> channel_1_samples;
       std::vector<int16_t, ExternalRAMAllocator<int16_t>> channel_2_samples;
@@ -204,7 +204,7 @@ void NabuMicrophone::read_task_(void *params) {
             }
 
             size_t bytes_read;
-            esp_err_t err = i2s_read(this_microphone->parent_->get_port(), buffer, DMA_SAMPLES * sizeof(int32_t),
+            esp_err_t err = i2s_read(this_microphone->parent_->get_port(), buffer, CHANNELS*DMA_SAMPLES * sizeof(int32_t),
                                      &bytes_read, (10 / portTICK_PERIOD_MS));
             if (err != ESP_OK) {
               event.type = i2s_audio::TaskEventType::WARNING;

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -12,7 +12,7 @@
 namespace esphome {
 namespace nabu_microphone {
 
-static const size_t RING_BUFFER_LENGTH = 64;  // Measured in milliseconds
+static const size_t RING_BUFFER_LENGTH = 640;  // Measured in milliseconds
 static const size_t QUEUE_LENGTH = 10;
 
 static const size_t DMA_BUF_COUNT = 4;

--- a/esphome/components/nabu_microphone/nabu_microphone.cpp
+++ b/esphome/components/nabu_microphone/nabu_microphone.cpp
@@ -12,7 +12,7 @@
 namespace esphome {
 namespace nabu_microphone {
 
-static const size_t RING_BUFFER_LENGTH = 640;  // Measured in milliseconds
+static const size_t RING_BUFFER_LENGTH = 64;  // Measured in milliseconds
 static const size_t QUEUE_LENGTH = 10;
 
 static const size_t DMA_BUF_COUNT = 4;

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -77,12 +77,26 @@ class NabuMicrophoneChannel : public microphone::Microphone, public Component {
  public:
   void setup() override;
 
-  void start() override { this->parent_->start(); }
+  void start() override {
+    this->parent_->start();
+    this->is_muted_ = false;
+    this->requested_stop_ = false;
+  }
 
   void set_parent(NabuMicrophone *nabu_microphone) { this->parent_ = nabu_microphone; }
 
-  void stop() override {};
+  void stop() override {
+    this->requested_stop_ = true;
+    this->is_muted_ = true;  // Mute until it is actually stopped
+  };
+
   void loop() override;
+
+  void set_mute_state(bool mute_state) override { this->is_muted_ = mute_state; }
+  bool get_mute_state() { return this->is_muted_; }
+
+  // void set_requested_stop() { this->requested_stop_ = true; }
+  bool get_requested_stop() { return this->requested_stop_; }
 
   size_t read(int16_t *buf, size_t len) override { return this->ring_buffer_->read((void *) buf, len, 0); };
   size_t available() override { return this->ring_buffer_->available(); }
@@ -98,6 +112,8 @@ class NabuMicrophoneChannel : public microphone::Microphone, public Component {
   std::unique_ptr<RingBuffer> ring_buffer_;
 
   bool amplify_;
+  bool is_muted_;
+  bool requested_stop_;
 };
 
 }  // namespace nabu_microphone

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -23,10 +23,9 @@ class NabuMicrophone : public i2s_audio::I2SAudioIn, public Component {
 
   void loop() override;
 
-  // size_t read(int16_t *buf, size_t len) override;
-  // size_t read_secondary(int16_t *buf, size_t len) override;
-
-  // size_t available_secondary() override { return this->comm_ring_buffer_->available(); }
+  void mute();
+  void unmute();
+  
   void set_channel_1(NabuMicrophoneChannel *microphone) { this->channel_1_ = microphone; }
   void set_channel_2(NabuMicrophoneChannel *microphone) { this->channel_2_ = microphone; }
 

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -98,7 +98,7 @@ class NabuMicrophoneChannel : public microphone::Microphone, public Component {
   // void set_requested_stop() { this->requested_stop_ = true; }
   bool get_requested_stop() { return this->requested_stop_; }
 
-  size_t read(int16_t *buf, size_t len) override { return this->ring_buffer_->read((void *) buf, len, 0); };
+  size_t read(int16_t *buf, size_t len,  TickType_t ticks_to_wait = 0) override { return this->ring_buffer_->read((void *) buf, len, ticks_to_wait); };
   size_t available() override { return this->ring_buffer_->available(); }
   void reset() override { this->ring_buffer_->reset(); }
 

--- a/esphome/components/nabu_microphone/nabu_microphone.h
+++ b/esphome/components/nabu_microphone/nabu_microphone.h
@@ -25,7 +25,7 @@ class NabuMicrophone : public i2s_audio::I2SAudioIn, public Component {
 
   void mute();
   void unmute();
-  
+
   void set_channel_1(NabuMicrophoneChannel *microphone) { this->channel_1_ = microphone; }
   void set_channel_2(NabuMicrophoneChannel *microphone) { this->channel_2_ = microphone; }
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -12,7 +12,8 @@ from esphome.const import (
 )
 from esphome import automation
 from esphome.automation import register_action, register_condition
-from esphome.components import microphone, speaker, media_player
+from esphome.components import microphone, micro_wake_word, speaker, media_player
+
 
 AUTO_LOAD = ["socket"]
 DEPENDENCIES = ["api", "microphone"]
@@ -42,6 +43,7 @@ CONF_AUTO_GAIN = "auto_gain"
 CONF_NOISE_SUPPRESSION_LEVEL = "noise_suppression_level"
 CONF_VOLUME_MULTIPLIER = "volume_multiplier"
 
+CONF_MICRO_WAKE_WORD = "micro_wake_word"
 CONF_WAKE_WORD = "wake_word"
 
 CONF_ON_TIMER_STARTED = "on_timer_started"
@@ -92,6 +94,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Exclusive(CONF_MEDIA_PLAYER, "output"): cv.use_id(
                 media_player.MediaPlayer
             ),
+            cv.Optional(CONF_MICRO_WAKE_WORD): cv.use_id(micro_wake_word.MicroWakeWord),
             cv.Optional(CONF_USE_WAKE_WORD, default=False): cv.boolean,
             cv.Optional(CONF_VAD_THRESHOLD): cv.All(
                 cv.requires_component("esp_adf"), cv.only_with_esp_idf, cv.uint8_t
@@ -166,6 +169,10 @@ async def to_code(config):
 
     mic = await cg.get_variable(config[CONF_MICROPHONE])
     cg.add(var.set_microphone(mic))
+
+    if CONF_MICRO_WAKE_WORD in config:
+        mww = await cg.get_variable(config[CONF_MICRO_WAKE_WORD])
+        cg.add(var.set_micro_wake_word(mww))
 
     if CONF_SPEAKER in config:
         spkr = await cg.get_variable(config[CONF_SPEAKER])

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -488,6 +488,7 @@ void VoiceAssistant::write_speaker_() {
 #endif
 
 #ifdef USE_MICRO_WAKE_WORD
+// TODO: potentially remove, not currently used to initiate a pipeline
 void VoiceAssistant::on_wake_word(const micro_wake_word::DetectionEvent &detection_event) {
   ESP_LOGD(TAG, "directly communicated wake word: %s", detection_event.wake_word->c_str());
 }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -487,6 +487,12 @@ void VoiceAssistant::write_speaker_() {
 }
 #endif
 
+#ifdef USE_MICRO_WAKE_WORD
+void VoiceAssistant::on_wake_word(const micro_wake_word::DetectionEvent &detection_event) {
+  ESP_LOGD(TAG, "directly communicated wake word: %s", detection_event.wake_word->c_str());
+}
+#endif
+
 void VoiceAssistant::client_subscription(api::APIConnection *client, bool subscribe) {
   if (!subscribe) {
     if (this->api_client_ == nullptr || client != this->api_client_) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -398,31 +398,31 @@ void VoiceAssistant::loop() {
 #ifdef USE_SPEAKER
       if (this->speaker_ != nullptr) {
         ssize_t received_len = 0;
-        // if (this->audio_mode_ == AUDIO_MODE_UDP) {
-        //   if (this->speaker_buffer_index_ + RECEIVE_SIZE < SPEAKER_BUFFER_SIZE) {
-        //     received_len = this->socket_->read(this->speaker_buffer_ + this->speaker_buffer_index_, RECEIVE_SIZE);
-        //     if (received_len > 0) {
-        //       this->speaker_buffer_index_ += received_len;
-        //       this->speaker_buffer_size_ += received_len;
-        //       this->speaker_bytes_received_ += received_len;
-        //     }
-        //   } else {
-        //     ESP_LOGD(TAG, "Receive buffer full");
-        //   }
-        // }
+        if (this->audio_mode_ == AUDIO_MODE_UDP) {
+          if (this->speaker_buffer_index_ + RECEIVE_SIZE < SPEAKER_BUFFER_SIZE) {
+            received_len = this->socket_->read(this->speaker_buffer_ + this->speaker_buffer_index_, RECEIVE_SIZE);
+            if (received_len > 0) {
+              this->speaker_buffer_index_ += received_len;
+              this->speaker_buffer_size_ += received_len;
+              this->speaker_bytes_received_ += received_len;
+            }
+          } else {
+            ESP_LOGD(TAG, "Receive buffer full");
+          }
+        }
         // Build a small buffer of audio before sending to the speaker
-        // bool end_of_stream = this->stream_ended_ && (this->audio_mode_ == AUDIO_MODE_API || received_len < 0);
-        // if (this->speaker_bytes_received_ > RECEIVE_SIZE * 4 || end_of_stream)
-        //   this->write_speaker_();
-        // if (this->wait_for_stream_end_) {
-        //   this->cancel_timeout("playing");
-        //   if (end_of_stream) {
-        //     ESP_LOGD(TAG, "End of audio stream received");
-        //     this->cancel_timeout("speaker-timeout");
-        //     this->set_state_(State::RESPONSE_FINISHED, State::RESPONSE_FINISHED);
-        //   }
-        //   break;  // We dont want to timeout here as the STREAM_END event will take care of that.
-        // }
+        bool end_of_stream = this->stream_ended_ && (this->audio_mode_ == AUDIO_MODE_API || received_len < 0);
+        if (this->speaker_bytes_received_ > RECEIVE_SIZE * 4 || end_of_stream)
+          this->write_speaker_();
+        if (this->wait_for_stream_end_) {
+          this->cancel_timeout("playing");
+          if (end_of_stream) {
+            ESP_LOGD(TAG, "End of audio stream received");
+            this->cancel_timeout("speaker-timeout");
+            this->set_state_(State::RESPONSE_FINISHED, State::RESPONSE_FINISHED);
+          }
+          break;  // We dont want to timeout here as the STREAM_END event will take care of that.
+        }
         playing = this->speaker_->is_running();
       }
 #endif
@@ -442,10 +442,10 @@ void VoiceAssistant::loop() {
     case State::RESPONSE_FINISHED: {
 #ifdef USE_SPEAKER
       if (this->speaker_ != nullptr) {
-        // if (this->speaker_buffer_size_ > 0) {
-        //   this->write_speaker_();
-        //   break;
-        // }
+        if (this->speaker_buffer_size_ > 0) {
+          this->write_speaker_();
+          break;
+        }
         if (this->speaker_->has_buffered_data() || this->speaker_->is_running()) {
           break;
         }
@@ -472,18 +472,18 @@ void VoiceAssistant::loop() {
 
 #ifdef USE_SPEAKER
 void VoiceAssistant::write_speaker_() {
-  // if (this->speaker_buffer_size_ > 0) {
-  //   size_t write_chunk = std::min<size_t>(this->speaker_buffer_size_, 4 * 1024);
-  //   size_t written = this->speaker_->play(this->speaker_buffer_, write_chunk);
-  //   if (written > 0) {
-  //     memmove(this->speaker_buffer_, this->speaker_buffer_ + written, this->speaker_buffer_size_ - written);
-  //     this->speaker_buffer_size_ -= written;
-  //     this->speaker_buffer_index_ -= written;
-  //     this->set_timeout("speaker-timeout", 5000, [this]() { this->speaker_->stop(); });
-  //   } else {
-  //     ESP_LOGV(TAG, "Speaker buffer full, trying again next loop");
-  //   }
-  // }
+  if (this->speaker_buffer_size_ > 0) {
+    size_t write_chunk = std::min<size_t>(this->speaker_buffer_size_, 4 * 1024);
+    size_t written = this->speaker_->play(this->speaker_buffer_, write_chunk);
+    if (written > 0) {
+      memmove(this->speaker_buffer_, this->speaker_buffer_ + written, this->speaker_buffer_size_ - written);
+      this->speaker_buffer_size_ -= written;
+      this->speaker_buffer_index_ -= written;
+      this->set_timeout("speaker-timeout", 5000, [this]() { this->speaker_->stop(); });
+    } else {
+      ESP_LOGV(TAG, "Speaker buffer full, trying again next loop");
+    }
+  }
 }
 #endif
 
@@ -815,16 +815,16 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_TTS_STREAM_START: {
 #ifdef USE_SPEAKER
-      // this->wait_for_stream_end_ = true;
-      // ESP_LOGD(TAG, "TTS stream start");
-      // this->defer([this] { this->tts_stream_start_trigger_->trigger(); });
+      this->wait_for_stream_end_ = true;
+      ESP_LOGD(TAG, "TTS stream start");
+      this->defer([this] { this->tts_stream_start_trigger_->trigger(); });
 #endif
       break;
     }
     case api::enums::VOICE_ASSISTANT_TTS_STREAM_END: {
 #ifdef USE_SPEAKER
-      // this->stream_ended_ = true;
-      // ESP_LOGD(TAG, "TTS stream end");
+      this->stream_ended_ = true;
+      ESP_LOGD(TAG, "TTS stream end");
 #endif
       break;
     }
@@ -844,20 +844,17 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
 }
 
 void VoiceAssistant::on_audio(const api::VoiceAssistantAudio &msg) {
-  // TODO: Fix this hack! HomeAssistant thinks we have a speaker, so it sends the TTS response as a wav (good)
-  // It will also send the audio over the protobuf and call this function to try to output directly to the speaker (bad)
-
-  // #ifdef USE_SPEAKER  // We should never get to this function if there is no speaker anyway
-  //   if (this->speaker_buffer_index_ + msg.data.length() < SPEAKER_BUFFER_SIZE) {
-  //     memcpy(this->speaker_buffer_ + this->speaker_buffer_index_, msg.data.data(), msg.data.length());
-  //     this->speaker_buffer_index_ += msg.data.length();
-  //     this->speaker_buffer_size_ += msg.data.length();
-  //     this->speaker_bytes_received_ += msg.data.length();
-  //     ESP_LOGV(TAG, "Received audio: %u bytes from API", msg.data.length());
-  //   } else {
-  //     ESP_LOGE(TAG, "Cannot receive audio, buffer is full");
-  //   }
-  // #endif
+  #ifdef USE_SPEAKER  // We should never get to this function if there is no speaker anyway
+    if (this->speaker_buffer_index_ + msg.data.length() < SPEAKER_BUFFER_SIZE) {
+      memcpy(this->speaker_buffer_ + this->speaker_buffer_index_, msg.data.data(), msg.data.length());
+      this->speaker_buffer_index_ += msg.data.length();
+      this->speaker_buffer_size_ += msg.data.length();
+      this->speaker_bytes_received_ += msg.data.length();
+      ESP_LOGV(TAG, "Received audio: %u bytes from API", msg.data.length());
+    } else {
+      ESP_LOGE(TAG, "Cannot receive audio, buffer is full");
+    }
+  #endif
 }
 
 void VoiceAssistant::on_timer_event(const api::VoiceAssistantTimerEventResponse &msg) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -376,7 +376,7 @@ void VoiceAssistant::loop() {
     }
     case State::STOP_MICROPHONE: {
       if (this->mic_->is_running()) {
-        // this->mic_->stop();
+        this->mic_->stop();
         this->set_state_(State::STOPPING_MICROPHONE);
       } else {
         this->set_state_(this->desired_state_);
@@ -384,9 +384,9 @@ void VoiceAssistant::loop() {
       break;
     }
     case State::STOPPING_MICROPHONE: {
-      // if (this->mic_->is_stopped()) {
-      //   this->set_state_(this->desired_state_);
-      // }
+      if (this->mic_->is_stopped()) {
+        this->set_state_(this->desired_state_);
+      }
       this->set_state_(this->desired_state_);
       break;
     }
@@ -735,7 +735,7 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       this->defer([this, text]() {
         this->tts_start_trigger_->trigger(text);
 #ifdef USE_SPEAKER
-        // this->speaker_->start();
+        this->speaker_->start();
 #endif
       });
       break;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -92,6 +92,11 @@ class VoiceAssistant : public Component {
   void set_microphone(microphone::Microphone *mic) { this->mic_ = mic; }
 #ifdef USE_MICRO_WAKE_WORD
   void set_micro_wake_word(micro_wake_word::MicroWakeWord *mww) { this->micro_wake_word_ = mww; }
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  void set_speech_ms(uint32_t speech_ms) { this->speech_ms_ = speech_ms; }
+  void set_timeout_ms(uint32_t timeout_ms) { this->timeout_ms_ = timeout_ms; }
+  void set_silence_ms(uint32_t silence_ms) { this->silence_ms_ = silence_ms; }
+#endif
 #endif
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
@@ -119,10 +124,8 @@ class VoiceAssistant : public Component {
     uint32_t flags = 0;
     flags |= VoiceAssistantFeature::FEATURE_VOICE_ASSISTANT;
     flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
-    // TODO: Fix this hack! This makes the TTS response be sent as a wav file rather than an mp3, since the mp3 decoder
-    // isn't implemented yet
-    // #ifdef USE_SPEAKER
-    // if (this->speaker_ != nullptr) {
+    // TODO: Fix this hack! This makes the TTS response be sent as a wav file rather than an mp3 for speed
+    // #ifdef USE_SPEAKER if (this->speaker_ != nullptr) {
     flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
     // }
     // #endif
@@ -286,6 +289,20 @@ class VoiceAssistant : public Component {
 
 #ifdef USE_MICRO_WAKE_WORD
   micro_wake_word::MicroWakeWord *micro_wake_word_{nullptr};
+
+#ifdef USE_MICRO_WAKE_WORD_VAD
+  uint32_t speech_ms_{500};  // This is hard to configure (HA uses 300) with the current VAD, as it may initially be
+                             // detected from the wake word
+  uint32_t timeout_ms_{15000};
+  uint32_t silence_ms_{1000};
+
+  int32_t speech_ms_left_{0};
+  int32_t silence_ms_left_{0};
+  int32_t timeout_ms_left_{0};
+
+  optional<uint32_t> last_loop_ms_;
+  bool last_vad_state_;
+#endif
 #endif
 };
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -12,6 +12,9 @@
 #include "esphome/components/api/api_connection.h"
 #include "esphome/components/api/api_pb2.h"
 #include "esphome/components/microphone/microphone.h"
+#ifdef USE_MICRO_WAKE_WORD
+#include "esphome/components/micro_wake_word/micro_wake_word.h"
+#endif
 #ifdef USE_SPEAKER
 #include "esphome/components/speaker/speaker.h"
 #endif
@@ -87,6 +90,9 @@ class VoiceAssistant : public Component {
   void failed_to_start();
 
   void set_microphone(microphone::Microphone *mic) { this->mic_ = mic; }
+#ifdef USE_MICRO_WAKE_WORD
+  void set_micro_wake_word(micro_wake_word::MicroWakeWord *mww) { this->micro_wake_word_ = mww; }
+#endif
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
     this->speaker_ = speaker;
@@ -113,12 +119,13 @@ class VoiceAssistant : public Component {
     uint32_t flags = 0;
     flags |= VoiceAssistantFeature::FEATURE_VOICE_ASSISTANT;
     flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
-    // TODO: Fix this hack! This makes the TTS response be sent as a wav file rather than an mp3, since the mp3 decoder isn't implemented yet
-// #ifdef USE_SPEAKER
+    // TODO: Fix this hack! This makes the TTS response be sent as a wav file rather than an mp3, since the mp3 decoder
+    // isn't implemented yet
+    // #ifdef USE_SPEAKER
     // if (this->speaker_ != nullptr) {
-      flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
+    flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
     // }
-// #endif
+    // #endif
 
     if (this->has_timers_) {
       flags |= VoiceAssistantFeature::FEATURE_TIMERS;
@@ -276,6 +283,10 @@ class VoiceAssistant : public Component {
   AudioMode audio_mode_{AUDIO_MODE_UDP};
   bool udp_socket_running_{false};
   bool start_udp_socket_();
+
+#ifdef USE_MICRO_WAKE_WORD
+  micro_wake_word::MicroWakeWord *micro_wake_word_{nullptr};
+#endif
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<VoiceAssistant> {

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -140,6 +140,10 @@ class VoiceAssistant : public Component {
   void request_start(bool continuous, bool silence_detection);
   void request_stop();
 
+#ifdef USE_MICRO_WAKE_WORD
+  void on_wake_word(const micro_wake_word::DetectionEvent &detection_event);
+#endif
+
   void on_event(const api::VoiceAssistantEventResponse &msg);
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -124,11 +124,11 @@ class VoiceAssistant : public Component {
     uint32_t flags = 0;
     flags |= VoiceAssistantFeature::FEATURE_VOICE_ASSISTANT;
     flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
-    // TODO: Fix this hack! This makes the TTS response be sent as a wav file rather than an mp3 for speed
-    // #ifdef USE_SPEAKER if (this->speaker_ != nullptr) {
-    flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
-    // }
-    // #endif
+#ifdef USE_SPEAKER
+    if (this->speaker_ != nullptr) {
+      flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
+    }
+#endif
 
     if (this->has_timers_) {
       flags |= VoiceAssistantFeature::FEATURE_TIMERS;
@@ -308,7 +308,7 @@ class VoiceAssistant : public Component {
   bool last_vad_state_;
 #endif
 #endif
-};
+};  // namespace voice_assistant
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<VoiceAssistant> {
   TEMPLATABLE_VALUE(std::string, wake_word);


### PR DESCRIPTION
There aren't too many drastic changes here, but instead just laying down a foundation for communicating directly between the micro_wake_word and voice_assistant components. 

In general, the voice_assistant component has a pointer to the micro_wake_word component (if it exists). It can get the wake word objects from mWW via ``get_wake_words()``. You can enable or disable the wake words by passing a vector of strings with the enabled friendly wake word names using ``enable_wake_words()``, but this logic may be better to just keep inside the voice assistant component.

The current code still relies on the ``on_wake_word_detected`` action to initiate a pipeline, but I have also setup a direct message from mWW to the VA with the full detection information. I'm still not sure what's the best approach here. Exposing it through the action let's users have fine-tuned control over it, but it may add latency. It could take up to 2 loops before the message is actually received by the voice assistant component based on how the tasks are setup. Not a huge deal, but if we try to eliminate the current required pause after the wake word, this delay may cause issues.

The microphone task blocks on i2s_read instead of using a magic number delay. The mWW tasks block on reading/writing audio and features instead of a fixed delay.

I've also added a mute state to the microphone class. The ``nabu_microphone`` component implements this by just sending 0s instead of the actual data. If one channel gets a request to stop, it mutes the channel. If both channel microphones request a stop, then it will actually stop reading from the I2S bus. As such, I've added back the stopping microphone code to the voice assistant component that was previously commented out. Since microWakeWord is now always listening, the I2S bus will stay alive since that channel won't request a stop. Hopefully, this will make it easier for us to merge any voice_assistant changes back into ESPHome before the rest of the components are ready.