### PR TITLE
Build firmware with ESPHome dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       files: |
         voice-kit.factory.yaml
-      esphome-version: 2024.9.0-dev
+      esphome-version: dev
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       files: |
         voice-kit.factory.yaml
-      esphome-version: 2024.8.1
+      esphome-version: 2024.9.0-dev
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}


### PR DESCRIPTION
Change the GitHub build action to use the ESPHome dev branch. This is necessary because #72 relies on a core change in esphome/esphome#7390