### PR TITLE
Better handle `stop` word

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1354,11 +1354,24 @@ script:
   # Why is this wrapped on a script?
   #   Becasue we want to stop the sequence if the TTS step is faster than that.
   #   This allows us to prevent having the deactivation of the stop word before its own activation.
-  - id: activate_stop_word_if_tts_step_is_long
+  - id: activate_stop_word_once
     then:
       - delay: 1s
       # Enable stop wake word
-      - lambda: id(stop).enable();
+      - if:
+          condition:
+            switch.is_off: timer_ringing
+          then:
+            - lambda: id(stop).enable();
+            - wait_until:
+                not:
+                  media_player.is_announcing:
+            - if:
+                condition:
+                  switch.is_off: timer_ringing
+                then:
+                  - lambda: id(stop).disable();
+
 
 i2s_audio:
   - id: i2s_output
@@ -1645,7 +1658,7 @@ voice_assistant:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: control_leds
     # Start a script that would potentially enable the stop word if the response is longer than a second
-    - script.execute: activate_stop_word_if_tts_step_is_long
+    - script.execute: activate_stop_word_once
   # When the voice assistant ends ...
   on_end:
     - wait_until:
@@ -1656,14 +1669,6 @@ voice_assistant:
         id: media_mixing_input
         decibel_reduction: 0
         duration: 1.0s
-    # Stop the script that would potentially enable the stop word if the response is longer than a second
-    - script.stop: activate_stop_word_if_tts_step_is_long
-    # Disable the stop word (If the timer is not ringing)
-    - if:
-        condition:
-          switch.is_off: timer_ringing
-        then:
-          - lambda: id(stop).disable();
     # If the end happened because of an error, let the error phase on for a second
     - if:
         condition:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1372,7 +1372,6 @@ script:
                 then:
                   - lambda: id(stop).disable();
 
-
 i2s_audio:
   - id: i2s_output
     # i2s_output data pin is gpio10


### PR DESCRIPTION
With the addition of continued conversation, I found some issues related to how the `stop` word was loaded and unloaded.

It was loaded when the first response was streamed back and never unloaded until the end of the conversation.

This led to this:
https://github.com/user-attachments/assets/c177a610-ed02-4004-bc2e-65b4fa480ea8

Now, everything is componentized into a script called `activate_stop_word_once`.
The script activates the `stop` word and wait until the end of the annoucement (The response) to disabled it again.

As a result, during a conversation, the `stop` word is only loaded when the VPE replies.

Timer is still handled separately as before (Because timers are a rapid succession of annoucement - I do not want to keep loading and disabling the `stop` word in that case)