### PR TITLE
Switch to switch off timer ticking LED

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -195,6 +195,15 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
+  # Timer LED remaining time off switch
+  - platform: template
+    id: timer_led_off
+    name: Timer LED off
+    icon: "mdi:led-off"
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    disabled_by_default: true
   # Internal switch to track when a timer is ringing on the device.
   - platform: template
     id: timer_ringing
@@ -1019,7 +1028,7 @@ script:
             id(control_leds_voice_assistant_error_phase).execute();
           } else if (id(voice_assistant_phase) == ${voice_assist_not_ready_phase_id}) {
             id(control_leds_voice_assistant_not_ready_phase).execute();
-          } else if (id(is_timer_active)) {
+          } else if (id(is_timer_active) && !id(timer_led_off).state) {
             id(control_leds_timer_ticking).execute();
           } else if (id(master_mute_switch).state) {
             id(control_leds_muted_or_silent).execute();


### PR DESCRIPTION
A switch to switch off the timer ticking LED (closes #418).
I think that was a good idea and I also find the reasoning logical. As in the example with a short sleep, there are cases where you don't want the LEDs to light up on the timer.
I have hidden and deactivated the switch by default, as it is probably not used by everyone and therefore the configuration remains clearer.