### PR TITLE
Add restart button to home-assistant-voice.yaml

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1663,6 +1663,9 @@ button:
     name: "Factory Reset"
     entity_category: diagnostic
     internal: true
+  - platform: restart
+    id: restart_button
+    name: "Restart"
 
 debug:
   update_interval: 5s

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1666,6 +1666,7 @@ button:
   - platform: restart
     id: restart_button
     name: "Restart"
+    entity_category: config
 
 debug:
   update_interval: 5s

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1667,6 +1667,8 @@ button:
     id: restart_button
     name: "Restart"
     entity_category: config
+    disabled_by_default: true
+    icon: "mdi:restart"
 
 debug:
   update_interval: 5s


### PR DESCRIPTION
This Adds a restart button to the device per this issue https://github.com/esphome/home-assistant-voice-pe/issues/270

This would allow people to reboot the PE from the HA UI or via Automation without having to unplug and plug-in the power cable.

Thanks
-DM