### PR TITLE
Change beta firmware switch entity category from diagnostic to config

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -62,7 +62,7 @@ switch:
     name: Beta firmware
     icon: "mdi:test-tube"
     disabled_by_default: true
-    entity_category: diagnostic
+    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:


### PR DESCRIPTION
Since the beta firmware switch isn't a sensor, it should have the config entity category.