### PR TITLE
Require 16-bit samples for media player

### DIFF
--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -55,6 +55,7 @@ struct MediaPlayerSupportedFormat {
   uint32_t sample_rate;
   uint32_t num_channels;
   MediaPlayerFormatPurpose purpose;
+  uint32_t sample_bytes;
 };
 
 struct MediaFile {

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -606,12 +606,14 @@ media_player::MediaPlayerTraits NabuMediaPlayer::get_traits() {
       media_player::MediaPlayerSupportedFormat{.format = "flac",
                                                .sample_rate = 48000,
                                                .num_channels = 2,
-                                               .purpose = media_player::MediaPlayerFormatPurpose::PURPOSE_DEFAULT});
+                                               .purpose = media_player::MediaPlayerFormatPurpose::PURPOSE_DEFAULT,
+                                               .sample_bytes = 2});
   traits.get_supported_formats().push_back(media_player::MediaPlayerSupportedFormat{
       .format = "flac",
       .sample_rate = 48000,
       .num_channels = 1,
-      .purpose = media_player::MediaPlayerFormatPurpose::PURPOSE_ANNOUNCEMENT});
+      .purpose = media_player::MediaPlayerFormatPurpose::PURPOSE_ANNOUNCEMENT,
+      .sample_bytes = 2});
   return traits;
 };
 


### PR DESCRIPTION
Uses the `sample_bytes` field to required 16-bit samples from the ESPHome media proxy.

Requires:
* https://github.com/esphome/esphome/pull/7451
* https://github.com/home-assistant/core/pull/126016