### PR TITLE
Bump ESPHome build and min versions to 2025.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.3.0
+      esphome-version: 2025.3.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -21,7 +21,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.2.0
+  min_version: 2025.3.2
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
ESPHome 2025.3.2 fixes two separate bugs that makes enqueuing media not work, which in turn was making the pre-announce media fail in the voice assistant component.

The minimum ESPHome version is increased as well, since the pre-announce media and start conversation features require an API message added in 2025.3