### PR TITLE
[nabu] Handle URLs with https

### DIFF
--- a/esphome/components/nabu/audio_reader.cpp
+++ b/esphome/components/nabu/audio_reader.cpp
@@ -4,6 +4,10 @@
 
 #include "esphome/core/ring_buffer.h"
 
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#include "esp_crt_bundle.h"
+#endif
+
 namespace esphome {
 namespace nabu {
 
@@ -73,6 +77,12 @@ esp_err_t AudioReader::start(const std::string &uri, media_player::MediaFileType
   client_config.max_redirection_count = 10;
   client_config.buffer_size = 512;
   client_config.keep_alive_enable = true;
+  
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+  if (uri.find("https:") != std::string::npos) {
+    client_config.crt_bundle_attach = esp_crt_bundle_attach;
+  }
+#endif
 
   this->client_ = esp_http_client_init(&client_config);
 

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -15,6 +15,7 @@ namespace esphome {
 namespace nabu {
 
 // TODO:
+//  - Align TLS certification defines with the http_request component
 //  - Clean up process around playing back local media files
 //    - Create a registry of media files in Python
 //    - Add a yaml action to play a specific media file


### PR DESCRIPTION
Adds support for reading media from https sources.

Currently the ``nabu`` component relies on the ``http_request`` component to specify whether to accept secure connections or not. This should be aligned before merging upstream. It would probably be best to actually use the ``http_request`` component to handle the actual reading.