### PR TITLE
[micro_wake_word] Bugfix: New spectrogram features should go to the back of the queue

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -189,7 +189,7 @@ void MicroWakeWord::preprocessor_task_(void *params) {
           features_buffer[i] = clamp<int8_t>(value, INT8_MIN, INT8_MAX);
         }
 
-        if (!xQueueSend(this_mww->features_queue_, features_buffer, 0)) {
+        if (!xQueueSendToBack(this_mww->features_queue_, features_buffer, 0)) {
           // Features queue is too full, so we fell behind on inferring!
 
           xEventGroupSetBits(this_mww->event_group_, EventGroupBits::PREPROCESSOR_MESSAGE_WARNING_FEATURES_FULL);
@@ -393,7 +393,7 @@ void MicroWakeWord::stop() {
   xEventGroupWaitBits(this->event_group_,
                       (PREPROCESSOR_MESSAGE_IDLE | INFERENCE_MESSAGE_IDLE),  // Bit message to read
                       pdTRUE,                                                // Clear the bit on exit
-                      pdTRUE,                                                  // Wait for all the bits,
+                      pdTRUE,                                                // Wait for all the bits,
                       pdMS_TO_TICKS(STOPPING_TIMEOUT_MS));                   // Block to wait until the tasks stop
 
   xEventGroupClearBits(this->event_group_, ALL_BITS);


### PR DESCRIPTION
In #61, I modified how the spectrogram features were transferred from the preprocessor task to the inference task, where it uses a queue instead of a ring buffer. I mistakenly sent the newest features to the front of the queue. If the inference task ever fell even slightly behind, then this would result in the spectrogram features being processed out of order. This explains the sudden decrease in wake word performance! This PR sends the newest features to the back of the queue so everything is processed in the correct order.