### PR TITLE
[voice_assistant] remove unused mWW VAD for end of speech detection

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -337,41 +337,6 @@ void VoiceAssistant::loop() {
         }
         available = this->ring_buffer_->available();
       }
-
-#ifdef USE_MICRO_WAKE_WORD_VAD
-      if (!this->silence_detection_) {
-        bool new_vad_state = false;
-        if (this->micro_wake_word_ != nullptr) {
-          new_vad_state = this->micro_wake_word_->get_vad_state();
-        }
-
-        uint32_t new_loop_ms = millis();
-        if (this->last_loop_ms_.has_value()) {
-          uint32_t since_last_loop_ms = new_loop_ms - this->last_loop_ms_.value();
-
-          if (new_vad_state && this->last_vad_state_) {
-            // Speech
-            this->speech_ms_left_ -= since_last_loop_ms;
-            this->silence_ms_left_ = this->silence_ms_;
-          } else if (!new_vad_state && !this->last_vad_state_) {
-            // No speech
-            this->silence_ms_left_ -= since_last_loop_ms;
-          }
-
-          this->timeout_ms_left_ -= since_last_loop_ms;
-        }
-        this->last_loop_ms_ = new_loop_ms;
-        this->last_vad_state_ = new_vad_state;
-
-        if ((this->timeout_ms_left_ < 0) || ((this->speech_ms_left_ < 0) && (this->silence_ms_left_ < 0))) {
-          this->signal_stop_();
-          // TODO: Both of these are hacky... protocol needs to be updated to handle this properly?
-          this->set_state_(State::STOP_MICROPHONE, State::IDLE);
-          // this->set_state_(State::STOP_MICROPHONE, State::AWAITING_RESPONSE);
-        }
-#endif
-      }
-
       break;
     }
     case State::STOP_MICROPHONE: {
@@ -922,7 +887,7 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 #endif
 }
 
-void VoiceAssistant::on_set_configuration(const std::vector<std::string>& active_wake_words) {
+void VoiceAssistant::on_set_configuration(const std::vector<std::string> &active_wake_words) {
   if (this->micro_wake_word_) {
     // Disable all wake words first
     for (auto &model : this->micro_wake_word_->get_wake_words()) {
@@ -934,9 +899,7 @@ void VoiceAssistant::on_set_configuration(const std::vector<std::string>& active
       for (auto &model : this->micro_wake_word_->get_wake_words()) {
         if (model->get_id() == ww_id) {
           model->enable();
-          ESP_LOGD(TAG, "Enabled wake word: %s (id=%s)",
-                   model->get_wake_word().c_str(),
-                   model->get_id().c_str());
+          ESP_LOGD(TAG, "Enabled wake word: %s (id=%s)", model->get_wake_word().c_str(), model->get_id().c_str());
         }
       }
     }
@@ -967,7 +930,6 @@ const Configuration &VoiceAssistant::get_configuration() {
     // No microWakeWord
     this->config_.max_active_wake_words = 0;
   }
-
 
   return this->config_;
 };

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -281,12 +281,6 @@ void VoiceAssistant::loop() {
         flags |= api::enums::VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD;
       if (this->silence_detection_)
         flags |= api::enums::VOICE_ASSISTANT_REQUEST_USE_VAD;
-      else {
-        this->speech_ms_left_ = this->speech_ms_;
-        this->silence_ms_left_ = this->silence_ms_;
-        this->timeout_ms_left_ = this->timeout_ms_;
-        this->last_loop_ms_ = {};
-      }
 
       api::VoiceAssistantAudioSettings audio_settings;
       audio_settings.noise_suppression_level = this->noise_suppression_level_;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -105,11 +105,6 @@ class VoiceAssistant : public Component {
   void set_microphone(microphone::Microphone *mic) { this->mic_ = mic; }
 #ifdef USE_MICRO_WAKE_WORD
   void set_micro_wake_word(micro_wake_word::MicroWakeWord *mww) { this->micro_wake_word_ = mww; }
-#ifdef USE_MICRO_WAKE_WORD_VAD
-  void set_speech_ms(uint32_t speech_ms) { this->speech_ms_ = speech_ms; }
-  void set_timeout_ms(uint32_t timeout_ms) { this->timeout_ms_ = timeout_ms; }
-  void set_silence_ms(uint32_t silence_ms) { this->silence_ms_ = silence_ms; }
-#endif
 #endif
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
@@ -313,20 +308,6 @@ class VoiceAssistant : public Component {
 
 #ifdef USE_MICRO_WAKE_WORD
   micro_wake_word::MicroWakeWord *micro_wake_word_{nullptr};
-
-#ifdef USE_MICRO_WAKE_WORD_VAD
-  uint32_t speech_ms_{500};  // This is hard to configure (HA uses 300) with the current VAD, as it may initially be
-                             // detected from the wake word
-  uint32_t timeout_ms_{15000};
-  uint32_t silence_ms_{1000};
-
-  int32_t speech_ms_left_{0};
-  int32_t silence_ms_left_{0};
-  int32_t timeout_ms_left_{0};
-
-  optional<uint32_t> last_loop_ms_;
-  bool last_vad_state_;
-#endif
 #endif
 };  // namespace voice_assistant
 


### PR DESCRIPTION
Removes the unused code for end of speech detection on the device, as it didn't work consistently with the current approach for the stop signalling. I will revisit this later!