### PR TITLE
Guard implementation against no MWW

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -896,6 +896,7 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 }
 
 void VoiceAssistant::on_set_configuration(const std::vector<std::string> &active_wake_words) {
+#ifdef USE_MICRO_WAKE_WORD
   if (this->micro_wake_word_) {
     // Disable all wake words first
     for (auto &model : this->micro_wake_word_->get_wake_words()) {
@@ -912,12 +913,14 @@ void VoiceAssistant::on_set_configuration(const std::vector<std::string> &active
       }
     }
   }
+#endif
 };
 
 const Configuration &VoiceAssistant::get_configuration() {
   this->config_.available_wake_words.clear();
   this->config_.active_wake_words.clear();
 
+#ifdef USE_MICRO_WAKE_WORD
   if (this->micro_wake_word_) {
     this->config_.max_active_wake_words = 1;
 
@@ -935,9 +938,12 @@ const Configuration &VoiceAssistant::get_configuration() {
       this->config_.available_wake_words.push_back(std::move(wake_word));
     }
   } else {
+#endif
     // No microWakeWord
     this->config_.max_active_wake_words = 0;
+#ifdef USE_MICRO_WAKE_WORD
   }
+#endif
 
   return this->config_;
 };


### PR DESCRIPTION
Fixes #290 

Guard against properties defined only when `USE_MICRO_WAKE_WORD` is defined.