### PR TITLE
Point external component to dev branch

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1305,7 +1305,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: kahrendt-20240916-volume-limits
+      ref: dev
     components:
       - aic3204
       - audio_dac


### PR DESCRIPTION
Follow up to #118. Sets the external component back to dev the branch.