### PR TITLE
Set shorter name for ble

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -41,6 +41,9 @@ wifi:
 
 improv_serial:
 
+esp32_ble:
+  name: ha-voice-pe
+
 esp32_improv:
   authorizer: center_button
   on_start:


### PR DESCRIPTION
ESPHome 2024.12.0 allows setting a name different from the `esphome`->`name`. The mac address will still be appended onto the end of the ble name.