### PR TITLE
[i2s_audio] use ESPHome's i2s_audio

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -1207,7 +1207,6 @@ external_components:
     components:
       - aic3204
       - audio_dac
-      - i2s_audio
       - media_player
       - micro_wake_word
       - microphone


### PR DESCRIPTION
We no longer need a custom ``i2s_audio`` component after #98 