### PR TITLE
[media_player] Add mute, unmute and volume change triggers

### DIFF
--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -719,6 +719,14 @@ void NabuMediaPlayer::set_mute_state_(bool mute_state) {
     }
   }
 
+  if (this->is_muted_ != mute_state) {
+    if (mute_state) {
+      this->mute_trigger_->trigger();
+    } else {
+      this->unmute_trigger_->trigger();
+    }
+  }
+
   this->is_muted_ = mute_state;
 
   this->save_volume_restore_state_();
@@ -735,6 +743,8 @@ void NabuMediaPlayer::set_volume_(float volume, bool publish) {
     ssize_t decibel_index = remap<ssize_t, float>(volume, 1.0f, 0.0f, 0, decibel_reduction_table.size() - 1);
     this->software_volume_scale_factor_ = decibel_reduction_table[decibel_index];
   }
+
+  this->volume_trigger_->trigger(volume);
 
   if (publish) {
     this->volume = volume;

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -73,6 +73,10 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }
 #endif
 
+  Trigger<> *get_mute_trigger() const { return this->mute_trigger_; }
+  Trigger<> *get_unmute_trigger() const { return this->unmute_trigger_; }
+  Trigger<float> *get_volume_trigger() const { return this->volume_trigger_; }
+
  protected:
   // Receives commands from HA or from the voice assistant component
   // Sends commands to the media_control_commanda_queue_
@@ -138,6 +142,10 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
 
   // Used to save volume/mute state for restoration
   ESPPreferenceObject pref_;
+
+  Trigger<> *mute_trigger_ = new Trigger<>();
+  Trigger<> *unmute_trigger_ = new Trigger<>();
+  Trigger<float> *volume_trigger_ = new Trigger<float>();
 };
 
 template<typename... Ts> class DuckingSetAction : public Action<Ts...>, public Parented<NabuMediaPlayer> {


### PR DESCRIPTION
Adds ``on_mute``, ``on_unmute``, and ``on_volume`` triggers to the nabu media player component. For ``on_volume``, the variable ``x`` has the new volume (a floating point number between 0 and 1).