### PR TITLE
[nabu] fix recursive call with software volume

### DIFF
--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -637,7 +637,7 @@ void NabuMediaPlayer::set_mute_state_(bool mute_state) {
   {  // Fall back to software mute control if there is no audio_dac or if it isn't configured
     if (mute_state) {
       this->software_volume_scale_factor_ = 0;
-    } else {
+    } else if (this->software_volume_scale_factor_ == 0) {
       this->set_volume_(this->volume, false);  // restore previous volume
     }
   }


### PR DESCRIPTION
Fixes a bug where the ``set_volume`` function would recursively call itself when the ``audio_dac`` component isn't enabled. Thanks @gnumpi for fixing it [here]( https://github.com/gnumpi/nabu-voice-kit/commit/3730028f9665be177bffa6ab6262a54bd460081c#diff-8d67ad893a05e9153bcbca06d9867fdc41ff15166bbd0bf530a7f18c8a9430a8R640).