### PR TITLE
[nabu] Use speaker output instead of writing to I2S directly

### DIFF
--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -6,16 +6,6 @@
 namespace esphome {
 namespace media_player {
 
-struct StreamInfo {
-  bool operator==(const StreamInfo &rhs) const {
-    return (channels == rhs.channels) && (bits_per_sample == rhs.bits_per_sample) && (sample_rate == rhs.sample_rate);
-  }
-  bool operator!=(const StreamInfo &rhs) const { return !operator==(rhs); }
-  uint8_t channels = 1;
-  uint8_t bits_per_sample = 16;
-  uint32_t sample_rate = 16000;
-};
-
 enum MediaPlayerState : uint8_t {
   MEDIA_PLAYER_STATE_NONE = 0,
   MEDIA_PLAYER_STATE_IDLE = 1,

--- a/esphome/components/nabu/audio_decoder.cpp
+++ b/esphome/components/nabu/audio_decoder.cpp
@@ -220,7 +220,7 @@ FileDecoderState AudioDecoder::decode_flac_() {
       return FileDecoderState::FAILED;
     }
     
-    media_player::StreamInfo stream_info;
+    audio::AudioStreamInfo stream_info;
     stream_info.channels = this->flac_decoder_->get_num_channels();
     stream_info.sample_rate = this->flac_decoder_->get_sample_rate();
     stream_info.bits_per_sample = this->flac_decoder_->get_sample_depth();
@@ -293,7 +293,7 @@ FileDecoderState AudioDecoder::decode_mp3_() {
       this->output_buffer_length_ = mp3_frame_info.outputSamps * bytes_per_sample;
       this->output_buffer_current_ = this->output_buffer_;
 
-      media_player::StreamInfo stream_info;
+      audio::AudioStreamInfo stream_info;
       stream_info.channels = mp3_frame_info.nChans;
       stream_info.sample_rate = mp3_frame_info.samprate;
       stream_info.bits_per_sample = mp3_frame_info.bitsPerSample;
@@ -329,7 +329,7 @@ FileDecoderState AudioDecoder::decode_wav_() {
           // Header parsing is complete
 
           // Assume PCM
-          media_player::StreamInfo stream_info;
+          audio::AudioStreamInfo stream_info;
           stream_info.channels = this->wav_decoder_->num_channels();
           stream_info.sample_rate = this->wav_decoder_->sample_rate();
           stream_info.bits_per_sample = this->wav_decoder_->bits_per_sample();

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -6,7 +6,7 @@
 #include "wav_decoder.h"
 #include "mp3_decoder.h"
 
-#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/audio/audio.h"
 #include "esphome/core/ring_buffer.h"
 
 namespace esphome {
@@ -38,7 +38,7 @@ class AudioDecoder {
 
   AudioDecoderState decode(bool stop_gracefully);
 
-  const optional<media_player::StreamInfo> &get_stream_info() const { return this->stream_info_; }
+  const optional<audio::AudioStreamInfo> &get_stream_info() const { return this->stream_info_; }
 
  protected:
   esp_err_t allocate_buffers_();
@@ -67,7 +67,7 @@ class AudioDecoder {
   size_t wav_bytes_left_;
 
   media_player::MediaFileType media_file_type_{media_player::MediaFileType::NONE};
-  optional<media_player::StreamInfo> stream_info_{};
+  optional<audio::AudioStreamInfo> stream_info_{};
 
   size_t potentially_failed_count_{0};
   bool end_of_file_{false};

--- a/esphome/components/nabu/audio_decoder.h
+++ b/esphome/components/nabu/audio_decoder.h
@@ -7,6 +7,9 @@
 #include "mp3_decoder.h"
 
 #include "esphome/components/audio/audio.h"
+#include "esphome/components/media_player/media_player.h"
+
+
 #include "esphome/core/ring_buffer.h"
 
 namespace esphome {
@@ -38,7 +41,7 @@ class AudioDecoder {
 
   AudioDecoderState decode(bool stop_gracefully);
 
-  const optional<audio::AudioStreamInfo> &get_stream_info() const { return this->stream_info_; }
+  const optional<audio::AudioStreamInfo> &get_audio_stream_info() const { return this->audio_stream_info_; }
 
  protected:
   esp_err_t allocate_buffers_();
@@ -54,7 +57,7 @@ class AudioDecoder {
   uint8_t *input_buffer_{nullptr};
   uint8_t *input_buffer_current_{nullptr};
   size_t input_buffer_length_;
-  
+
   uint8_t *output_buffer_{nullptr};
   uint8_t *output_buffer_current_{nullptr};
   size_t output_buffer_length_;
@@ -67,7 +70,7 @@ class AudioDecoder {
   size_t wav_bytes_left_;
 
   media_player::MediaFileType media_file_type_{media_player::MediaFileType::NONE};
-  optional<audio::AudioStreamInfo> stream_info_{};
+  optional<audio::AudioStreamInfo> audio_stream_info_{};
 
   size_t potentially_failed_count_{0};
   bool end_of_file_{false};

--- a/esphome/components/nabu/audio_mixer.cpp
+++ b/esphome/components/nabu/audio_mixer.cpp
@@ -20,7 +20,7 @@ static const size_t TASK_DELAY_MS = 25;
 static const int16_t MAX_AUDIO_SAMPLE_VALUE = INT16_MAX;
 static const int16_t MIN_AUDIO_SAMPLE_VALUE = INT16_MIN;
 
-esp_err_t AudioMixer::start(const std::string &task_name, UBaseType_t priority) {
+esp_err_t AudioMixer::start(speaker::Speaker *speaker, const std::string &task_name, UBaseType_t priority) {
   esp_err_t err = this->allocate_buffers_();
 
   if (err != ESP_OK) {
@@ -36,6 +36,8 @@ esp_err_t AudioMixer::start(const std::string &task_name, UBaseType_t priority) 
     return ESP_FAIL;
   }
 
+  this->speaker_ = speaker;
+
   return ESP_OK;
 }
 
@@ -47,9 +49,9 @@ void AudioMixer::stop() {
   xQueueReset(this->command_queue_);
 }
 
-size_t AudioMixer::read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait) {
-  return this->output_ring_buffer_->read((void *) buffer, length, ticks_to_wait);
-}
+// size_t AudioMixer::read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait) {
+//   return this->output_ring_buffer_->read((void *) buffer, length, ticks_to_wait);
+// }
 
 void AudioMixer::suspend_task() {
   if (this->task_handle_ != nullptr) {
@@ -151,8 +153,10 @@ void AudioMixer::audio_mixer_task_(void *params) {
     }
 
     if (combination_buffer_length > 0) {
-      size_t output_bytes_written = this_mixer->output_ring_buffer_->write_without_replacement(
-          (void *) combination_buffer, combination_buffer_length, pdMS_TO_TICKS(TASK_DELAY_MS));
+      // size_t output_bytes_written = this_mixer->output_ring_buffer_->write_without_replacement(
+      //     (void *) combination_buffer, combination_buffer_length, pdMS_TO_TICKS(TASK_DELAY_MS));
+      size_t output_bytes_written = this_mixer->speaker_->play(
+          (uint8_t*) combination_buffer, combination_buffer_length, pdMS_TO_TICKS(TASK_DELAY_MS));
       combination_buffer_length -= output_bytes_written;
       if ((combination_buffer_length > 0) && (output_bytes_written > 0)) {
         memmove(combination_buffer, combination_buffer + output_bytes_written / sizeof(int16_t),
@@ -294,11 +298,10 @@ esp_err_t AudioMixer::allocate_buffers_() {
   if (this->announcement_ring_buffer_ == nullptr)
     this->announcement_ring_buffer_ = RingBuffer::create(INPUT_RING_BUFFER_SAMPLES * sizeof(int16_t));
 
-  if (this->output_ring_buffer_ == nullptr)
-    this->output_ring_buffer_ = RingBuffer::create(OUTPUT_BUFFER_SAMPLES * sizeof(int16_t));
+  // if (this->output_ring_buffer_ == nullptr)
+  //   this->output_ring_buffer_ = RingBuffer::create(OUTPUT_BUFFER_SAMPLES * sizeof(int16_t));
 
-  if ((this->output_ring_buffer_ == nullptr) || (this->media_ring_buffer_ == nullptr) ||
-      ((this->output_ring_buffer_ == nullptr))) {
+  if ((this->announcement_ring_buffer_ == nullptr) || (this->media_ring_buffer_ == nullptr)) {
     return ESP_ERR_NO_MEM;
   }
 
@@ -323,7 +326,7 @@ esp_err_t AudioMixer::allocate_buffers_() {
 }
 
 void AudioMixer::reset_ring_buffers_() {
-  this->output_ring_buffer_->reset();
+  // this->output_ring_buffer_->reset();
   this->media_ring_buffer_->reset();
   this->announcement_ring_buffer_->reset();
 }

--- a/esphome/components/nabu/audio_mixer.cpp
+++ b/esphome/components/nabu/audio_mixer.cpp
@@ -10,8 +10,8 @@
 namespace esphome {
 namespace nabu {
 
-static const size_t INPUT_RING_BUFFER_SAMPLES = 24000;  // Audio samples
-static const size_t OUTPUT_BUFFER_SAMPLES = 8192;       // Audio samples - keep small for fast pausing
+static const size_t INPUT_RING_BUFFER_SAMPLES = 24000;
+static const size_t OUTPUT_BUFFER_SAMPLES = 8192;
 static const size_t QUEUE_COUNT = 20;
 
 static const uint32_t TASK_STACK_SIZE = 3072;
@@ -48,10 +48,6 @@ void AudioMixer::stop() {
   xQueueReset(this->event_queue_);
   xQueueReset(this->command_queue_);
 }
-
-// size_t AudioMixer::read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait) {
-//   return this->output_ring_buffer_->read((void *) buffer, length, ticks_to_wait);
-// }
 
 void AudioMixer::suspend_task() {
   if (this->task_handle_ != nullptr) {
@@ -153,8 +149,6 @@ void AudioMixer::audio_mixer_task_(void *params) {
     }
 
     if (combination_buffer_length > 0) {
-      // size_t output_bytes_written = this_mixer->output_ring_buffer_->write_without_replacement(
-      //     (void *) combination_buffer, combination_buffer_length, pdMS_TO_TICKS(TASK_DELAY_MS));
       size_t output_bytes_written = this_mixer->speaker_->play(
           (uint8_t*) combination_buffer, combination_buffer_length, pdMS_TO_TICKS(TASK_DELAY_MS));
       combination_buffer_length -= output_bytes_written;
@@ -298,9 +292,6 @@ esp_err_t AudioMixer::allocate_buffers_() {
   if (this->announcement_ring_buffer_ == nullptr)
     this->announcement_ring_buffer_ = RingBuffer::create(INPUT_RING_BUFFER_SAMPLES * sizeof(int16_t));
 
-  // if (this->output_ring_buffer_ == nullptr)
-  //   this->output_ring_buffer_ = RingBuffer::create(OUTPUT_BUFFER_SAMPLES * sizeof(int16_t));
-
   if ((this->announcement_ring_buffer_ == nullptr) || (this->media_ring_buffer_ == nullptr)) {
     return ESP_ERR_NO_MEM;
   }
@@ -326,7 +317,6 @@ esp_err_t AudioMixer::allocate_buffers_() {
 }
 
 void AudioMixer::reset_ring_buffers_() {
-  // this->output_ring_buffer_->reset();
   this->media_ring_buffer_->reset();
   this->announcement_ring_buffer_->reset();
 }

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -2,8 +2,6 @@
 
 #ifdef USE_ESP_IDF
 
-#include "esphome/components/media_player/media_player.h"
-
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/ring_buffer.h"

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -24,7 +24,7 @@ namespace nabu {
 //    - Unable to pause
 //  - Each stream has a corresponding input ring buffer. Retrieved via the `get_media_ring_buffer` and
 //    `get_announcement_ring_buffer` functions
-//  - The mixed audio is stored in the output ring buffer. Use the `read` function to access
+//  - The mixed audio is sent to the configured speaker component.
 //  - The mixer runs as a FreeRTOS task
 //    - The task reports its state using the TaskEvent queue. Regularly call the  `read_event` function to obtain the
 //      current state
@@ -74,15 +74,6 @@ static const std::vector<int16_t> decibel_reduction_table = {
 
 class AudioMixer {
  public:
-  // /// @brief Returns the number of bytes available to read from the ring buffer
-  // size_t available() { return this->output_ring_buffer_->available(); }
-
-  // /// @brief Reads from the output ring buffer
-  // /// @param buffer stores the read data
-  // /// @param length how many bytes requested to read from the ring buffer
-  // /// @return number of bytes actually read; will be less than length if not available in ring buffer
-  // size_t read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait = 0);
-
   /// @brief Sends a CommandEvent to the command queue
   /// @param command Pointer to CommandEvent object to be sent
   /// @param ticks_to_wait The number of FreeRTOS ticks to wait for an event to appear on the queue. Defaults to 0.
@@ -127,7 +118,7 @@ class AudioMixer {
   /// @return ESP_OK if successful or an error otherwise
   esp_err_t allocate_buffers_();
 
-  /// @brief Resets teh output, media, and anouncement ring buffers
+  /// @brief Resets the media and anouncement ring buffers
   void reset_ring_buffers_();
 
   /// @brief Mixes the media and announcement samples. If the resulting audio clips, the media samples are first scaled.
@@ -138,7 +129,7 @@ class AudioMixer {
   void mix_audio_samples_without_clipping_(int16_t *media_buffer, int16_t *announcement_buffer,
                                            int16_t *combination_buffer, size_t samples_to_mix);
 
-  /// @brief Scales audio samples. Scales in place when audio_samples = output_buffer.
+  /// @brief Scales audio samples. Scales in place when audio_samples == output_buffer.
   /// @param audio_samples PCM int16 audio samples
   /// @param output_buffer Buffer to store the scaled samples
   /// @param scale_factor Q15 fixed point scaling factor
@@ -157,8 +148,6 @@ class AudioMixer {
   // Stores commands to send the mixer task
   QueueHandle_t command_queue_;
 
-  // // Stores the mixed audio
-  // std::unique_ptr<RingBuffer> output_ring_buffer_;
   speaker::Speaker *speaker_{nullptr};
 
   std::unique_ptr<RingBuffer> media_ring_buffer_;

--- a/esphome/components/nabu/audio_mixer.h
+++ b/esphome/components/nabu/audio_mixer.h
@@ -2,6 +2,9 @@
 
 #ifdef USE_ESP_IDF
 
+#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/speaker/speaker.h"
+
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/ring_buffer.h"
@@ -71,14 +74,14 @@ static const std::vector<int16_t> decibel_reduction_table = {
 
 class AudioMixer {
  public:
-  /// @brief Returns the number of bytes available to read from the ring buffer
-  size_t available() { return this->output_ring_buffer_->available(); }
+  // /// @brief Returns the number of bytes available to read from the ring buffer
+  // size_t available() { return this->output_ring_buffer_->available(); }
 
-  /// @brief Reads from the output ring buffer
-  /// @param buffer stores the read data
-  /// @param length how many bytes requested to read from the ring buffer
-  /// @return number of bytes actually read; will be less than length if not available in ring buffer
-  size_t read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait = 0);
+  // /// @brief Reads from the output ring buffer
+  // /// @param buffer stores the read data
+  // /// @param length how many bytes requested to read from the ring buffer
+  // /// @return number of bytes actually read; will be less than length if not available in ring buffer
+  // size_t read(uint8_t *buffer, size_t length, TickType_t ticks_to_wait = 0);
 
   /// @brief Sends a CommandEvent to the command queue
   /// @param command Pointer to CommandEvent object to be sent
@@ -97,10 +100,11 @@ class AudioMixer {
   }
 
   /// @brief Starts the mixer task
+  /// @param speaker Pointer to Speaker component
   /// @param task_name FreeRTOS task name
   /// @param priority FreeRTOS task priority. Defaults to 1
   /// @return ESP_OK if successful, and error otherwise
-  esp_err_t start(const std::string &task_name, UBaseType_t priority = 1);
+  esp_err_t start(speaker::Speaker *speaker, const std::string &task_name, UBaseType_t priority = 1);
 
   /// @brief Stops the mixer task and clears the queues
   void stop();
@@ -153,8 +157,9 @@ class AudioMixer {
   // Stores commands to send the mixer task
   QueueHandle_t command_queue_;
 
-  // Stores the mixed audio
-  std::unique_ptr<RingBuffer> output_ring_buffer_;
+  // // Stores the mixed audio
+  // std::unique_ptr<RingBuffer> output_ring_buffer_;
+  speaker::Speaker *speaker_{nullptr};
 
   std::unique_ptr<RingBuffer> media_ring_buffer_;
   std::unique_ptr<RingBuffer> announcement_ring_buffer_;

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -8,6 +8,7 @@
 #include "audio_mixer.h"
 
 #include "esphome/components/audio/audio.h"
+#include "esphome/components/media_player/media_player.h"
 
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -44,7 +45,7 @@ struct InfoErrorEvent {
   InfoErrorSource source;
   optional<esp_err_t> err;
   optional<media_player::MediaFileType> file_type;
-  optional<audio::AudioStreamInfo> stream_info;
+  optional<audio::AudioStreamInfo> audio_stream_info;
   optional<ResampleInfo> resample_info;
 };
 
@@ -105,7 +106,7 @@ class AudioPipeline {
   media_player::MediaFile *current_media_file_{nullptr};
 
   media_player::MediaFileType current_media_file_type_;
-  audio::AudioStreamInfo current_stream_info_;
+  audio::AudioStreamInfo current_audio_stream_info_;
   ResampleInfo current_resample_info_;
   uint32_t target_sample_rate_;
 

--- a/esphome/components/nabu/audio_pipeline.h
+++ b/esphome/components/nabu/audio_pipeline.h
@@ -7,7 +7,7 @@
 #include "audio_resampler.h"
 #include "audio_mixer.h"
 
-#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/audio/audio.h"
 
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -44,7 +44,7 @@ struct InfoErrorEvent {
   InfoErrorSource source;
   optional<esp_err_t> err;
   optional<media_player::MediaFileType> file_type;
-  optional<media_player::StreamInfo> stream_info;
+  optional<audio::AudioStreamInfo> stream_info;
   optional<ResampleInfo> resample_info;
 };
 
@@ -105,7 +105,7 @@ class AudioPipeline {
   media_player::MediaFile *current_media_file_{nullptr};
 
   media_player::MediaFileType current_media_file_type_;
-  media_player::StreamInfo current_stream_info_;
+  audio::AudioStreamInfo current_stream_info_;
   ResampleInfo current_resample_info_;
   uint32_t target_sample_rate_;
 

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP_IDF
 
+#include "esphome/components/media_player/media_player.h"
 #include "esphome/core/ring_buffer.h"
 
 #include <esp_http_client.h>

--- a/esphome/components/nabu/audio_reader.h
+++ b/esphome/components/nabu/audio_reader.h
@@ -2,7 +2,6 @@
 
 #ifdef USE_ESP_IDF
 
-#include "esphome/components/media_player/media_player.h"
 #include "esphome/core/ring_buffer.h"
 
 #include <esp_http_client.h>

--- a/esphome/components/nabu/audio_resampler.cpp
+++ b/esphome/components/nabu/audio_resampler.cpp
@@ -69,7 +69,7 @@ esp_err_t AudioResampler::allocate_buffers_() {
   return ESP_OK;
 }
 
-esp_err_t AudioResampler::start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate,
+esp_err_t AudioResampler::start(audio::AudioStreamInfo &stream_info, uint32_t target_sample_rate,
                                 ResampleInfo &resample_info) {
   esp_err_t err = this->allocate_buffers_();
   if (err != ESP_OK) {

--- a/esphome/components/nabu/audio_resampler.h
+++ b/esphome/components/nabu/audio_resampler.h
@@ -5,7 +5,7 @@
 #include "biquad.h"
 #include "resampler.h"
 
-#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/audio/audio.h"
 #include "esphome/core/ring_buffer.h"
 
 namespace esphome {
@@ -33,7 +33,7 @@ class AudioResampler {
   /// @param stream_info the incoming sample rate, bits per sample, and number of channels
   /// @param target_sample_rate the necessary sample rate to convert to
   /// @return ESP_OK if it is able to convert the incoming stream or an error otherwise
-  esp_err_t start(media_player::StreamInfo &stream_info, uint32_t target_sample_rate, ResampleInfo &resample_info);
+  esp_err_t start(audio::AudioStreamInfo &stream_info, uint32_t target_sample_rate, ResampleInfo &resample_info);
 
   AudioResamplerState resample(bool stop_gracefully);
 
@@ -60,7 +60,7 @@ class AudioResampler {
   float *float_output_buffer_current_{nullptr};
   size_t float_output_buffer_length_;
 
-  media_player::StreamInfo stream_info_;
+  audio::AudioStreamInfo stream_info_;
   ResampleInfo resample_info_;
 
   Resample *resampler_{nullptr};

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -36,6 +36,8 @@ _LOGGER = logging.getLogger(__name__)
 
 from esphome.external_files import download_content
 
+AUTO_LOAD = ["audio"]
+
 CODEOWNERS = ["@synesthesiam", "@kahrendt"]
 DEPENDENCIES = ["media_player"]
 DOMAIN = "file"

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -16,6 +16,7 @@ from esphome.const import (
     CONF_FILE,
     CONF_ID,
     CONF_PATH,
+    CONF_SAMPLE_RATE,
     CONF_RAW_DATA_ID,
     CONF_TYPE,
     CONF_URL,
@@ -23,19 +24,6 @@ from esphome.const import (
 )
 from esphome.core import HexInt, CORE
 
-
-from esphome.components.i2s_audio import (
-    I2S_BITS_PER_SAMPLE,
-    CONF_BITS_PER_SAMPLE,
-    CONF_I2S_MODE,
-    CONF_PRIMARY,
-    I2S_MODE_OPTIONS,
-    CONF_I2S_AUDIO_ID,
-    CONF_I2S_DOUT_PIN,
-    I2SAudioComponent,
-    I2SAudioOut,
-    _validate_bits,
-)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +46,6 @@ CONF_DECIBEL_REDUCTION = "decibel_reduction"
 CONF_AUDIO_DAC = "audio_dac"
 CONF_MEDIA_FILE = "media_file"
 CONF_FILES = "files"
-CONF_SAMPLE_RATE = "sample_rate"
 CONF_VOLUME_INCREMENT = "volume_increment"
 CONF_VOLUME_MIN = "volume_min"
 CONF_VOLUME_MAX = "volume_max"
@@ -74,7 +61,6 @@ NabuMediaPlayer = nabu_ns.class_(
     NabuMediaPlayer,
     media_player.MediaPlayer,
     cg.Component,
-    I2SAudioOut,
 )
 
 DuckingSetAction = nabu_ns.class_(
@@ -193,16 +179,8 @@ CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(NabuMediaPlayer),
         cv.Required(CONF_SPEAKER): cv.use_id(speaker.Speaker),
-        cv.GenerateID(CONF_I2S_AUDIO_ID): cv.use_id(I2SAudioComponent),
         cv.Optional(CONF_AUDIO_DAC): cv.use_id(audio_dac.AudioDac),
-        cv.Required(CONF_I2S_DOUT_PIN): pins.internal_gpio_output_pin_number,
-        cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.enum(
-            I2S_MODE_OPTIONS, lower=True
-        ),
         cv.Optional(CONF_SAMPLE_RATE, default=16000): cv.int_range(min=1),
-        cv.Optional(CONF_BITS_PER_SAMPLE, default="16bit"): cv.All(
-            _validate_bits, cv.enum(I2S_BITS_PER_SAMPLE)
-        ),
         cv.Optional(CONF_VOLUME_INCREMENT, default=0.05): cv.percentage,
         cv.Optional(CONF_VOLUME_MAX, default=1.0): cv.percentage,
         cv.Optional(CONF_VOLUME_MIN, default=0.0): cv.percentage,
@@ -262,12 +240,8 @@ async def to_code(config):
 
     cg.add_define("USE_OTA_STATE_CALLBACK")
 
-    await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
-    cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
-    cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
-    cg.add(var.set_i2s_mode(config[CONF_I2S_MODE]))
-
+    
     cg.add(var.set_volume_increment(config[CONF_VOLUME_INCREMENT]))
     cg.add(var.set_volume_max(config[CONF_VOLUME_MAX]))
     cg.add(var.set_volume_min(config[CONF_VOLUME_MIN]))

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -45,10 +45,7 @@ namespace nabu {
 //    - Each stream has a corresponding input buffer that the ``AudioResampler`` feeds directly
 //    - Pausing the media stream is done here
 //    - Media stream ducking is done here
-//    - The output ring buffer feeds the ``speaker_task`` directly. It is kept small intentionally to avoid latency when
-//      pausing
-//  - Audio output is handled by the ``speaker_task``. It configures the I2S bus and copies audio from the mixer's
-//    output ring buffer to the DMA buffers
+//    - The output ring buffer feeds the configured speaker the audio directly
 //  - Media player commands are received by the ``control`` function. The commands are added to the
 //    ``media_control_command_queue_`` to be processed in the component's loop
 //    - Starting a stream intializes the appropriate pipeline or stops it if it is already running
@@ -66,15 +63,10 @@ namespace nabu {
 static const size_t QUEUE_LENGTH = 20;
 
 static const uint8_t NUMBER_OF_CHANNELS = 2;  // Hard-coded expectation of stereo (2 channel) audio
-static const size_t DMA_BUFFER_SIZE = 512;
-static const size_t SAMPLES_IN_ONE_DMA_BUFFER = DMA_BUFFER_SIZE * NUMBER_OF_CHANNELS;
-static const size_t DMA_BUFFERS_COUNT = 4;
-static const size_t SAMPLES_IN_ALL_DMA_BUFFERS = SAMPLES_IN_ONE_DMA_BUFFER * DMA_BUFFERS_COUNT;
 
 static const UBaseType_t MEDIA_PIPELINE_TASK_PRIORITY = 1;
 static const UBaseType_t ANNOUNCEMENT_PIPELINE_TASK_PRIORITY = 1;
 static const UBaseType_t MIXER_TASK_PRIORITY = 10;
-static const UBaseType_t SPEAKER_TASK_PRIORITY = 23;
 
 static const size_t TASK_DELAY_MS = 10;
 

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -10,6 +10,7 @@
 #endif
 #include "esphome/components/i2s_audio/i2s_audio.h"
 #include "esphome/components/media_player/media_player.h"
+#include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -79,6 +80,8 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }
 #endif
 
+  void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
+
   Trigger<> *get_mute_trigger() const { return this->mute_trigger_; }
   Trigger<> *get_unmute_trigger() const { return this->unmute_trigger_; }
   Trigger<float> *get_volume_trigger() const { return this->volume_trigger_; }
@@ -108,6 +111,8 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   std::unique_ptr<AudioPipeline> announcement_pipeline_;
   std::unique_ptr<AudioMixer> audio_mixer_;
 
+  speaker::Speaker *speaker_{nullptr};
+
   // Monitors the mixer task
   void watch_mixer_();
 
@@ -117,12 +122,6 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
 
   AudioPipelineState media_pipeline_state_{AudioPipelineState::STOPPED};
   AudioPipelineState announcement_pipeline_state_{AudioPipelineState::STOPPED};
-
-  void watch_speaker_();
-
-  static void speaker_task(void *params);
-  TaskHandle_t speaker_task_handle_{nullptr};
-  QueueHandle_t speaker_event_queue_;
 
   optional<std::string> media_url_{};                        // only modified by control function
   optional<std::string> announcement_url_{};                 // only modified by control function
@@ -148,8 +147,6 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
 #ifdef USE_AUDIO_DAC
   audio_dac::AudioDac *audio_dac_{nullptr};
 #endif
-
-  int16_t software_volume_scale_factor_;  // Q15 fixed point scale factor
 
   // Used to save volume/mute state for restoration on reboot
   ESPPreferenceObject pref_;

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -8,7 +8,6 @@
 #ifdef USE_AUDIO_DAC
 #include "esphome/components/audio_dac/audio_dac.h"
 #endif
-#include "esphome/components/i2s_audio/i2s_audio.h"
 #include "esphome/components/media_player/media_player.h"
 #include "esphome/components/speaker/speaker.h"
 
@@ -49,7 +48,7 @@ struct VolumeRestoreState {
   bool is_muted;
 };
 
-class NabuMediaPlayer : public Component, public media_player::MediaPlayer, public i2s_audio::I2SAudioOut {
+class NabuMediaPlayer : public Component, public media_player::MediaPlayer {
  public:
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
   void setup() override;
@@ -64,10 +63,6 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   /// @param duration (float) The duration (in seconds) for transitioning to the new ducking level
   void set_ducking_reduction(uint8_t decibel_reduction, float duration);
 
-  // I2S configuration
-  void set_i2s_mode(i2s_mode_t mode) { this->i2s_mode_ = mode; }
-  void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
-  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
 
   // Percentage to increase or decrease the volume for volume up or volume down commands
@@ -102,8 +97,6 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
   /// @brief Saves the current volume and mute state to the flash for restoration.
   void save_volume_restore_state_();
 
-  esp_err_t start_i2s_driver_();
-
   // Reads commands from media_control_command_queue_. Starts pipelines and mixer if necessary.
   void watch_media_commands_();
 
@@ -130,10 +123,7 @@ class NabuMediaPlayer : public Component, public media_player::MediaPlayer, publ
 
   QueueHandle_t media_control_command_queue_;
 
-  i2s_bits_per_sample_t bits_per_sample_;
-  i2s_mode_t i2s_mode_{};
   uint32_t sample_rate_;
-  uint8_t dout_pin_{0};
 
   bool is_paused_{false};
   bool is_muted_{false};

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -23,18 +23,6 @@
 namespace esphome {
 namespace nabu {
 
-static const uint8_t DAC_PAGE_SELECTION_REGISTER = 0x00;
-static const uint8_t DAC_LEFT_MUTE_REGISTER = 0x12;
-static const uint8_t DAC_RIGHT_MUTE_REGISTER = 0x13;
-static const uint8_t DAC_LEFT_VOLUME_REGISTER = 0x41;
-static const uint8_t DAC_RIGHT_VOLUME_REGISTER = 0x42;
-
-static const uint8_t DAC_VOLUME_PAGE = 0x00;
-static const uint8_t DAC_MUTE_PAGE = 0x01;
-
-static const uint8_t DAC_MUTE_COMMAND = 0x40;
-static const uint8_t DAC_UNMUTE_COMMAND = 0x00;
-
 struct MediaCallCommand {
   optional<media_player::MediaPlayerCommand> command;
   optional<float> volume;

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1370,17 +1370,24 @@ microphone:
       id: comm_mic
       amplify_shift: 2
 
+speaker:
+  - platform: i2s_audio
+    sample_rate: 48000
+    i2s_mode: secondary
+    i2s_dout_pin: GPIO10
+    bits_per_sample: 32bit
+    i2s_audio_id: i2s_output
+    dac_type: external
+    channel: left
+
 media_player:
   - platform: nabu
     id: nabu_media_player
     name: Media Player
     internal: false
     audio_dac:
+    speaker:
     sample_rate: 48000
-    i2s_dout_pin: GPIO10
-    bits_per_sample: 32bit
-    i2s_mode: secondary
-    i2s_audio_id: i2s_output
     volume_increment: 0.05
     volume_min: 0.4
     volume_max: 0.85
@@ -1448,7 +1455,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: dev
+      ref: kahrendt-20241016-use-speaker-output
     components:
       - aic3204
       - audio_dac


### PR DESCRIPTION
Outputs audio to a speaker component instead of directly writing to the I2S bus. Requires the merged changes in https://github.com/esphome/esphome/pull/7605. It also modifies the voice assistant component to ensure the speaker code doesn't run, as it should handle all audio out via the media player.

This better compartmentalizes the component, as it will run on any future speaker components.

I will follow up with another PR to revert the external component branch to dev.