### PR TITLE
Add `id` to the `speaker` component

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1415,6 +1415,7 @@ microphone:
 
 speaker:
   - platform: i2s_audio
+    id: i2s_audio_speaker
     sample_rate: 48000
     i2s_mode: secondary
     i2s_dout_pin: GPIO10


### PR DESCRIPTION
This allows users to override this and use their own speaker. I'm using it to add digital optical SPDIF (via [esphome/esphome#8065](https://github.com/esphome/esphome/pull/8065)) to my Home Assistant Voice Preview Edition via the Grove port without needing to entirely fork `home-assistant-voice.yaml`. It's working flawlessly so far:

<img width="350" alt="HA Voice PE with MSB Technology DAC" src="https://github.com/user-attachments/assets/b746f935-9c82-4e42-831d-fbf56402f7d9">
<img width="350" alt="HA Voice PE top view" src="https://github.com/user-attachments/assets/19f6e8e1-adbe-40ba-8257-e32be289a6c4">
<img width="350" alt="Optical transmitter connected via Grove port" src="https://github.com/user-attachments/assets/3581c395-7a69-444b-babe-73bd979bdadd">
<img width="350" alt="Optical transmitter to Grove wiring" src="https://github.com/user-attachments/assets/c2a9117d-3905-4aab-a438-0a38f9de70f2">

```yaml
packages:
  remote_package_shorthand: github://johnboiles/home-assistant-voice-pe/home-assistant-voice.yaml@dev

esphome:
  name: home-assistant-voice
  friendly_name: Home Assistant Voice
  name_add_mac_suffix: false

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  fast_connect: true # Required for hidden AP

external_components:
  - source: github://pr#8065
    components: [ i2s_audio, spdif_audio ]
    refresh: 0s

i2s_audio:
  - id: !remove i2s_output
  - id: i2s_output_spdif

speaker:
  - id: !remove i2s_audio_speaker
  - id: spdif_speaker
    platform: spdif_audio
    i2s_audio_id: i2s_output_spdif
    data_pin: GPIO1 # Grove port SDA pin
    sample_rate: 48000
    timeout: never
    buffer_duration: 80ms
    fill_silence: true
    debug: true

switch:
  - platform: gpio
    pin: GPIO46
    id: grove_port_power
    restore_mode: ALWAYS_ON
    setup_priority: 1001

media_player:
  - id: !extend nabu_media_player
    name: Media Player
    audio_dac: !remove
    volume_increment: !remove
    volume_min: !remove
    volume_max: !remove
``` 