### PR TITLE
Build with esp-idf v5.1.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2024.11.0
+      esphome-version: 2024.12.0b1
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -19,7 +19,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2024.9.0
+  min_version: 2024.12.0
   platformio_options:
     board_build.flash_mode: dio
   on_boot:


### PR DESCRIPTION
Builds using ESPHome release 2024.12.0b1 with esp-idf v5.1.5 as the default. This should prevent crashes when the ``http_request`` component attempts to read an update with a faulty internet connection.