### PR TITLE
Alter update manifest to point to new manifest location after renaming

### DIFF
--- a/voice-kit.factory.yaml
+++ b/voice-kit.factory.yaml
@@ -28,7 +28,7 @@ update:
   - platform: http_request
     name: None
     id: update_http_request
-    source: https://firmware.esphome.io/voice-kit/esphome-voice-kit/manifest.json
+    source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json
 
 dashboard_import:
   package_import_url: github://esphome/voice-kit/voice-kit.yaml


### PR DESCRIPTION
This is in preparation to rename the files and repo so that existing running `esphome-voice-kit` devices will get one last update before the following update will be the renamed firmware