### PR TITLE
FLAC decoder improvements

### DIFF
--- a/esphome/components/nabu/audio_decoder.cpp
+++ b/esphome/components/nabu/audio_decoder.cpp
@@ -136,7 +136,7 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
       
       if (bytes_to_read > 0) {
         uint8_t *new_audio_data = this->input_buffer_ + this->input_buffer_length_;
-        bytes_read = this->input_ring_buffer_->read((void *) new_audio_data, bytes_to_read, pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS) );
+        bytes_read = this->input_ring_buffer_->read((void *) new_audio_data, bytes_to_read, pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
 
         this->input_buffer_length_ += bytes_read;
       }

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -54,7 +54,7 @@ class AudioDecoder {
   uint8_t *input_buffer_{nullptr};
   uint8_t *input_buffer_current_{nullptr};
   size_t input_buffer_length_;
-
+  
   uint8_t *output_buffer_{nullptr};
   uint8_t *output_buffer_current_{nullptr};
   size_t output_buffer_length_;

--- a/esphome/components/nabu/audio_pipeline.cpp
+++ b/esphome/components/nabu/audio_pipeline.cpp
@@ -244,7 +244,7 @@ esp_err_t AudioPipeline::stop() {
     xEventGroupSetBits(this->event_group_, EventGroupBits::READER_MESSAGE_ERROR);
   }
   if (!(event_group_bits & DECODER_MESSAGE_FINISHED)) {
-    // Ddecoder failed to stop
+    // Decoder failed to stop
     xEventGroupSetBits(this->event_group_, EventGroupBits::DECODER_MESSAGE_ERROR);
   }
   if (!(event_group_bits & RESAMPLER_MESSAGE_FINISHED)) {

--- a/esphome/components/nabu/flac_decoder.cpp
+++ b/esphome/components/nabu/flac_decoder.cpp
@@ -4,9 +4,9 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <vector>
 
 #include "flac_decoder.h"
+
 namespace flac {
 
 FLACDecoderResult FLACDecoder::read_header(size_t buffer_length) {
@@ -68,15 +68,192 @@ FLACDecoderResult FLACDecoder::read_header(size_t buffer_length) {
     return FLAC_DECODER_ERROR_BAD_HEADER;
   }
 
+  if ((this->min_block_size_ < 16 ) || (this->min_block_size_ > this->max_block_size_) ||
+      (this->max_block_size_ > 65535)) {
+    return FLAC_DECODER_ERROR_BAD_HEADER;
+  }
+  
   // Successfully read header
   return FLAC_DECODER_SUCCESS;
 }  // read_header
+
+
+
+FLACDecoderResult FLACDecoder::frame_sync_(){
+    this->frame_sync_bytes_[0] = 0;
+    this->frame_sync_bytes_[1] = 0;
+    
+    bool second_ff_byte_found = false;
+    uint32_t byte;
+    
+    this->align_to_byte();
+    
+    while(true){
+      if ( second_ff_byte_found ){
+        //try if the prev found 0xff is first of the MAGIC NUMBER 
+        byte = 0xff;
+        second_ff_byte_found = false;
+      }
+      else{
+        byte = this->read_aligned_byte();
+      }
+      if( byte == 0xff ){
+        byte = this->read_aligned_byte();
+        if( byte == 0xff ){
+          //found a second 0xff, could be the first byte of the MAGIC NUMBER
+          second_ff_byte_found = true;
+        }
+        else if(byte >> 1 == 0x7c) { /* MAGIC NUMBER for the last 6 sync bits and reserved 7th bit */
+          this->frame_sync_bytes_[0] = 0xff;
+          this->frame_sync_bytes_[1] = byte;
+          return FLAC_DECODER_SUCCESS;
+        }
+      }
+      else if (this->out_of_data_){
+        return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+      }
+  }
+  return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+}
+
+  
+FLACDecoderResult FLACDecoder::decode_frame_header_(){
+  uint8_t raw_header[16];
+  uint32_t raw_header_len = 0;
+  uint32_t new_byte;
+  
+  if( this->frame_sync_() != FLAC_DECODER_SUCCESS ){
+    return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+  }
+
+  raw_header[raw_header_len++] = this->frame_sync_bytes_[0];
+  raw_header[raw_header_len++] = this->frame_sync_bytes_[1];
+
+  /* make sure that reserved bit is 0 */
+	if(raw_header[1] & 0x02){ /* MAGIC NUMBER */
+		return FLAC_DECODER_ERROR_BAD_MAGIC_NUMBER;
+  }
+  
+  new_byte = this->read_aligned_byte();
+  if(new_byte == 0xff) { /* MAGIC NUMBER for the first 8 frame sync bits */
+			/* if we get here it means our original sync was erroneous since the sync code cannot appear in the header */
+      // needs to search for sync code again
+      return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+  }
+  raw_header[raw_header_len++] = new_byte;
+
+  // 9.1.1 Block size bits
+  uint8_t block_size_code = raw_header[2] >> 4;
+  if (block_size_code == 0) {
+    return FLAC_DECODER_ERROR_BAD_BLOCK_SIZE_CODE;
+  } else if (block_size_code == 1) {
+    this->curr_frame_block_size_ = 192;
+  } else if ((2 <= block_size_code) && (block_size_code <= 5)) {
+    this->curr_frame_block_size_ = 576 << (block_size_code - 2);
+  } else if (block_size_code == 6) {
+    // uncommon block size
+    // gets parsed later
+  } else if (block_size_code == 7) {
+    // uncommon block size
+    // gets parsed later
+  } else if (block_size_code <= 15) {
+    this->curr_frame_block_size_ = 256 << (block_size_code - 8);
+  } else {
+    return FLAC_DECODER_ERROR_BAD_BLOCK_SIZE_CODE;
+  }
+
+  // 9.1.2 Sample rate bits
+  // Assuming that we have sample rate from header
+  // indicates if uncommon sample rate needs to be parsed though
+  uint8_t sample_rate_code = raw_header[2] & 0x0f;
+  //assert( sample_rate_code == 0 || sample_rate_code == 0b1010 );
+  
+  // 9.1.3 Channel bits
+  new_byte = this->read_aligned_byte();
+  if(new_byte == 0xff) { /* MAGIC NUMBER for the first 8 frame sync bits */
+			/* if we get here it means our original sync was erroneous since the sync code cannot appear in the header */
+      // needs to search for sync code again
+      return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+  }
+  raw_header[raw_header_len++] = new_byte;
+  this->curr_frame_channel_assign_ = raw_header[3] >> 4;
+  
+  // 9.1.4 Bit depth bits
+  uint8_t bits_per_sample_code = (raw_header[3] & 0x0e) >> 1;
+  switch( bits_per_sample_code){
+    case 0:
+      //take bit depth from streaminfo header
+      break;
+    case 1: //  8 bit
+    case 2: // 12 bit
+      // not supported in this version
+      return FLAC_DECODER_ERROR_BAD_HEADER;
+    case 4: // 16 bit
+      break;
+    case 5: // 20bit
+    case 6: // 24bit
+    case 7: // 32bit
+    default:
+      // not supported in this version
+      return FLAC_DECODER_ERROR_BAD_HEADER;
+  }
+
+  //reserved bit needs to be zero:
+  //ignore raw_header[3] & 0x01 != 0 
+  //seems not to be respected by all encoder versions
+
+  
+  // 9.1.5. Coded number
+  //The coded number is stored in a variable length code like UTF-8 as defined in [RFC3629], but extended to a maximum of 36 bits unencoded, 7 bytes encoded.
+  // Interpretation depends on block_size_mode, signalled with (raw_header[1] & 0x01)
+  // We don't support file seeking for now so ignore the coded number
+  // todo: check for invalid codes, i.e. 0xffffffff (fixed block size) and 0xffffffffffffffff (variable block size)
+  uint32_t next_int = this->read_aligned_byte();
+  raw_header[raw_header_len++] = next_int;
+  while (next_int >= 0b11000000 ) {
+    raw_header[raw_header_len++] = this->read_aligned_byte();
+    next_int = (next_int << 1) & 0xFF;
+  }
+
+  // 9.1.6 Uncommon block size
+  if (block_size_code == 6) {
+    raw_header[raw_header_len] = this->read_aligned_byte();
+    this->curr_frame_block_size_ = raw_header[raw_header_len++] + 1;
+  } else if (block_size_code == 7) {
+    raw_header[raw_header_len] = this->read_aligned_byte();
+    this->curr_frame_block_size_ =  raw_header[raw_header_len++] << 8;
+    raw_header[raw_header_len] = this->read_aligned_byte();
+    this->curr_frame_block_size_ |= raw_header[raw_header_len++];
+    this->curr_frame_block_size_ += 1;
+  }
+  
+  // 9.1.7 Uncommon sample rate 
+  // Assuming that we have sample rate from header
+  if (sample_rate_code == 12) {
+    raw_header[raw_header_len++] = this->read_aligned_byte();
+  } else if ((sample_rate_code == 13) || (sample_rate_code == 14)) {
+    raw_header[raw_header_len++] = this->read_aligned_byte();
+    raw_header[raw_header_len++] = this->read_aligned_byte();
+  }
+
+  // out of data wasn't checked after each read, check it now
+  if(this->out_of_data_){
+    return FLAC_DECODER_ERROR_OUT_OF_DATA;
+  }
+
+  // 9.1.8 Frame header CRC
+  uint8_t crc_read = this->read_aligned_byte();
+    
+  return FLAC_DECODER_SUCCESS;
+}
 
 FLACDecoderResult FLACDecoder::decode_frame(size_t buffer_length, int16_t *output_buffer, uint32_t *num_samples) {
   this->buffer_index_ = 0;
   this->bytes_left_ = buffer_length;
   this->out_of_data_ = false;
-
+  
+  FLACDecoderResult ret = FLAC_DECODER_SUCCESS;
+  
   *num_samples = 0;
 
   if (!this->block_samples_) {
@@ -84,76 +261,38 @@ FLACDecoderResult FLACDecoder::decode_frame(size_t buffer_length, int16_t *outpu
     esphome::ExternalRAMAllocator<int32_t> allocator(esphome::ExternalRAMAllocator<int32_t>::ALLOW_FAILURE);
     this->block_samples_ = allocator.allocate(this->max_block_size_ * this->num_channels_);
   }
-
+  if (!this->block_samples_) {
+    return FLAC_DECODER_ERROR_MEMORY_ALLOCATION_ERROR;
+  }
+  
   if (this->bytes_left_ == 0) {
-    // Done with the stream
+    // buffer is empty when called
     return FLAC_DECODER_NO_MORE_FRAMES;
   }
-
+  
   uint64_t previous_bit_buffer = this->bit_buffer_;
   uint32_t previous_bit_buffer_length = this->bit_buffer_length_;
-
-  // sync code
-  if (this->read_uint(14) != 0x3FFE) {
-    return FLAC_DECODER_ERROR_SYNC_NOT_FOUND;
+  ret = this->decode_frame_header_();
+  if( ret != FLAC_DECODER_SUCCESS ){
+    return ret;
   }
 
-  this->read_uint(1);
-  this->read_uint(1);
-
-  uint32_t block_size_code = this->read_uint(4);
-  uint32_t sample_rate_code = this->read_uint(4);
-  uint32_t channel_assignment = this->read_uint(4);
-
-  this->read_uint(3);
-  this->read_uint(1);
-
-  uint32_t next_int = this->read_uint(8);
-  while (next_int >= 0b11000000) {
-    this->read_uint(8);
-    next_int = (next_int << 1) & 0xFF;
-
-    if (this->out_of_data_) {
-      this->bit_buffer_ = previous_bit_buffer;
-      this->bit_buffer_length_ = previous_bit_buffer_length;
-      return FLAC_DECODER_ERROR_OUT_OF_DATA;
-    }
+  // Memory is allocated based on the maximum block size. 
+  // Ensure that no out-of-bounds access occurs, particularly in case of parsing errors.
+  if( this->curr_frame_block_size_ > this->max_block_size_ ){
+    return FLAC_DECODER_ERROR_BLOCK_SIZE_OUT_OF_RANGE;
   }
 
-  uint32_t block_size = 0;
-  if (block_size_code == 1) {
-    block_size = 192;
-  } else if ((2 <= block_size_code) && (block_size_code <= 5)) {
-    block_size = 576 << (block_size_code - 2);
-  } else if (block_size_code == 6) {
-    block_size = this->read_uint(8) + 1;
-  } else if (block_size_code == 7) {
-    block_size = this->read_uint(16) + 1;
-  } else if (block_size_code <= 15) {
-    block_size = 256 << (block_size_code - 8);
-  } else {
-    return FLAC_DECODER_ERROR_BAD_BLOCK_SIZE_CODE;
-  }
-
-  // Assuming that we have sample rate from header
-  if (sample_rate_code == 12) {
-    this->read_uint(8);
-  } else if ((sample_rate_code == 13) || (sample_rate_code == 14)) {
-    this->read_uint(16);
-  }
-
-  this->read_uint(8);
-
-  // Output buffer size should be max_block_size * num_channels
-  this->decode_subframes(block_size, this->sample_depth_, channel_assignment);
-  *num_samples = block_size * this->num_channels_;
+  // Output buffer size (in sample) should be max_block_size * num_channels
+  this->decode_subframes(this->curr_frame_block_size_, this->sample_depth_, this->curr_frame_channel_assign_);
+  *num_samples = this->curr_frame_block_size_ * this->num_channels_;
 
   if (this->bytes_left_ < 2) {
     this->bit_buffer_ = previous_bit_buffer;
     this->bit_buffer_length_ = previous_bit_buffer_length;
     return FLAC_DECODER_ERROR_OUT_OF_DATA;
   }
-
+  
   // Footer
   this->align_to_byte();
   this->read_uint(16);
@@ -165,9 +304,9 @@ FLACDecoderResult FLACDecoder::decode_frame(size_t buffer_length, int16_t *outpu
 
   // Copy samples to output buffer
   std::size_t output_index = 0;
-  for (uint32_t i = 0; i < block_size; i++) {
+  for (uint32_t i = 0; i < this->curr_frame_block_size_; i++) {
     for (uint32_t j = 0; j < this->num_channels_; j++) {
-      output_buffer[output_index] = this->block_samples_[(j * block_size) + i] + addend;
+      output_buffer[output_index] = this->block_samples_[(j * this->curr_frame_block_size_) + i] + addend;
       output_index++;
     }
   }
@@ -182,9 +321,6 @@ void FLACDecoder::free_buffers() {
     allocator.deallocate(this->block_samples_, this->max_block_size_ * this->num_channels_);
     this->block_samples_ = nullptr;
   }
-
-  this->block_result_.clear();
-  this->block_result_.shrink_to_fit();
 }  // free_buffers
 
 FLACDecoderResult FLACDecoder::decode_subframes(uint32_t block_size, uint32_t sample_depth,
@@ -254,9 +390,7 @@ FLACDecoderResult FLACDecoder::decode_subframe(uint32_t block_size, uint32_t sam
   if (type == 0) {
     // Constant
     int32_t value = this->read_sint(sample_depth) << shift;
-    for (std::size_t i = 0; i < block_size; i++) {
-      this->block_samples_[block_samples_offset + i] = value;
-    }
+    std::fill(this->block_samples_ + block_samples_offset, this->block_samples_ + block_samples_offset + block_size, value );
   } else if (type == 1) {
     // Verbatim
     for (std::size_t i = 0; i < block_size; i++) {
@@ -291,28 +425,31 @@ FLACDecoderResult FLACDecoder::decode_fixed_subframe(uint32_t block_size, std::s
 
   FLACDecoderResult result = FLAC_DECODER_SUCCESS;
 
-  this->block_result_.clear();
+  int32_t* const sub_frame_buffer = this->block_samples_ + block_samples_offset;
+  int32_t *out_ptr = sub_frame_buffer;
+  
+  //warum-up samples
   for (std::size_t i = 0; i < pre_order; i++) {
-    this->block_result_.push_back(this->read_sint(sample_depth));
+    *(out_ptr++) = this->read_sint(sample_depth);
   }
-  result = decode_residuals(block_size);
+  result = decode_residuals(sub_frame_buffer, pre_order, block_size);
   if (result != FLAC_DECODER_SUCCESS) {
     return result;
   }
-  restore_linear_prediction(FLAC_FIXED_COEFFICIENTS[pre_order], 0);
-
-  std::copy(this->block_result_.begin(), this->block_result_.end(), this->block_samples_ + block_samples_offset);
-
+  restore_linear_prediction(sub_frame_buffer, block_size, FLAC_FIXED_COEFFICIENTS[pre_order], 0);
   return result;
+
 }  // decode_fixed_subframe
 
 FLACDecoderResult FLACDecoder::decode_lpc_subframe(uint32_t block_size, std::size_t block_samples_offset,
                                                    uint32_t lpc_order, uint32_t sample_depth) {
   FLACDecoderResult result = FLAC_DECODER_SUCCESS;
 
-  this->block_result_.clear();
+  int32_t* const sub_frame_buffer = this->block_samples_ + block_samples_offset;
+  int32_t* out_ptr = sub_frame_buffer;
+  
   for (std::size_t i = 0; i < lpc_order; i++) {
-    this->block_result_.push_back(this->read_sint(sample_depth));
+    *(out_ptr++) = this->read_sint(sample_depth);
   }
 
   uint32_t precision = this->read_uint(4) + 1;
@@ -325,18 +462,16 @@ FLACDecoderResult FLACDecoder::decode_lpc_subframe(uint32_t block_size, std::siz
   }
   coefs[lpc_order] = 1 << shift;
 
-  result = decode_residuals(block_size);
+  result = decode_residuals(sub_frame_buffer, lpc_order, block_size);
   if (result != FLAC_DECODER_SUCCESS) {
     return result;
   }
-  restore_linear_prediction(coefs, shift);
-
-  std::copy(this->block_result_.begin(), this->block_result_.end(), this->block_samples_ + block_samples_offset);
+  restore_linear_prediction(sub_frame_buffer, block_size, coefs, shift);
 
   return result;
-}  // decode_lpc_subframe
+}  // decode_lpc_subframe 
 
-FLACDecoderResult FLACDecoder::decode_residuals(uint32_t block_size) {
+FLACDecoderResult FLACDecoder::decode_residuals(int32_t* sub_frame_buffer, size_t warm_up_samples, uint32_t block_size) {
   uint32_t method = this->read_uint(2);
   if (method >= 2) {
     return FLAC_DECODER_ERROR_RESERVED_RESIDUAL_CODING_METHOD;
@@ -355,20 +490,43 @@ FLACDecoderResult FLACDecoder::decode_residuals(uint32_t block_size) {
     return FLAC_DECODER_ERROR_BLOCK_SIZE_NOT_DIVISIBLE_RICE;
   }
 
-  for (std::size_t i = 0; i < num_partitions; i++) {
-    uint32_t count = block_size >> partition_order;
-    if (i == 0) {
-      count -= this->block_result_.size();
-    }
+  int32_t *out_ptr = sub_frame_buffer + warm_up_samples;
+  {
+    uint32_t count = (block_size >> partition_order) - warm_up_samples;
     uint32_t param = this->read_uint(param_bits);
     if (param < escape_param) {
       for (std::size_t j = 0; j < count; j++) {
-        this->block_result_.push_back(this->read_rice_sint(param));
+        *(out_ptr++) = this->read_rice_sint(param);
       }
     } else {
       std::size_t num_bits = this->read_uint(5);
+      if( num_bits == 0 ){
+        std::memset( out_ptr, 0, count * sizeof(int32_t));
+        out_ptr += count;
+      } else {
+        for (std::size_t j = 0; j < count; j++) {
+          *(out_ptr++) = this->read_sint(num_bits);
+        }
+      }
+    }
+  }
+
+  uint32_t count = block_size >> partition_order;
+  for (std::size_t i = 1; i < num_partitions; i++) {
+    uint32_t param = this->read_uint(param_bits);
+    if (param < escape_param) {
       for (std::size_t j = 0; j < count; j++) {
-        this->block_result_.push_back(this->read_sint(num_bits));
+        *(out_ptr++) = this->read_rice_sint(param);
+      }
+    } else {
+      std::size_t num_bits = this->read_uint(5);
+      if( num_bits == 0 ){
+        std::memset( out_ptr, 0, count * sizeof(int32_t));
+        out_ptr += count;
+      } else {
+        for (std::size_t j = 0; j < count; j++) {
+          *(out_ptr++) = this->read_sint(num_bits);
+        }
       }
     }
   }  // for each partition
@@ -376,30 +534,49 @@ FLACDecoderResult FLACDecoder::decode_residuals(uint32_t block_size) {
   return FLAC_DECODER_SUCCESS;
 }  // decode_residuals
 
-void FLACDecoder::restore_linear_prediction(const std::vector<int16_t> &coefs, int32_t shift) {
-  for (std::size_t i = 0; i < this->block_result_.size() - coefs.size() + 1; i++) {
+void FLACDecoder::restore_linear_prediction(int32_t* sub_frame_buffer, size_t num_of_samples, const std::vector<int16_t> &coefs, int32_t shift) {
+  
+  for (std::size_t i = 0; i < num_of_samples - coefs.size() + 1; i++) {
     int32_t sum = 0;
     for (std::size_t j = 0; j < coefs.size(); ++j) {
-      sum += (this->block_result_[i + j] * coefs[j]);
+      sum += (sub_frame_buffer[i + j] * coefs[j]);
     }
-    this->block_result_[i + coefs.size() - 1] = (sum >> shift);
+    sub_frame_buffer[i + coefs.size() - 1] = (sum >> shift);
   }
 }  // restore_linear_prediction
 
-uint32_t FLACDecoder::read_uint(std::size_t num_bits) {
+uint32_t FLACDecoder::read_aligned_byte(){
+  //assumes byte alignment
+  assert( this->bit_buffer_length_ % 8 == 0 );
+  
+  if( this->bit_buffer_length_ >= 8 ){
+    this->bit_buffer_length_ -=8;
+    uint32_t ret_byte = this->bit_buffer_ >> this->bit_buffer_length_; 
+    return ret_byte & FLAC_UINT_MASK[8];
+  }
+  
   if (this->bytes_left_ == 0) {
     this->out_of_data_ = true;
     return 0;
   }
+  
+  uint8_t next_byte = this->buffer_[this->buffer_index_];
+  this->buffer_index_++;
+  this->bytes_left_--;
+  
+  return next_byte;
 
+}
+
+uint32_t FLACDecoder::read_uint(std::size_t num_bits) {
   while (this->bit_buffer_length_ < num_bits) {
-    uint8_t next_byte = this->buffer_[this->buffer_index_];
-    this->buffer_index_++;
-    this->bytes_left_--;
     if (this->bytes_left_ == 0) {
       this->out_of_data_ = true;
       return 0;
     }
+    uint8_t next_byte = this->buffer_[this->buffer_index_];
+    this->buffer_index_++;
+    this->bytes_left_--;
 
     this->bit_buffer_ = (this->bit_buffer_ << 8) | next_byte;
     this->bit_buffer_length_ += 8;
@@ -419,6 +596,7 @@ int32_t FLACDecoder::read_sint(std::size_t num_bits) {
   return (int32_t) next_int - (((int32_t) next_int >> (num_bits - 1)) << num_bits);
 }  // read_sint
 
+// why int64_t? standard restricts residuals to fit into 32bit
 int64_t FLACDecoder::read_rice_sint(uint8_t param) {
   long value = 0;
   while (this->read_uint(1) == 0) {

--- a/esphome/components/nabu/flac_decoder.h
+++ b/esphome/components/nabu/flac_decoder.h
@@ -126,8 +126,6 @@ class FLACDecoder {
   /* Completes predicted samples. */
   void restore_linear_prediction(int32_t* sub_frame_buffer, size_t num_of_samples, const std::vector<int16_t> &coefs, int32_t shift);
 
-  bool wait_for_bytes_(uint32_t num_of_bytes, TickType_t ticks_to_wait );
-  
   uint32_t read_aligned_byte();
 
   /* Reads an unsigned integer of arbitrary bit size. */
@@ -190,7 +188,6 @@ class FLACDecoder {
   uint32_t partial_header_type_{0};
   uint32_t partial_header_length_{0};
 
-  bool frame_sync_found_{false};
   uint8_t frame_sync_bytes_[2];
 };
 


### PR DESCRIPTION
**Resolved Issues**:
1. Frames are now flagged as corrupted if an invalid block size is detected, preventing memory access beyond allocated bounds.
2. Frames are marked as corrupted when an unsupported bit depth is parsed (currently restricted to 16-bit).
3. Correctly handle Rice partitions when encountering an escape code and when the bits per sample is zero.
4. Ensure that failed frames are not retried for decoding if the buffer hasn’t changed, avoiding potential infinite loops.
5. Discard processed buffer data after detecting a corrupted frame to force new data reading and initiate a fresh sync-code search.
6. Reject frames marked as potentially failed when they are the last frame of a stream or file, preventing deadlocks.
7. Residuals and predicted samples are now written directly to the frame_buffer, eliminating the need for dynamic memory allocation by avoiding the use of a vector.

None of the files in the FLAC bitstream test set (https://github.com/ietf-wg-cellar/flac-test-files) cause the decoder to crash anymore, but not all playable files are decoded correctly with this implementation. In addition to unsupported formats, such as 24-bit and multi-channel files, the following issues remain:


**Remaining Issues**:

- There are some limitations because the current implementation of the decode function requires the entire frame to be stored in the processing buffer and cannot request additional data on its own:

    * The amount of data that can be processed is limited by the buffer size. For example, if the file or stream header contains large meta blocks (such as images) that exceed the buffer capacity, the file cannot be decoded. While the meta block could be discarded, the current implementation lacks a mechanism to resume reading from the last position when the decode function is called with new data.

   * This also impacts performance. Whenever a frame cannot be fully decoded due to insufficient bits in the buffer, all 
   previously decoded samples must be decoded again when new data becomes available.

- FLAC supports block sizes as small as 16 samples per block. However, the overhead of calling the decode function separately for each block and waiting for new data between blocks decreases throughput, making it difficult to decode small block sizes in real-time.
- The decoder doesn’t support sample rate or bit depth changes within a file/stream.
