### PR TITLE
Add start/stop VA services

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -110,6 +110,13 @@ logger:
 
 api:
   id: api_id
+  services:
+    - service: start_va
+      then:
+        - voice_assistant.start
+    - service: stop_va
+      then:
+        - voice_assistant.stop
   on_client_connected:
     - script.execute: control_leds
   on_client_disconnected:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -113,7 +113,19 @@ api:
   actions:
     - action: start_va
       then:
-        - voice_assistant.start
+        - if:
+            condition:
+              and:
+                - switch.is_off: master_mute_switch
+                - not:
+                    voice_assistant.is_running
+            then:
+              - script.execute:
+                  id: play_sound
+                  priority: true
+                  sound_file: !lambda return id(center_button_press_sound);
+              - delay: 300ms
+              - voice_assistant.start:
     - action: stop_va
       then:
         - voice_assistant.stop

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -110,11 +110,11 @@ logger:
 
 api:
   id: api_id
-  services:
-    - service: start_va
+  actions:
+    - action: start_va
       then:
         - voice_assistant.start
-    - service: stop_va
+    - action: stop_va
       then:
         - voice_assistant.stop
   on_client_connected:


### PR DESCRIPTION
This would enable users to automate triggering the VA pipeline externally, from HA. A few usecases:
- starting the VA when your face gets recognized by CompreFace
- pressing a button
- adding sentence triggers in automations to create conversations
- etc.