### PR TITLE
Ignore Duplicate Wake Word Error

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1549,7 +1549,9 @@ voice_assistant:
   on_error:
     - if:
         condition:
-          lambda: return !id(init_in_progress);
+          and:
+            - lambda: return !id(init_in_progress);
+            - lambda: return code != "duplicate_wake_up_detected";
         then:
           - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
           - script.execute: control_leds


### PR DESCRIPTION
The Voice Assistant throws a `duplicate_wake_up_detected` error when two devices are triggered at almost the same time. 
Because only one device can get a pipeline to avoid having commands processed twice.

The device was blinking red with this error and it always bugged me.

So now I filter `duplicate_wake_up_detected` and smoothly stop the voice assistant component without going to the error phase.

No more red blinking for that particular one.