### PR TITLE
[nabu] Prevent stuck media pipeline in certain situations

### DIFF
--- a/esphome/components/nabu/audio_decoder.cpp
+++ b/esphome/components/nabu/audio_decoder.cpp
@@ -71,6 +71,7 @@ esp_err_t AudioDecoder::start(media_player::MediaFileType media_file_type) {
       this->wav_decoder_->reset();
       break;
     case media_player::MediaFileType::NONE:
+      return ESP_ERR_NOT_SUPPORTED;
       break;
   }
 

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -239,6 +239,19 @@ esp_err_t AudioPipeline::stop() {
                                                   pdTRUE,               // Wait for all the bits,
                                                   pdMS_TO_TICKS(200));  // Duration to block/wait
 
+  if (!(event_group_bits & READER_MESSAGE_FINISHED)) {
+    // Reader failed to stop
+    xEventGroupSetBits(this->event_group_, EventGroupBits::READER_MESSAGE_ERROR);
+  }
+  if (!(event_group_bits & DECODER_MESSAGE_FINISHED)) {
+    // Ddecoder failed to stop
+    xEventGroupSetBits(this->event_group_, EventGroupBits::DECODER_MESSAGE_ERROR);
+  }
+  if (!(event_group_bits & RESAMPLER_MESSAGE_FINISHED)) {
+    // Resampler failed to stop
+    xEventGroupSetBits(this->event_group_, EventGroupBits::RESAMPLER_MESSAGE_ERROR);
+  }
+
   if ((event_group_bits & FINISHED_BITS) != FINISHED_BITS) {
     // Not all bits were set, so it timed out
     return ESP_ERR_TIMEOUT;

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -237,7 +237,7 @@ esp_err_t AudioPipeline::stop() {
                                                   FINISHED_BITS,        // Bit message to read
                                                   pdFALSE,              // Clear the bits on exit
                                                   pdTRUE,               // Wait for all the bits,
-                                                  pdMS_TO_TICKS(200));  // Duration to block/wait
+                                                  pdMS_TO_TICKS(300));  // Duration to block/wait
 
   if (!(event_group_bits & READER_MESSAGE_FINISHED)) {
     // Reader failed to stop

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -239,7 +239,7 @@ esp_err_t AudioPipeline::stop() {
                                                   pdTRUE,               // Wait for all the bits,
                                                   pdMS_TO_TICKS(200));  // Duration to block/wait
 
-  if (!(event_group_bits & FINISHED_BITS)) {
+  if ((event_group_bits & FINISHED_BITS) != FINISHED_BITS) {
     // Not all bits were set, so it timed out
     return ESP_ERR_TIMEOUT;
   }

--- a/esphome/components/nabu/audio_reader.cpp
+++ b/esphome/components/nabu/audio_reader.cpp
@@ -112,6 +112,10 @@ esp_err_t AudioReader::start(const std::string &uri, media_player::MediaFileType
     file_type = media_player::MediaFileType::MP3;
   } else if (str_endswith(url_string, ".flac")) {
     file_type = media_player::MediaFileType::FLAC;
+  } else {
+    file_type = media_player::MediaFileType::NONE;
+    this->cleanup_connection_();
+    return ESP_ERR_NOT_SUPPORTED;
   }
 
   this->transfer_buffer_current_ = this->transfer_buffer_;
@@ -127,7 +131,7 @@ AudioReaderState AudioReader::read() {
     return this->file_read_();
   }
 
-  return AudioReaderState::INITIALIZED;
+  return AudioReaderState::FAILED;
 }
 
 AudioReaderState AudioReader::file_read_() {
@@ -148,7 +152,7 @@ AudioReaderState AudioReader::http_read_() {
         (void *) this->transfer_buffer_, this->transfer_buffer_length_, pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
     this->transfer_buffer_length_ -= bytes_written;
 
-    // Shif remaining data to the start of the transfer buffer
+    // Shift remaining data to the start of the transfer buffer
     memmove(this->transfer_buffer_, this->transfer_buffer_ + bytes_written, this->transfer_buffer_length_);
   }
 

--- a/esphome/components/nabu/audio_reader.cpp
+++ b/esphome/components/nabu/audio_reader.cpp
@@ -77,7 +77,7 @@ esp_err_t AudioReader::start(const std::string &uri, media_player::MediaFileType
   client_config.max_redirection_count = 10;
   client_config.buffer_size = 512;
   client_config.keep_alive_enable = true;
-  
+
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
   if (uri.find("https:") != std::string::npos) {
     client_config.crt_bundle_attach = esp_crt_bundle_attach;

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -36,11 +36,13 @@ class AudioReader {
 
   esphome::RingBuffer *output_ring_buffer_;
 
-  uint8_t *transfer_buffer_{nullptr};
-  const uint8_t *transfer_buffer_current_{nullptr};
-
   size_t transfer_buffer_length_;  // Amount of data currently stored in transfer buffer (in bytes)
   size_t transfer_buffer_size_;    // Capacity of transfer buffer (in bytes)
+
+  ssize_t no_data_read_count_;
+
+  uint8_t *transfer_buffer_{nullptr};
+  const uint8_t *transfer_buffer_current_{nullptr};
 
   esp_http_client_handle_t client_{nullptr};
 

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -11,8 +11,7 @@ namespace esphome {
 namespace nabu {
 
 enum class AudioReaderState : uint8_t {
-  INITIALIZED = 0,
-  READING,
+  READING = 0,
   FINISHED,
   FAILED,
 };

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -503,19 +503,19 @@ void NabuMediaPlayer::loop() {
     this->media_pipeline_state_ = this->media_pipeline_->get_state();
 
   if (this->media_pipeline_state_ == AudioPipelineState::ERROR_READING) {
-    ESP_LOGE(TAG, "Media pipeline encountered an error reading the file.");
+    ESP_LOGE(TAG, "The media pipeline's file reader encountered an error.");
   } else if (this->media_pipeline_state_ == AudioPipelineState::ERROR_DECODING) {
-    ESP_LOGE(TAG, "Media pipeline encountered an error decoding the file.");
+    ESP_LOGE(TAG, "The media pipeline's audio decoder encountered an error.");
   } else if (this->media_pipeline_state_ == AudioPipelineState::ERROR_RESAMPLING) {
-    ESP_LOGE(TAG, "Media pipeline encountered an error resampling the file.");
+    ESP_LOGE(TAG, "The media pipeline's audio resampler encountered an error.");
   }
 
   if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_READING) {
-    ESP_LOGE(TAG, "Announcement pipeline encountered an error reading the file.");
+    ESP_LOGE(TAG, "The announcement pipeline's file reader encountered an error.");
   } else if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_DECODING) {
-    ESP_LOGE(TAG, "Announcement pipeline encountered an error decoding the file.");
+    ESP_LOGE(TAG, "The announcement pipeline's audio decoder encountered an error.");
   } else if (this->announcement_pipeline_state_ == AudioPipelineState::ERROR_RESAMPLING) {
-    ESP_LOGE(TAG, "Announcement pipeline encountered an error resampling the file.");
+    ESP_LOGE(TAG, "The announcement pipeline's audio resampler encountered an error.");
   }
 
   if (this->announcement_pipeline_state_ != AudioPipelineState::STOPPED) {


### PR DESCRIPTION
If the http read fails, it would previously get the media player into a stuck state. This PR adds a manual counting process to throw an error if the http read fails repeatedly. It also logs error more thourougly and fixes a logic issue when determining if the stop pipeline command timed out.