### PR TITLE
[voice_assistant] support start conversation after announcement

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -895,6 +895,7 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
   if (this->media_player_ != nullptr) {
     this->tts_start_trigger_->trigger(msg.text);
     this->media_player_->make_call().set_media_url(msg.media_id).set_announcement(true).perform();
+    this->continue_conversation_ = msg.start_conversation;
     this->set_state_(State::STREAMING_RESPONSE, State::STREAMING_RESPONSE);
     this->tts_end_trigger_->trigger(msg.media_id);
     this->end_trigger_->trigger();


### PR DESCRIPTION
Adds support for the ``start_conversation`` flag, so that the voice assistant can automatically start after the announcement finishes without needing to say the wake word.