### PR TITLE
Fix LEDs stuck on startup twinkle

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -49,6 +49,9 @@ esp32_improv:
   on_provisioned:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
+  on_stop:
+    - lambda: id(improv_ble_in_progress) = false;
+    - script.execute: control_leds
 
 external_components:
   - source: github://pr#7461


### PR DESCRIPTION
If there is a delay connecting to wifi, Improv BLE (and the captive portal) may start, activating the twinkle effect. If, however, wifi _does_ connect after a delay, Improv will stop without triggering `on_provisioned`. This results in the LEDs getting stuck on the start-up effect and never advancing.

This PR corrects this behavior by adding the `on_stop` trigger to Improv, allowing the subsequent effects to be visible.