### PR TITLE
Use external memory for TLS

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -92,6 +92,8 @@ esp32:
       CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST: "y"
       CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY: "y"
 
+      CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC: "y"
+
 wifi:
   id: wifi_id
   on_connect:


### PR DESCRIPTION
Attempts to fix an issue where a second audio stream doesn't play when local access to HA uses https.