### PR TITLE
Support TTS streaming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.6.1
+      esphome-version: 2025.6.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.5.1
+      esphome-version: 2025.6.1
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1686,11 +1686,26 @@ voice_assistant:
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: control_leds
+  on_intent_progress:
+    - if:
+        condition:
+          # A nonempty x variable means a streaming TTS url was sent to the media player
+          lambda: 'return !x.empty();'
+        then:
+          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+          - script.execute: control_leds
+          # Start a script that would potentially enable the stop word if the response is longer than a second
+          - script.execute: activate_stop_word_once
   on_tts_start:
-    - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
-    - script.execute: control_leds
-    # Start a script that would potentially enable the stop word if the response is longer than a second
-    - script.execute: activate_stop_word_once
+    - if:
+        condition:
+          # The intent_progress trigger didn't start the TTS Reponse
+          lambda: 'return id(voice_assistant_phase) != ${voice_assist_replying_phase_id};'
+        then:
+          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+          - script.execute: control_leds
+          # Start a script that would potentially enable the stop word if the response is longer than a second
+          - script.execute: activate_stop_word_once
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1534,6 +1534,13 @@ external_components:
     components:
       - voice_kit
     refresh: 0s
+  # The following are experimental (but fixed) PRs to support streaming TTS
+  - source: github://pr#9221
+    components: [audio]
+  - source: github://pr#9222
+    components: [speaker]
+  - source: github://pr#9224
+    components: [voice_assistant]
 
 audio_dac:
   - platform: aic3204

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1564,13 +1564,6 @@ external_components:
     components:
       - voice_kit
     refresh: 0s
-  # The following are experimental (but fixed) PRs to support streaming TTS
-  - source: github://pr#9221
-    components: [audio]
-  - source: github://pr#9222
-    components: [speaker]
-  - source: github://pr#9224
-    components: [voice_assistant]
 
 audio_dac:
   - platform: aic3204


### PR DESCRIPTION
- Uses for streaming TTS if the HA TTS provider supports it (only Piper with the latest HA beta and wyoming-piper addon supports it!)
- Fixes timeout errors causing no response to be played if the first TTS response is very slow to generate
- Reduces timeout errors due to temporary network delays after audio starts playing
- Fixes crashes when either the STT or TTS texts are very long