### PR TITLE
Check for update when changing prod <-> beta

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -65,6 +65,8 @@ switch:
     on_turn_on:
       - logger.log: "OTA updates set to use Beta firmware"
       - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json");
+      - component.update: update_http_request
     on_turn_off:
       - logger.log: "OTA updates set to use Production firmware"
       - lambda: id(update_http_request).set_source_url("https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json");
+      - component.update: update_http_request


### PR DESCRIPTION
When turning on or off the beta switch, the device should check fetch the new manifest to show if an update is available right away.