### PR TITLE
[nabu] Bugfix: Send the configured sample rate to the speaker

### DIFF
--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -127,7 +127,7 @@ esp_err_t NabuMediaPlayer::start_pipeline_(AudioPipelineType type, bool url) {
     audio::AudioStreamInfo audio_stream_info;
     audio_stream_info.channels = 2;
     audio_stream_info.bits_per_sample = 16;
-    audio_stream_info.sample_rate = 48000;
+    audio_stream_info.sample_rate = this->sample_rate_;
 
     this->speaker_->set_audio_stream_info(audio_stream_info);
   }


### PR DESCRIPTION
The sample rate sent to the speaker was still hard-coded to 48 kHz. This now sends the speaker the configured sample rate. 

Note that this bug doesn't apply to the Voice PE hardware. It only affects devices that using a sample rate besides 48 kHz for audio out.