### PR TITLE
Fix Improv Serial Animation

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -96,6 +96,7 @@ wifi:
   id: wifi_id
   ap:
   on_connect:
+    - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
   on_disconnect:
     - script.execute: control_leds


### PR DESCRIPTION
When doing Improv Serial provisioning, the "White Twinkle" animation never ends.
This is because we do not go in the Improv BLE component.

This PR forces the global variable `improv_ble_in_progress` to false once it connects to the Wifi, whatever the means.
This ensures that the animations will run smoothly even for users doing Improv Serial.