### PR TITLE
Stop current pipeline when wake word detected

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1257,6 +1257,9 @@ micro_wake_word:
                       voice_assistant.is_running:
                     then:
                       - voice_assistant.stop:
+                      - wait_until:
+                          not:
+                            voice_assistant.is_running:
                 - voice_assistant.start:
                     wake_word: !lambda return wake_word;
 

--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1252,6 +1252,11 @@ micro_wake_word:
                           not:
                             lambda: |-
                               return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+                - if:
+                    condition:
+                      voice_assistant.is_running:
+                    then:
+                      - voice_assistant.stop:
                 - voice_assistant.start:
                     wake_word: !lambda return wake_word;
 


### PR DESCRIPTION
The idea is to stop the pipeline when the wake word is detected to allow a new run

This PR allows the user to stop the pipeline during a response. "Sorry I am not aware of any area called works...." "OK Nabu, Turn on the office lights"

But it still fails to stop a pipeline during its query **"Ok Nabu, turn off the wait no Ok Nabu, Turn on the office lights"**

**DO NOT MERGE. Attempting to interrupt a query really messes everything up in this current state**