### PR TITLE
Don't attempt to comment on PR if it comes from a fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
   comment:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'esphome/home-assistant-voice-pe'
     name: Comment on PR
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Due to permission issues, the workflows running on a fork cannot comment on the PR and this makes the job fail.

An alternative is to change the trigger to `pull_request_target` which then runs the workflow with the correct permissions, but you cannot test PRs where the actual workflow file has changed as it will only run the workflow file that is merged into the default branch.