### PR TITLE
Bump esphome/workflows from 2025.1.0 to 2025.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.1.0
+    uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
     with:
       files: |
         home-assistant-voice.factory.yaml
@@ -62,7 +62,7 @@ jobs:
     name: Upload to R2
     needs:
       - build-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.1.0
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.4.0
     with:
       directory: home-assistant-voice-pe
     secrets: inherit
@@ -83,7 +83,7 @@ jobs:
   upload-to-release:
     name: Upload to Release
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.1.0
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.4.0
     needs:
       - build-firmware
     with:
@@ -92,7 +92,7 @@ jobs:
   promote-beta:
     name: Promote to Beta
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.1.0
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
     needs:
       - upload-to-r2
     with:
@@ -105,7 +105,7 @@ jobs:
   promote-prod:
     name: Promote to Production
     if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.1.0
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
     needs:
       - upload-to-r2
     with:


### PR DESCRIPTION
https://github.com/esphome/workflows/releases/tag/2025.4.0

Mostly this updates the build-action as v6.0.0 of that will fail with ESPHome 2025.5.0