### PR TITLE
Revert changing the media player's name

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1432,7 +1432,7 @@ speaker:
 media_player:
   - platform: speaker
     id: external_media_player
-    name: None
+    name: Media Player
     internal: False
     volume_increment: 0.05
     volume_min: 0.4


### PR DESCRIPTION
#326 changed the media player name to ``None`` in order to use the device's name, but this causes a breaking change with the entity id in HA. This reverts that change.

This closes #331, as it should no longer make the breaking change for future users updating.