### PR TITLE
Disable speaker timeout and reduce buffer duration

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1388,7 +1388,9 @@ speaker:
     bits_per_sample: 32bit
     i2s_audio_id: i2s_output
     dac_type: external
-    channel: left
+    channel: stereo
+    timeout: never
+    buffer_duration: 100ms
 
 media_player:
   - platform: nabu


### PR DESCRIPTION
Disables the speaker timeout, as we do not need to share the I2S bus and are not constrained by memory. Reduces the ring buffer duration to 100 ms so that pausing is nearly instantaneous.

Requires esphome/esphome#7749.