### PR TITLE
YAML config: use the updated default okay_nabu model

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1341,7 +1341,7 @@ audio_dac:
 micro_wake_word:
   id: mww
   models:
-    - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu/okay_nabu.json
+    - model: okay_nabu
       id: okay_nabu
     - model: hey_jarvis
       id: hey_jarvis


### PR DESCRIPTION
The "Okay Nabu" model in (https://github.com/esphome/micro-wake-word-models/) has been updated, so this updates the configuration to use it. Additionally, all the wake words will be properly capitalized since those have been updated in that repo.