### PR TITLE
[voice_assistant] Stop action cancels any continue conversation flag

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -635,6 +635,16 @@ void VoiceAssistant::request_stop() {
       this->signal_stop_();
       break;
     case State::STREAMING_RESPONSE:
+#ifdef USE_MEDIA_PLAYER
+      // Stop any ongoing media player announcement
+      if (this->media_player_ != nullptr) {
+        this->media_player_->make_call()
+            .set_command(media_player::MEDIA_PLAYER_COMMAND_STOP)
+            .set_announcement(true)
+            .perform();
+      }
+#endif
+      break;
     case State::RESPONSE_FINISHED:
       break;  // Let the incoming audio stream finish then it will go to idle.
   }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -610,6 +610,7 @@ void VoiceAssistant::request_start(bool continuous, bool silence_detection) {
 
 void VoiceAssistant::request_stop() {
   this->continuous_ = false;
+  this->continue_conversation_ = false;
 
   switch (this->state_) {
     case State::IDLE:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1558,26 +1558,34 @@ micro_wake_word:
                 switch.is_on: timer_ringing
               then:
                 - switch.turn_off: timer_ringing
-              # Start voice assistant, stop current announcement.
+              # Stop voice assistant if running
               else:
                 - if:
                     condition:
-                      media_player.is_announcing:
+                      voice_assistant.is_running:
                     then:
-                      media_player.stop:
-                        announcement: true
+                      voice_assistant.stop:
+                    # Stop any other media player announcement
                     else:
                       - if:
                           condition:
-                            switch.is_on: wake_sound
+                            media_player.is_announcing:
                           then:
-                            - script.execute:
-                                id: play_sound
-                                priority: true
-                                sound_file: !lambda return id(wake_word_triggered_sound);
-                            - delay: 300ms
-                      - voice_assistant.start:
-                          wake_word: !lambda return wake_word;
+                            - media_player.stop:
+                                announcement: true
+                          # Start the voice assistant and play the wake sound, if enabled
+                          else:
+                            - if:
+                                condition:
+                                  switch.is_on: wake_sound
+                                then:
+                                  - script.execute:
+                                      id: play_sound
+                                      priority: true
+                                      sound_file: !lambda return id(wake_word_triggered_sound);
+                                  - delay: 300ms
+                            - voice_assistant.start:
+                                wake_word: !lambda return wake_word;
 
 voice_assistant:
   id: va

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -279,16 +279,16 @@ binary_sensor:
                     else:
                       - if:
                           condition:
-                            media_player.is_announcing:
+                            voice_assistant.is_running:
                           then:
-                            media_player.stop:
-                              announcement: true
+                            - voice_assistant.stop:
                           else:
                             - if:
                                 condition:
-                                  voice_assistant.is_running:
+                                  media_player.is_announcing:
                                 then:
-                                  - voice_assistant.stop:
+                                  media_player.stop:
+                                    announcement: true
                                 else:
                                   - if:
                                       condition:


### PR DESCRIPTION
Currently, if an LLM response ends in a question, it will continue the conversation and start listening for the user's follow up after playing the response. If the user says "stop" or their wake word, it currently stops the ongoing announcement, but the VPE will still start listening in this situation.

The ``voice_assistant`` component changes in this PR sets the continue conversation flag to false whenever a stop action is sent. The voice assistant component will also send a stop command to the media player if the VA is currently streaming a response.

Finally, it adds a check to the firmware yaml's ``on_wake_word_detected`` action to test if the voice assistant is currently running. If so, it will send a stop command to the voice assistant, which will now stop the ongoing announcement and cancel any continue conversation followup.