### PR TITLE
Duck audio for all announcements

### DIFF
--- a/voice-kit.yaml
+++ b/voice-kit.yaml
@@ -207,6 +207,7 @@ switch:
     on_turn_on:
       - nabu.set_ducking:
           decibel_reduction: 20
+          duration: 0.0s
       - script.execute: ring_timer
       - script.execute: control_leds
       - delay: 15min
@@ -1227,6 +1228,23 @@ media_player:
       - script.execute: control_leds
     on_volume:
       - script.execute: control_leds
+    on_announcement:
+      - nabu.set_ducking:
+          decibel_reduction: 20
+          duration: 0.0s
+    on_state:
+      if:
+        condition:
+          and:
+            - switch.is_off: timer_ringing
+            - not:
+                voice_assistant.is_running:
+            - not:
+                lambda: return id(nabu_media_player)->state == media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING;
+        then:
+          - nabu.set_ducking:
+              decibel_reduction: 0
+              duration: 1.0s
     files:
       - id: center_button_press_sound
         file: sounds/center_button_press.flac


### PR DESCRIPTION
Duck audio for all announcements.
Now 3 processes duck audio
- The voice assistant (from start to end) so that you can speak
- The timer (Because the timer is a bunch of small announcement with delay in between)
- And the media player for all announcements even coming from Home Assistant