### PR TITLE
[voice_kit] Add VNR and pipeline stage I2C commands

### DIFF
--- a/esphome/components/voice_kit/voice_kit.h
+++ b/esphome/components/voice_kit/voice_kit.h
@@ -9,10 +9,13 @@
 namespace esphome {
 namespace voice_kit {
 
+static const uint8_t REGISTER_CHANNEL_1_STAGE = 0x40;
+
 // Configuration servicer resource IDs
 //
 static const uint8_t DFU_CONTROLLER_SERVICER_RESID = 240;
 static const uint8_t CONFIGURATION_SERVICER_RESID = 241;
+static const uint8_t CONFIGURATION_COMMAND_READ_BIT = 0x80;
 static const uint8_t DFU_COMMAND_READ_BIT = 0x80;
 
 static const uint16_t DFU_TIMEOUT_MS = 1000;
@@ -34,6 +37,26 @@ enum VoiceKitUpdaterStatus : uint8_t {
   UPDATE_IN_PROGRESS,
   UPDATE_REBOOT_PENDING,
   UPDATE_VERIFY_NEW_VERSION,
+};
+
+// Configuration enums from the XMOS firmware's src/configuration/configuration_servicer.h
+enum ConfCommands : uint8_t {
+  CONFIGURATION_SERVICER_RESID_VNR_VALUE = 0x00,
+  CONFIGURATION_SERVICER_RESID_CHANNEL_0_PIPELINE_STAGE = 0x30,
+  CONFIGURATION_SERVICER_RESID_CHANNEL_1_PIPELINE_STAGE = 0x40,
+};
+
+enum PipelineStages : uint8_t {
+  PIPELINE_STAGE_NONE = 0,
+  PIPELINE_STAGE_AEC = 1,
+  PIPELINE_STAGE_IC = 2,
+  PIPELINE_STAGE_NS = 3,
+  PIPELINE_STAGE_AGC = 4,
+};
+
+enum MicrophoneChannels : uint8_t {
+  MICROPHONE_CHANNEL_0 = 0,
+  MICROPHONE_CHANNEL_1 = 1,
 };
 
 // DFU enums from https://github.com/xmos/sln_voice/blob/develop/examples/ffva/src/dfu_int/dfu_state_machine.h
@@ -125,6 +148,10 @@ class VoiceKit : public Component, public i2c::I2CDevice {
   }
 
   void start_dfu_update();
+
+  uint8_t read_vnr();
+  void write_pipeline_stage(MicrophoneChannels channel, PipelineStages stage);
+  PipelineStages read_pipeline_stage(MicrophoneChannels channel);
 
  protected:
 #ifdef USE_VOICE_KIT_STATE_CALLBACK

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1313,9 +1313,9 @@ media_player:
 voice_kit:
   reset_pin: GPIO4
   firmware:
-    url: https://github.com/esphome/voice-kit-xmos-firmware/releases/download/v1.2.0/ffva_v1.2.0_upgrade.bin
-    version: "1.2.0"
-    md5: 912b84ea15df4a0081e39ffd9740b884
+    url: https://github.com/esphome/voice-kit-xmos-firmware/releases/download/v1.3.1/ffva_v1.3.1_upgrade.bin
+    version: "1.3.1"
+    md5: 964635c5bf125529dab14a2472a15401
 
 external_components:
   - source:


### PR DESCRIPTION
Requires https://github.com/esphome/voice-kit-xmos-firmware/pull/5 for the pipeline stage commands.

Adds functions to the ``voice_kit`` component for reading and writing certain settings on the XMOS. ``read_vnr()`` gets the XMOS's voice to noise ratio (basically a VAD). ``write_pipeline_stage`` allows you to configure the pipeline stage a microphone channel uses. ``read_pipeline_stage()`` is added just to confirm that the pipeline stages have been made on the XMOS.

There are 5 options for the stages:
PIPELINE_STAGE_NONE - no processing applied, raw microphone data
PIPELINE_STAGE_AEC - Acoustic Echo Cancellation
PIPELINE_STAGE_IC - AEC + Interference Cancellation
PIPELINE_STAGE_NS - AEC + IC + Noise Suppression
PIPELINE_STAGE_AGC - AEC +IC + NS + Automatic Gain Control

Here is some useful yaml for testing these out after adding ``id: voice_kit_component`` under the ``voice_kit`` component:

```
sensor:
  - platform: template
    name: "Voice to noise ratio"
    lambda: return id(voice_kit_component).read_vnr();
    update_interval: 0.25s
    state_class: "measurement"
    accuracy_decimals: 3

select:
  - platform: template
    name: "Channel 0 stage"
    options:
      - "None"
      - "AEC"
      - "IC"
      - "NS"
      - "AGC"
    optimistic: true
    on_value:
      then:
        - lambda: |-
            if (x == "None") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_0, voice_kit::PIPELINE_STAGE_NONE);
            } else if (x == "AEC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_0, voice_kit::PIPELINE_STAGE_AEC);
            } else if (x == "IC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_0, voice_kit::PIPELINE_STAGE_IC);
            } else if (x == "NS") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_0, voice_kit::PIPELINE_STAGE_NS);
            } else if (x == "AGC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_0, voice_kit::PIPELINE_STAGE_AGC);
            }
  - platform: template
    name: "Channel 1 stage"
    options:
      - "None"
      - "AEC"
      - "IC"
      - "NS"
      - "AGC"
    optimistic: true
    on_value:
      then:
        - lambda: |-
            if (x == "None") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_1, voice_kit::PIPELINE_STAGE_NONE);
            } else if (x == "AEC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_1, voice_kit::PIPELINE_STAGE_AEC);
            } else if (x == "IC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_1, voice_kit::PIPELINE_STAGE_IC);
            } else if (x == "NS") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_1, voice_kit::PIPELINE_STAGE_NS);
            } else if (x == "AGC") {
              id(voice_kit_component).write_pipeline_stage(voice_kit::MICROPHONE_CHANNEL_1, voice_kit::PIPELINE_STAGE_AGC);
            }
```