### PR TITLE
Suspend tasks on OTA

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -66,8 +66,6 @@ class MicroWakeWord : public Component {
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
   State state_{State::IDLE};
 
-
-
   std::vector<WakeWordModel *> wake_word_models_;
 
 #ifdef USE_MICRO_WAKE_WORD_VAD
@@ -80,6 +78,11 @@ class MicroWakeWord : public Component {
   struct FrontendState frontend_state_;
 
   uint8_t features_step_size_;
+
+  /// @brief Suspends the preprocessor and inference tasks
+  void suspend_tasks_();
+  /// @brief Resumes the preprocessor and inference tasks
+  void resume_tasks_();
 
   void set_state_(State state);
 

--- a/esphome/components/nabu/audio_mixer.cpp
+++ b/esphome/components/nabu/audio_mixer.cpp
@@ -51,6 +51,18 @@ size_t AudioMixer::read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait
   return this->output_ring_buffer_->read((void *) buffer, length, ticks_to_wait);
 }
 
+void AudioMixer::suspend_task() {
+  if (this->task_handle_ != nullptr) {
+    vTaskSuspend(this->task_handle_);
+  }
+}
+
+void AudioMixer::resume_task() {
+  if (this->task_handle_ != nullptr) {
+    vTaskResume(task_handle_);
+  }
+}
+
 void AudioMixer::audio_mixer_task_(void *params) {
   AudioMixer *this_mixer = (AudioMixer *) params;
 
@@ -259,7 +271,7 @@ void AudioMixer::audio_mixer_task_(void *params) {
         }
       } else {
         // No audio data available in either buffer
-        
+
         delay(TASK_DELAY_MS);
       }
     }

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -115,6 +115,11 @@ class AudioMixer {
   /// @return pointer to announcement ring buffer
   RingBuffer *get_announcement_ring_buffer() { return this->announcement_ring_buffer_.get(); }
 
+  /// @brief Suspends the mixer task
+  void suspend_task();
+  /// @brief Resumes the mixer task
+  void resume_task();
+
  protected:
   /// @brief Allocates the ring buffers, task stack, and queues
   /// @return ESP_OK if successful or an error otherwise

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -269,6 +269,30 @@ void AudioPipeline::reset_ring_buffers() {
   this->resampled_ring_buffer_->reset();
 }
 
+void AudioPipeline::suspend_tasks() {
+  if (this->read_task_handle_ != nullptr) {
+    vTaskSuspend(this->read_task_handle_);
+  }
+  if (this->decode_task_handle_ != nullptr) {
+    vTaskSuspend(this->decode_task_handle_);
+  }
+  if (this->resample_task_handle_ != nullptr) {
+    vTaskSuspend(this->resample_task_handle_);
+  }
+}
+
+void AudioPipeline::resume_tasks() {
+  if (this->read_task_handle_ != nullptr) {
+    vTaskResume(this->read_task_handle_);
+  }
+  if (this->decode_task_handle_ != nullptr) {
+    vTaskResume(this->decode_task_handle_);
+  }
+  if (this->resample_task_handle_ != nullptr) {
+    vTaskResume(this->resample_task_handle_);
+  }
+}
+
 void AudioPipeline::read_task_(void *params) {
   AudioPipeline *this_pipeline = (AudioPipeline *) params;
 

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -62,6 +62,11 @@ class AudioPipeline {
 
   void reset_ring_buffers();
 
+  /// @brief Suspends any running tasks
+  void suspend_tasks();
+  /// @brief Resumes any running tasks
+  void resume_tasks();
+
  protected:
   esp_err_t allocate_buffers_();
   esp_err_t common_start_(uint32_t target_sample_rate, const std::string &task_name, UBaseType_t priority);


### PR DESCRIPTION
- Ensures the media player tasks are running before attempting to send commands to them
- Suspends all the media player, microphone, and mWW tasks when OTA starts
- Resumes all the suspended tasks when OTA encounters an error