### PR TITLE
Revert "Add restart button to home-assistant-voice.yaml"

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1661,12 +1661,6 @@ button:
     name: "Factory Reset"
     entity_category: diagnostic
     internal: true
-  - platform: restart
-    id: restart_button
-    name: "Restart"
-    entity_category: config
-    disabled_by_default: true
-    icon: "mdi:restart"
 
 debug:
   update_interval: 5s


### PR DESCRIPTION
There is no normal operations use case for restarting the Voice PE. We shouldn't add features "because we can". 

Reverts esphome/home-assistant-voice-pe#273

