### PR TITLE
[nabu] play local media file yaml action

### DIFF
--- a/esphome/components/nabu/audio_decoder.cpp
+++ b/esphome/components/nabu/audio_decoder.cpp
@@ -277,7 +277,6 @@ FileDecoderState AudioDecoder::decode_mp3_() {
         return FileDecoderState::POTENTIALLY_FAILED;
         break;
       default:
-        // TODO: Better handle mp3 decoder errors
         return FileDecoderState::FAILED;
         break;
     }

--- a/esphome/components/nabu/media_player.py
+++ b/esphome/components/nabu/media_player.py
@@ -38,6 +38,7 @@ TYPE_WEB = "web"
 CONF_DECIBEL_REDUCTION = "decibel_reduction"
 
 CONF_AUDIO_DAC = "audio_dac"
+CONF_ANNOUNCEMENT = "announcement"
 CONF_MEDIA_FILE = "media_file"
 CONF_VOLUME_INCREMENT = "volume_increment"
 CONF_VOLUME_MIN = "volume_min"
@@ -280,13 +281,6 @@ async def to_code(config):
                 file_config[CONF_ID],
                 media_files_struct,
             )
-            # decl = VariableDeclarationExpression(type, "*", name)
-            # CORE.add_global(decl)
-            # var = MockObj(name, "->")
-            # CORE.register_variable(name, var)
-            # return var
-
-            # CORE.register_variable(MediaFile, file_config[CONF_ID])
 
 
 DUCKING_SET_SCHEMA = cv.Schema(
@@ -302,23 +296,25 @@ DUCKING_SET_SCHEMA = cv.Schema(
 )
 
 
-# @automation.register_action(
-#     "nabu.play_local_media_file",
-#     PlayLocalMediaAction,
-#     cv.maybe_simple_value(
-#         {
-#             cv.GenerateID(): cv.use_id(NabuMediaPlayer),
-#             cv.Required(CONF_MEDIA_FILE): cv.use_id(MediaFile),
-#         },
-#         key=CONF_MEDIA_FILE,
-#     ),
-# )
-# async def media_player_play_media_action(config, action_id, template_arg, args):
-#     var = cg.new_Pvariable(action_id, template_arg)
-#     await cg.register_parented(var, config[CONF_ID])
-#     media_file = config[CONF_MEDIA_FILE]
-#     cg.add(var.set_media_file(media_file))
-#     return var
+@automation.register_action(
+    "nabu.play_local_media_file",
+    PlayLocalMediaAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(NabuMediaPlayer),
+            cv.Required(CONF_MEDIA_FILE): cv.use_id(MediaFile),
+            cv.Optional(CONF_ANNOUNCEMENT, default=False): cv.boolean,
+        },
+        key=CONF_MEDIA_FILE,
+    ),
+)
+async def media_player_play_media_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    media_file = await cg.get_variable(config[CONF_MEDIA_FILE])
+    cg.add(var.set_media_file(media_file))
+    cg.add(var.set_announcement(config[CONF_ANNOUNCEMENT]))
+    return var
 
 
 @automation.register_action("nabu.set_ducking", DuckingSetAction, DUCKING_SET_SCHEMA)

--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -14,13 +14,6 @@
 namespace esphome {
 namespace nabu {
 
-// TODO:
-//  - Align TLS certification defines with the http_request component
-//  - Clean up process around playing back local media files
-//    - Create a registry of media files in Python
-//    - Add a yaml action to play a specific media file
-//
-//
 // Framework:
 //  - Media player that can handle two streams; one for media and one for announcements
 //    - If played together, they are mixed with the announcement stream staying at full volume

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -142,15 +142,16 @@ template<typename... Ts> class DuckingSetAction : public Action<Ts...>, public P
   }
 };
 
-// template<typename... Ts> class PlayLocalMediaAction : public Action<Ts...>, public Parented<NabuMediaPlayer> {
-//   TEMPLATABLE_VALUE(media_player::MediaFile, media_file)
-//   // public:
-//   //   void set_media_file(media_player::MediaFile media_file) { this->media_file_ = media_file; }
-//     void play(Ts... x) override {
-//     this->parent_->make_call().set_local_media_file(this->media_file_.value(x...)).perform(); }
-//   // protected:
-//   //   media_player::MediaFile media_file_;
-// };
+template<typename... Ts> class PlayLocalMediaAction : public Action<Ts...>, public Parented<NabuMediaPlayer> {
+  TEMPLATABLE_VALUE(media_player::MediaFile *, media_file)
+  TEMPLATABLE_VALUE(bool, announcement)
+  void play(Ts... x) override {
+    this->parent_->make_call()
+        .set_announcement(this->announcement_.value(x...))
+        .set_local_media_file(this->media_file_.value(x...))
+        .perform();
+  }
+};
 
 }  // namespace nabu
 }  // namespace esphome


### PR DESCRIPTION
Adds support for playing a local media file via a yaml action. Finished the TODO list! (Note, if the http_request component isn't configured, the default sdkconfig options still work with https URLs, so there is no need to align with how it is configured. Due to the media proxy in HA, we do not play mp3s frequently enough to make it worth to dive into how the decoder can fail at this time.)


Sample yaml:
```
button:
  - platform: template
    name: "local media action announcement"
    entity_category: diagnostic
    on_press:
      - nabu.play_local_media_file:
          media_file: timer_finished_wave_file
          announcement: true
```