### PR TITLE
[nabu] Adds software volume limits

### DIFF
--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -57,6 +57,8 @@ CONF_MEDIA_FILE = "media_file"
 CONF_FILES = "files"
 CONF_SAMPLE_RATE = "sample_rate"
 CONF_VOLUME_INCREMENT = "volume_increment"
+CONF_VOLUME_MIN = "volume_min"
+CONF_VOLUME_MAX = "volume_max"
 
 CONF_ON_MUTE = "on_mute"
 CONF_ON_UNMUTE = "on_unmute"
@@ -198,6 +200,8 @@ CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
             _validate_bits, cv.enum(I2S_BITS_PER_SAMPLE)
         ),
         cv.Optional(CONF_VOLUME_INCREMENT, default=0.05): cv.percentage,
+        cv.Optional(CONF_VOLUME_MAX, default=1.0): cv.percentage,
+        cv.Optional(CONF_VOLUME_MIN, default=0.0): cv.percentage,
         cv.Optional(CONF_FILES): cv.ensure_list(MEDIA_FILE_TYPE_SCHEMA),
         cv.Optional(CONF_ON_MUTE): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_UNMUTE): automation.validate_automation(single=True),
@@ -252,7 +256,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await media_player.register_media_player(var, config)
-    
+
     cg.add_define("USE_OTA_STATE_CALLBACK")
 
     await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
@@ -262,6 +266,8 @@ async def to_code(config):
     cg.add(var.set_i2s_mode(config[CONF_I2S_MODE]))
 
     cg.add(var.set_volume_increment(config[CONF_VOLUME_INCREMENT]))
+    cg.add(var.set_volume_max(config[CONF_VOLUME_MAX]))
+    cg.add(var.set_volume_min(config[CONF_VOLUME_MIN]))
 
     if on_mute := config.get(CONF_ON_MUTE):
         await automation.build_automation(

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -72,6 +72,9 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   // Percentage to increase or decrease the volume for volume up or volume down commands
   void set_volume_increment(float volume_increment) { this->volume_increment_ = volume_increment; }
 
+  void set_volume_max(float volume_max) { this->volume_max_ = volume_max; }
+  void set_volume_min(float volume_min) { this->volume_min_ = volume_min; }
+
 #ifdef USE_AUDIO_DAC
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }
 #endif
@@ -125,7 +128,7 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   optional<std::string> announcement_url_{};                 // only modified by control function
   optional<media_player::MediaFile *> media_file_{};         // only modified by control fucntion
   optional<media_player::MediaFile *> announcement_file_{};  // only modified by control fucntion
-  
+
   QueueHandle_t media_control_command_queue_;
 
   i2s_bits_per_sample_t bits_per_sample_;
@@ -138,6 +141,9 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
 
   // The amount to change the volume on volume up/down commands
   float volume_increment_;
+
+  float volume_max_;
+  float volume_min_;
 
 #ifdef USE_AUDIO_DAC
   audio_dac::AudioDac *audio_dac_{nullptr};

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1236,6 +1236,9 @@ media_player:
     bits_per_sample: 32bit
     i2s_mode: secondary
     i2s_audio_id: i2s_output
+    volume_increment: 0.05
+    volume_min: 0.4
+    volume_max: 0.85
     on_mute:
       - script.execute: control_leds
     on_unmute:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1305,7 +1305,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: dev
+      ref: kahrendt-20240916-volume-limits
     components:
       - aic3204
       - audio_dac


### PR DESCRIPTION
Adds two configuration options to the yaml: ``volume_min`` and ``volume_max``. These are percentages that represent the min and max volume setting allowed. Volume commands are mapped to within the bounds before sending it to the DAC.

If the volume is 0, then it automatically mutes the device. If the volume is changed to be greater than 0, the device is automatically unmuted.

This will require a follow up PR to switch the external component back to dev. The min and max volumes I chose will probably need to be tuned further.