### PR TITLE
Move read only and instructions from flash into PSRAM on boot

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -59,6 +59,12 @@ esp32:
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
       CONFIG_ESP32S3_INSTRUCTION_CACHE_32KB: "y"
 
+      # Moves instructions and read only data from flash into PSRAM on boot.
+      # Both enabled allows instructions to execute while a flash operation is in progress without needing to be placed in IRAM.
+      # Considerably speeds up mWW at the cost of using more PSRAM.
+      CONFIG_SPIRAM_RODATA: "y"
+      CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
+
       CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST: "y"
       CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY: "y"
 


### PR DESCRIPTION
Sets two new sdkconfig options: [config-spiram-rodata](https://docs.espressif.com/projects/esp-idf/en/v5.1.6/esp32s3/api-reference/kconfig.html#config-spiram-rodata) and [config-spiram-fetch-instructions](https://docs.espressif.com/projects/esp-idf/en/v5.1.6/esp32s3/api-reference/kconfig.html#config-spiram-fetch-instructions), which move the read only data and instructions from the flash into PSRAM on boot (which uses up about 3 ~~kB~~ MB out of the 8 ~~kB~~ MB available on the VPE). This allows code to be executed while a flash operation is occurring without placing it into IRAM. This drastically speeds up the microWakeWord inference task!

Before these changes, running mWW with the "Okay Nabu" model and the VAD model (the default settings for the VPE) used ~15% of the CPU. After these changes, it uses only ~8% of the CPU (~45% faster)! 

While this does use a lot more PSRAM, we still have far more PSRAM free then we currently use. Even with the media playing mixed with an announcement, we still have ~3 ~~kB~~ MB of PSRAM memory free.