### PR TITLE
[micro_wake_word] support internal wake words that won't show as available in HA

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -19,6 +19,7 @@ from esphome.automation import register_action, register_condition
 from esphome.const import (
     __version__,
     CONF_ID,
+    CONF_INTERNAL,
     CONF_MICROPHONE,
     CONF_MODEL,
     CONF_URL,
@@ -331,6 +332,7 @@ MODEL_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL): MODEL_SOURCE_SCHEMA,
         cv.Optional(CONF_PROBABILITY_CUTOFF): cv.percentage,
         cv.Optional(CONF_SLIDING_WINDOW_SIZE): cv.positive_int,
+        cv.Optional(CONF_INTERNAL, default=False): cv.boolean,
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
     }
 )
@@ -511,6 +513,7 @@ async def to_code(config):
                 manifest[KEY_WAKE_WORD],
                 manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE],
                 default_enabled,
+                model_parameters[CONF_INTERNAL],
             )
 
             for lang in manifest[KEY_TRAINED_LANGUAGES]:

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -214,6 +214,16 @@ void MicroWakeWord::preprocessor_task_(void *params) {
   }
 }
 
+std::vector<WakeWordModel *> MicroWakeWord::get_wake_words() {
+  std::vector<WakeWordModel *> external_wake_word_models;
+  for (auto model : this->wake_word_models_) {
+    if (!model->get_internal_only()) {
+      external_wake_word_models.push_back(model);
+    }
+  }
+  return external_wake_word_models;
+}
+
 void MicroWakeWord::inference_task_(void *params) {
   MicroWakeWord *this_mww = (MicroWakeWord *) params;
 

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -55,7 +55,7 @@ class MicroWakeWord : public Component {
 
   // Intended for the voice assistant component to know which wake words are available
   // Since these are pointers to the WakeWordModel objects, the voice assistant component can enable or disable them
-  const std::vector<WakeWordModel *> &get_wake_words() const { return this->wake_word_models_; }
+  std::vector<WakeWordModel *> get_wake_words();
 
  protected:
   microphone::Microphone *microphone_{nullptr};

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -162,7 +162,7 @@ void StreamingModel::reset_probabilities() {
 
 WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t probability_cutoff,
                              size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
-                             bool default_enabled) {
+                             bool default_enabled, bool internal_only) {
   this->id_ = id;
   this->model_start_ = model_start;
   this->probability_cutoff_ = probability_cutoff;
@@ -172,6 +172,7 @@ WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, 
   this->tensor_arena_size_ = tensor_arena_size;
   this->register_streaming_ops_(this->streaming_op_resolver_);
   this->current_stride_step_ = 0;
+  this->internal_only_ = internal_only;
 
   this->pref_ = global_preferences->make_preference<bool>(fnv1_hash(id));
   bool enabled;
@@ -186,12 +187,16 @@ WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, 
 
 void WakeWordModel::enable() {
   this->enabled_ = true;
-  this->pref_.save(&this->enabled_);
+  if (!this->internal_only_) {
+    this->pref_.save(&this->enabled_);
+  }
 }
 
 void WakeWordModel::disable() {
   this->enabled_ = false;
-  this->pref_.save(&this->enabled_);
+  if (!this->internal_only_) {
+    this->pref_.save(&this->enabled_);˝
+  }
 }
 
 DetectionEvent WakeWordModel::determine_detected() {

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -195,7 +195,7 @@ void WakeWordModel::enable() {
 void WakeWordModel::disable() {
   this->enabled_ = false;
   if (!this->internal_only_) {
-    this->pref_.save(&this->enabled_);˝
+    this->pref_.save(&this->enabled_);
   }
 }
 

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -89,7 +89,7 @@ class WakeWordModel final : public StreamingModel {
  public:
   WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t probability_cutoff,
                 size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
-                bool default_enabled);
+                bool default_enabled, bool internal_only);
 
   void log_model_config() override;
 
@@ -110,10 +110,14 @@ class WakeWordModel final : public StreamingModel {
   /// @brief Disable the model and save to flash. The next performing_streaming_inference call will unload it.
   virtual void disable() override;
 
+  bool get_internal_only() { return this->internal_only_; }
+
  protected:
   std::string id_;
   std::string wake_word_;
   std::vector<std::string> trained_languages_;
+  
+  bool internal_only_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -908,17 +908,18 @@ const Configuration &VoiceAssistant::get_configuration() {
     this->config_.max_active_wake_words = 1;
 
     for (auto &model : this->micro_wake_word_->get_wake_words()) {
+      if (!model->get_internal_only()) {
+        WakeWord wake_word;
+        wake_word.id = model->get_id();
+        wake_word.wake_word = model->get_wake_word();
+        for (const auto &lang : model->get_trained_languages()) {
+          wake_word.trained_languages.push_back(lang);
+        }
+        this->config_.available_wake_words.push_back(std::move(wake_word));
+      }
       if (model->is_enabled()) {
         this->config_.active_wake_words.push_back(model->get_id());
       }
-
-      WakeWord wake_word;
-      wake_word.id = model->get_id();
-      wake_word.wake_word = model->get_wake_word();
-      for (const auto &lang : model->get_trained_languages()) {
-        wake_word.trained_languages.push_back(lang);
-      }
-      this->config_.available_wake_words.push_back(std::move(wake_word));
     }
   } else {
     // No microWakeWord

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -908,18 +908,17 @@ const Configuration &VoiceAssistant::get_configuration() {
     this->config_.max_active_wake_words = 1;
 
     for (auto &model : this->micro_wake_word_->get_wake_words()) {
-      if (!model->get_internal_only()) {
-        WakeWord wake_word;
-        wake_word.id = model->get_id();
-        wake_word.wake_word = model->get_wake_word();
-        for (const auto &lang : model->get_trained_languages()) {
-          wake_word.trained_languages.push_back(lang);
-        }
-        this->config_.available_wake_words.push_back(std::move(wake_word));
-      }
       if (model->is_enabled()) {
         this->config_.active_wake_words.push_back(model->get_id());
       }
+
+      WakeWord wake_word;
+      wake_word.id = model->get_id();
+      wake_word.wake_word = model->get_wake_word();
+      for (const auto &lang : model->get_trained_languages()) {
+        wake_word.trained_languages.push_back(lang);
+      }
+      this->config_.available_wake_words.push_back(std::move(wake_word));
     }
   } else {
     // No microWakeWord


### PR DESCRIPTION
Adds an optional ``internal`` parameter for wake word models. If a model is marked internal, then it will not be sent as an available wake word to Home Assistant, and it will not save its enabled state to flash so it won't stay enabled on power loss. Internal models are useful for words/phrases that do not need to be enabled at all times; e.g., when a timer is ringing, enable an internal "stop" model, and then disable it when the timer is cancelled.