### PR TITLE
Build with ESPHome 2025.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.3.3
+      esphome-version: 2025.4.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}


### PR DESCRIPTION
Builds the firmware with the ESPHome 2025.4.0. It includes a fix for a potential deadlock in the speaker media player: <https://github.com/esphome/esphome/pull/8548>. This could potentially be the fix for #382 