### PR TITLE
[nabu] Bugfix: save and publish the given volume, not the bounded volume

### DIFF
--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -466,7 +466,7 @@ void NabuMediaPlayer::set_volume_(float volume, bool publish) {
   }
 
   if (publish) {
-    this->volume = bounded_volume;
+    this->volume = volume;
     this->save_volume_restore_state_();
   }
 


### PR DESCRIPTION
When changing to the new speaker output component, I started publishing and saving the bounded volume instead of the given volume. This resulted in the volume slider bouncing around and not reflecting what users actually wanted to set it to.