### PR TITLE
Send "single_press" event

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -271,6 +271,9 @@ binary_sensor:
               condition:
                 lambda: return !id(init_in_progress) && !id(color_changed);
               then:
+                - event.trigger:
+                    id: button_press_event
+                    event_type: "single_press"
                 - if:
                     condition:
                       switch.is_on: timer_ringing
@@ -954,6 +957,7 @@ event:
     icon: mdi:button-pointer
     device_class: button
     event_types:
+      - single_press
       - double_press
       - triple_press
       - long_press


### PR DESCRIPTION
It's unclear why no "single_press" event is sent. Although one could argue that single presses are hardcoded, there are cases where users might want to automate on those presses or have taken over control of the VPE and remapped the single press action.

orig. discussion: https://discord.com/channels/330944238910963714/427516175237382144/1355204805756321995