### PR TITLE
[micro_wake_word, voice_assistant] remove unused code directly sending wake word events to voice assistant

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -7,8 +7,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#include "esphome/components/voice_assistant/voice_assistant.h"
-
 #ifdef USE_OTA
 #include "esphome/components/ota/ota_backend.h"
 #endif
@@ -21,12 +19,6 @@
 #include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
 
 #include <cmath>
-
-// TODO:
-//  - does VAD need to be a separate class?
-//  - setup protocol between micro_wake_word and voice_assistant components
-//    - voice assistant should handle all decisions, mWW should just send info
-//  - load trained languages from manifest to expose to voice assistant
 
 namespace esphome {
 namespace micro_wake_word {
@@ -115,7 +107,6 @@ void MicroWakeWord::setup() {
   this->inference_task_stack_buffer_ = (StackType_t *) malloc(INFERENCE_TASK_STACK_SIZE);
 
   ESP_LOGCONFIG(TAG, "Micro Wake Word initialized");
-
 
 #ifdef USE_OTA
   ota::get_global_ota_callback()->add_on_state_callback(
@@ -355,13 +346,6 @@ void MicroWakeWord::loop() {
                detection_event.wake_word->c_str(), (detection_event.average_probability / uint8_to_float_divisor),
                (detection_event.max_probability / uint8_to_float_divisor));
       this->wake_word_detected_trigger_->trigger(*detection_event.wake_word);
-
-#ifdef USE_VOICE_ASSISTANT
-      // TODO: potentially remove, as it currently only logs in the voice assistant component
-      if (voice_assistant::global_voice_assistant != nullptr) {
-        voice_assistant::global_voice_assistant->on_wake_word(detection_event);
-      }
-#endif
     }
   }
 }

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -147,10 +147,6 @@ class VoiceAssistant : public Component {
   void request_start(bool continuous, bool silence_detection);
   void request_stop();
 
-#ifdef USE_MICRO_WAKE_WORD
-  void on_wake_word(const micro_wake_word::DetectionEvent &detection_event);
-#endif
-
   void on_event(const api::VoiceAssistantEventResponse &msg);
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);


### PR DESCRIPTION
Removed some unused code for sending wake word events directly the voice assistant component. If we used this, then we couldn't have yaml actions decide what to do with wake word events in particular situations.