### PR TITLE
[micro_wake_word] save/restore wake word enabled state to flash

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -500,10 +500,8 @@ async def to_code(config):
                 )
             )
         else:
-            default_enabled = False
-            if i == 0:
-                # Only enable the first wake word by default. After first boot, the enable state is saved/loaded to the flash
-                default_enabled = True
+            # Only enable the first wake word by default. After first boot, the enable state is saved/loaded to the flash
+            default_enabled = i == 0
             wake_word_model = cg.new_Pvariable(
                 model_parameters[CONF_ID],
                 str(model_parameters[CONF_ID]),

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -472,7 +472,7 @@ async def to_code(config):
         # Use the general model loading code for the VAD codegen
         config[CONF_MODELS].append(vad_model)
 
-    for model_parameters in config[CONF_MODELS]:
+    for i, model_parameters in enumerate(config[CONF_MODELS]):
         model_config = model_parameters.get(CONF_MODEL)
         data = []
         manifest, data = _model_config_to_manifest_data(model_config)
@@ -500,6 +500,10 @@ async def to_code(config):
                 )
             )
         else:
+            default_enabled = False
+            if i == 0:
+                # Only enable the first wake word by default. After first boot, the enable state is saved/loaded to the flash
+                default_enabled = True
             wake_word_model = cg.new_Pvariable(
                 model_parameters[CONF_ID],
                 str(model_parameters[CONF_ID]),
@@ -508,6 +512,7 @@ async def to_code(config):
                 sliding_window_size,
                 manifest[KEY_WAKE_WORD],
                 manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
+                default_enabled,
             )
 
             for lang in manifest[KEY_TRAINED_LANGUAGES]:


### PR DESCRIPTION
Saves and restores the enable/disabled state of each wake word model to flash. This saves the preference if the wake word has been changed in Home Assistant.

If there are no saved preferences, it only enables the first wake word in the YAML list of models.