### PR TITLE
[micro_wake_word] remove unused enable_wake_words function

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -350,23 +350,6 @@ void MicroWakeWord::loop() {
   }
 }
 
-void MicroWakeWord::enable_wake_words(std::vector<std::string> &wake_words_to_enable) {
-  // Disable and unload all models
-  for (auto &model : this->wake_word_models_) {
-    model->disable();
-  }
-
-  delay(20);  // make sure the models have actually unloaded
-
-  for (auto &model : this->wake_word_models_) {
-    for (auto &wake_word : wake_words_to_enable) {
-      if (!model->get_wake_word().compare(wake_word)) {
-        model->enable();
-      }
-    }
-  }
-}
-
 void MicroWakeWord::start() {
   if (!this->is_ready()) {
     ESP_LOGW(TAG, "Wake word detection can't start as the component hasn't been setup yet");

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -57,10 +57,6 @@ class MicroWakeWord : public Component {
   // Since these are pointers to the WakeWordModel objects, the voice assistant component can enable or disable them
   const std::vector<WakeWordModel *> &get_wake_words() const { return this->wake_word_models_; }
 
-  // Enables the wake word phrases given as strings in a vector. Disables any wake words not listed in the vector
-  // TODO: Should this logic be in the voice_assistant component?
-  void enable_wake_words(std::vector<std::string> &wake_words_to_enable);
-
  protected:
   microphone::Microphone *microphone_{nullptr};
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();


### PR DESCRIPTION
Removes the unused ``enable_wake_words`` function, as the ``voice_assistant`` component directly handles the wake word model objects for enabling and disabling.