### PR TITLE
Restore Wake Word Choice on start-up

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1263,6 +1263,7 @@ select:
       - "Hey Jarvis"
       - "Hey Mycroft"
     optimistic: true
+    restore_value: true
     on_value:
       then:
         - lambda: |-


### PR DESCRIPTION
The wake word choice the user made with the `select` entity was not restored at start-up
Even if the `select` entity is temporary, it's still annoying when testing.