### PR TITLE
Modify default wake word sensitivity

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1603,7 +1603,7 @@ select:
   - platform: template
     name: "Wake word sensitivity"
     optimistic: true
-    initial_option: Moderately sensitive
+    initial_option: Slightly sensitive
     restore_value: true
     entity_category: config
     options:


### PR DESCRIPTION
The current sensitivity is a breaking change for the "Okay Nabu" and "Hey Jarvis" models. This PR changes the default sensitivity to the ``Slightly sensitive`` setting to avoid a breaking change for these two models. "Hey Mycroft" will now be less sensitive then the current default.