### PR TITLE
Use dev branch for external component

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -52,8 +52,3 @@ esp32_improv:
   on_stop:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
-
-external_components:
-  - source: github://pr#7461
-    components: [esp32_improv]
-    refresh: 0s

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1455,7 +1455,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/voice-kit
-      ref: kahrendt-20241016-use-speaker-output
+      ref: dev
     components:
       - aic3204
       - audio_dac


### PR DESCRIPTION
Follow up to #163 to revert the external component branch to dev.

Also removes the external component for improv, since that is merged in upstream ESPHome.