### PR TITLE
Build firmware with ESPHome v2025.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.2.0
+      esphome-version: 2025.3.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}


### PR DESCRIPTION
Builds the firmware with ESPHome v2025.3.0 [(changelog)](https://esphome.io/changelog/2025.3.0.html)

It includes several changes that benefit the VPE:
- Fixes audio glitches when decoding certain FLAC files
- Reduces memory and CPU load when playing audio
- Increases the timeout for the server to send initial audio data (this was part of ESPHome v2025.2.2)

The increased timeout may partially address #355.