### PR TITLE
Bugfix media commands before wifi

### DIFF
--- a/esphome/components/nabu/nabu_media_player.cpp
+++ b/esphome/components/nabu/nabu_media_player.cpp
@@ -168,6 +168,10 @@ esp_err_t NabuMediaPlayer::start_pipeline_(AudioPipelineType type, bool url) {
 }
 
 void NabuMediaPlayer::watch_media_commands_() {
+  if (!this->is_ready()) {
+    return;
+  }
+
   MediaCallCommand media_command;
   CommandEvent command_event;
   esp_err_t err = ESP_OK;
@@ -335,6 +339,10 @@ void NabuMediaPlayer::set_ducking_reduction(uint8_t decibel_reduction, float dur
 }
 
 void NabuMediaPlayer::control(const media_player::MediaPlayerCall &call) {
+  if (!this->is_ready()) {
+    return;
+  }
+
   MediaCallCommand media_command;
 
   if (call.get_announcement().has_value() && call.get_announcement().value()) {

--- a/esphome/components/nabu/nabu_media_player.h
+++ b/esphome/components/nabu/nabu_media_player.h
@@ -38,7 +38,7 @@ struct VolumeRestoreState {
 
 class NabuMediaPlayer : public Component, public media_player::MediaPlayer {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::LATE; }
+  float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
   void setup() override;
   void loop() override;
 


### PR DESCRIPTION
Fixes a crash when sending media player commands before wifi is connected by increasing the setup priority and directly checking if the component is ready before handling a command.

This fixes it on the media player side, but a similar bug currently exists in the ``i2s_audio`` speaker that will still cause a crash. That bug is fixed in esphome/esphome#7759.