### PR TITLE
[voice_kit] add yaml configuration options for pipeline stage

### DIFF
--- a/esphome/components/voice_kit/voice_kit.h
+++ b/esphome/components/voice_kit/voice_kit.h
@@ -149,8 +149,12 @@ class VoiceKit : public Component, public i2c::I2CDevice {
 
   void start_dfu_update();
 
+  void set_channel_0_stage(PipelineStages channel_0_stage) { this->channel_0_stage_ = channel_0_stage; }
+  void set_channel_1_stage(PipelineStages channel_1_stage) { this->channel_1_stage_ = channel_1_stage; }
+
+  void write_pipeline_stages();
   uint8_t read_vnr();
-  void write_pipeline_stage(MicrophoneChannels channel, PipelineStages stage);
+
   PipelineStages read_pipeline_stage(MicrophoneChannels channel);
 
  protected:
@@ -168,6 +172,9 @@ class VoiceKit : public Component, public i2c::I2CDevice {
   bool dfu_reboot_();
   bool dfu_set_alternate_();
   bool dfu_check_if_ready_();
+
+  PipelineStages channel_0_stage_;
+  PipelineStages channel_1_stage_;
 
   GPIOPin *reset_pin_;
 


### PR DESCRIPTION
Adds ``channel_0_stage`` and ``channel_1_stage`` yaml configuration options. It changes the default channel 1 stage to use AEC+IC+Noise Suppression

I'm not sure how to best approach this, to keep the stage the component holds in sync with the stage on the XMOS. Write now I have a basic setter that the codegen stage uses. On boot, if the XMOS firmware doesn't need updating, it will write them to the XMOS using ``write_pipeline_stages()``. If the firmware updates, it will wait until its successful before calling that function. I'm open to any better approaches!