### PR TITLE
Add fast-connect substitution. Ignore one more error state.

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -14,6 +14,8 @@ substitutions:
   voice_assist_not_ready_phase_id: '10'
   # The voice assistant encountered an error
   voice_assist_error_phase_id: '11'
+  # Change this to true in case you ahve a hidden SSID at home.
+  hidden_ssid: "false"
 
 esphome:
   name: home-assistant-voice
@@ -97,6 +99,7 @@ esp32:
 
 wifi:
   id: wifi_id
+  fast_connect: ${hidden_ssid}
   on_connect:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
@@ -1596,6 +1599,7 @@ voice_assistant:
           and:
             - lambda: return !id(init_in_progress);
             - lambda: return code != "duplicate_wake_up_detected";
+            - lambda: return code != "stt-no-text-recognized";
         then:
           - lambda: id(voice_assistant_phase) = ${voice_assist_error_phase_id};
           - script.execute: control_leds


### PR DESCRIPTION
## Hidden SSID
A substitution called `hidden_ssid ` was added for people who have hidden SSID.

Taking control will still be necessary.  
I think documentation will have to be updated 

## Ignored Error state.
If you trigger the VPE but do not talk.
The VPE yields a `stt-no-text-recognized`.
This PR ignores it for the "Red flashes", so the device silently goes back to idle without flashing.
