### PR TITLE
Build with ESPHome 2025.5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.5.0
+      esphome-version: 2025.5.1
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -21,7 +21,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.5.0
+  min_version: 2025.5.1
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
CI will fails since ESPHome 2025.5.1 hasn't been released.

Includes two relevant bugfixes:
 - Prevents duplicate wake word activations on the device (this would cause the Mycroft model to stop the just initiated pipelines when set to more sensitive)
 - Fixes the logging of an error when the audio pipeline previously failed at the start of the next audio pipeline