### PR TITLE
Bump esphome version to 2024.12.4 for http request fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2024.12.2
+      esphome-version: 2024.12.4
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -19,7 +19,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2024.12.2
+  min_version: 2024.12.4
   platformio_options:
     board_build.flash_mode: dio
   on_boot:
@@ -1514,9 +1514,6 @@ external_components:
       - nabu_microphone
       - voice_assistant
       - voice_kit
-    refresh: 0s
-  - source: github://pr#8018
-    components: [http_request]
     refresh: 0s
 
 audio_dac:


### PR DESCRIPTION
This version includes an updated http request update component that doesn't slowly leak memory. 