### PR TITLE
Bugfix: Avoid crashing when started without internet access

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1517,6 +1517,7 @@ external_components:
     refresh: 0s
   - source: github://pr#8018
     components: [http_request]
+    refresh: 0s
 
 audio_dac:
   - platform: aic3204

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1515,6 +1515,8 @@ external_components:
       - voice_assistant
       - voice_kit
     refresh: 0s
+  - source: github://pr#8018
+    components: [http_request]
 
 audio_dac:
   - platform: aic3204


### PR DESCRIPTION
Temporarily uses an updated ``http_request`` component externally that should stop the device crashing with a watchdog timeout when there isn't internet access available. When esphome/esphome#8018 is part of the next ESPHome release, I will remove the external component.

Fixes esphome/home-assistant-voice-pe/issues/241