### PR TITLE
[bugfix] add USE_OTA_STATE_CALLBACK define

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -447,6 +447,7 @@ async def to_code(config):
     cg.add(var.set_microphone(mic))
 
     cg.add_define("USE_MICRO_WAKE_WORD")
+    cg.add_define("USE_OTA_STATE_CALLBACK")
 
     esp32.add_idf_component(
         name="esp-tflite-micro",

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -252,6 +252,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await media_player.register_media_player(var, config)
+    
+    cg.add_define("USE_OTA_STATE_CALLBACK")
 
     await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
     cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))

--- a/esphome/components/nabu_microphone/microphone.py
+++ b/esphome/components/nabu_microphone/microphone.py
@@ -146,3 +146,5 @@ async def to_code(config):
     cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))
     cg.add(var.set_use_apll(config[CONF_USE_APLL]))
     cg.add(var.set_i2s_mode(config[CONF_I2S_MODE]))
+
+    cg.add_define("USE_OTA_STATE_CALLBACK")


### PR DESCRIPTION
Fixes a bug from PR #85 that didn't compile if the ``http_request`` component isn't included in the yaml.