### PR TITLE
[voice_assistant] Support playing preannounce media, if available, and enqueue the announcement

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -894,7 +894,11 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 #ifdef USE_MEDIA_PLAYER
   if (this->media_player_ != nullptr) {
     this->tts_start_trigger_->trigger(msg.text);
-    this->media_player_->make_call().set_media_url(msg.media_id).set_announcement(true).perform();
+    if (!msg.preannounce_media_id.empty()) {
+      this->media_player_->make_call().set_media_url(msg.preannounce_media_id).set_announcement(true).perform();
+    }
+    // Enqueueing a URL with an empty playlist will still play the file immediately
+    this->media_player_->make_call().set_command(media_player::MEDIA_PLAYER_COMMAND_ENQUEUE).set_media_url(msg.media_id).set_announcement(true).perform();
     this->continue_conversation_ = msg.start_conversation;
     this->set_state_(State::STREAMING_RESPONSE, State::STREAMING_RESPONSE);
     this->tts_end_trigger_->trigger(msg.media_id);


### PR DESCRIPTION
Adds support for the pre-announce media URL with HA initiated announcements. The actual announcement is enqueued so that it plays after the pre-announce media finishes.