### PR TITLE
Stop TTS Response

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -781,8 +781,9 @@ light:
                   light_color.get_blue() * 255);
             Color muted_color(255, 0, 0);
             auto timer_ratio = 12.0f * id(first_active_timer).seconds_left / max(id(first_active_timer).total_seconds , static_cast<uint32_t>(1));
+            uint8_t last_led_on = static_cast<uint8_t>(ceil(timer_ratio)) - 1;
             for (int i = 0; i < 12; i++) {
-              float brightness_dip = ( timer_ratio > 11.0f &&  i == id(global_led_animation_index) % 12 ) ? 0.75f : 1.0f ;
+              float brightness_dip = ( i == id(global_led_animation_index) % 12 && i != last_led_on ) ? 0.9f : 1.0f ;
               if (i <= timer_ratio) {
                 it[i] = color * min (255.0f * brightness_dip * (timer_ratio - i) , 255.0f * brightness_dip) ;
               } else {

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -259,6 +259,7 @@ switch:
     entity_category: config
     restore_mode: ALWAYS_OFF
     internal: true
+
 binary_sensor:
   # Center Button. Used for many things (See on_multi_click)
   - platform: gpio

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1093,7 +1093,6 @@ script:
 
   # Script executed when the voice assistant is in error
   # Fast Red Pulse
-  # Note: Today on_end happens too fast after an error. This is barely visible.
   - id: control_leds_voice_assistant_error_phase
     then:
       - light.turn_on:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1327,6 +1327,17 @@ script:
             }
           }
           id(is_timer_active) = output;
+
+  # Script used activate the stop word if the TTS step is long.
+  # Why is this wrapped on a script?
+  #   Becasue we want to stop the sequence if the TTS step is faster than that.
+  #   This allows us to prevent having the deactivation of the stop word before its own activation.
+  - id: activate_stop_word_if_tts_step_is_long
+    then:
+      - delay: 1s
+      # Enable stop wake word
+      - lambda: id(stop).enable();
+
 i2s_audio:
   - id: i2s_output
     # i2s_output data pin is gpio10
@@ -1490,17 +1501,18 @@ micro_wake_word:
                           .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
                           .set_announcement(true)
                           .perform();
-                - if:
-                    condition:
-                      switch.is_on: wake_sound
-                    then:
-                      - script.execute:
-                          id: play_sound
-                          priority: true
-                          sound_file: !lambda return id(wake_word_triggered_sound);
-                      - delay: 300ms
-                - voice_assistant.start:
-                    wake_word: !lambda return wake_word;
+                    else:
+                      - if:
+                          condition:
+                            switch.is_on: wake_sound
+                          then:
+                            - script.execute:
+                                id: play_sound
+                                priority: true
+                                sound_file: !lambda return id(wake_word_triggered_sound);
+                            - delay: 300ms
+                      - voice_assistant.start:
+                          wake_word: !lambda return wake_word;
 
 voice_assistant:
   id: va
@@ -1527,9 +1539,6 @@ voice_assistant:
         then:
           - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
           - script.execute: control_leds
-          - delay: 1s
-          - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
-          - script.execute: control_leds
   # When the voice assistant starts: Play a wake up sound, duck audio.
   on_start:
     - nabu.set_ducking:
@@ -1547,6 +1556,7 @@ voice_assistant:
   on_tts_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: control_leds
+    - script.execute: activate_stop_word_if_tts_step_is_long
   # When the voice assistant ends: Stop ducking audio.
   on_end:
     - wait_until:
@@ -1555,6 +1565,13 @@ voice_assistant:
     - nabu.set_ducking:
         decibel_reduction: 0   # 0 dB means no reduction
         duration: 1.0s
+    - script.stop: activate_stop_word_if_tts_step_is_long
+    - lambda: id(stop).disable();
+    - if:
+        condition:
+          lambda: return id(voice_assistant_phase) == ${voice_assist_error_phase_id};
+        then:
+          - delay: 1s
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
     - script.execute: control_leds
   on_timer_finished:


### PR DESCRIPTION
4 things happening in this PR

## 1. You can stop TTS with the `stop` word
The `stop` word is activated only after 1 second as per Mike's recommendation to avoid messing with AEC.

## 2. I finally fixed the error state
When the voice assistant encounters an error, we want to display a temporary error state for 1 second.

I was doing this `on_error` but the voice assistant ends almost instantaneously after `on_error`.
So the error state was never really displayed.

Now the 1s delay is handled correctly.

## 3. Saying a wake word when the TTS is playing back does not start the pipeline anymore.

That was kind of a hack. 
Since we did not have a `stop` word, when the media player was announcing, and micro_wake_word was triggered, I stopped the announcement and started a new pipeline.

Now that we have a `stop` word, I decided to simplify this part.
If the media player is announcing, and micro_wake_word is triggered - I stop the announcement and that is it.

So long TTS response >>> `stop` >>> TTS stops. (And that's it - Nothing restarts)

## 4. I reworked ever so slightly the Timer Tick effect
I did not like the hack I put in place for when the LED ring was full.
Now, one LED dips in brightness for the whole duration of the timer (in a rotating manner)
Because it happens the whole duration of the timer, the brightness dip is more subtle, barely noticeable
