### PR TITLE
Bump ESPHome to v2025.3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.3.2
+      esphome-version: 2025.3.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -21,7 +21,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.3.2
+  min_version: 2025.3.3
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
Includes several fixes related to an incorrect pause state:
- esphome/esphome#8474 - correctly change from pause to idle state after receiving a stop command
  - fixes https://github.com/music-assistant/support/issues/3775 
- esphome/esphome#8488 - announcement playlist doesn't follow playlist and change to the correct state after starting a new file while paused
  - fixes #357 
  - fixes #370 