### PR TITLE
Add disabled grove port power switch

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -261,6 +261,7 @@ switch:
   - platform: gpio
     pin: GPIO46
     id: grove_port_power
+    # Change this to ALWAYS_ON if you are planning to use the Grove port
     restore_mode: RESTORE_DEFAULT_OFF
 
 binary_sensor:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -258,6 +258,13 @@ switch:
     entity_category: config
     restore_mode: ALWAYS_OFF
     internal: true
+  - platform: gpio
+    pin: GPIO46
+    id: grove_port_power
+    name: "Grove port power"
+    disabled_by_default: true
+    entity_category: config
+    restore_mode: RESTORE_DEFAULT_OFF
 
 binary_sensor:
   # Center Button. Used for many things (See on_multi_click)

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -261,9 +261,6 @@ switch:
   - platform: gpio
     pin: GPIO46
     id: grove_port_power
-    name: "Grove port power"
-    disabled_by_default: true
-    entity_category: config
     restore_mode: RESTORE_DEFAULT_OFF
 
 binary_sensor:


### PR DESCRIPTION
The grove port 5v pin is activated only when GPIO46 of the ESP32-S3 is turned on.