### PR TITLE
Switch to lock buttons

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -282,12 +282,12 @@ binary_sensor:
             switch.is_off: lock_buttons
           then:
             - script.execute: control_leds
-            # If a factory reset is requested, factory reset on release
-            - if:
-                condition:
-                  lambda: return id(factory_reset_requested);
-                then:
-                  - button.press: factory_reset_button
+      # If a factory reset is requested, factory reset on release
+      - if:
+          condition:
+            lambda: return id(factory_reset_requested);
+          then:
+            - button.press: factory_reset_button
     on_multi_click:
       # Simple Click:
       #   - Abort "things" in order
@@ -447,7 +447,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(dial_touched) && !id(lock_buttons).state;
+                lambda: return !id(dial_touched);
               then:
                 - light.turn_on:
                     brightness: 100%
@@ -476,7 +476,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(dial_touched) && !id(lock_buttons).state;
+                lambda: return !id(dial_touched);
               then:
                 - script.execute:
                     id: play_sound

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -259,23 +259,23 @@ binary_sensor:
       number: GPIO0
       inverted: true
     on_press:
-    - if:
-        condition:
-          switch.is_off: lock_buttons
-        then:
-          - script.execute: control_leds
+      - if:
+          condition:
+            switch.is_off: lock_buttons
+          then:
+            - script.execute: control_leds
     on_release:
-    - if:
-        condition:
-          switch.is_off: lock_buttons
-        then:
-          - script.execute: control_leds
-          # If a factory reset is requested, factory reset on release
-          - if:
-              condition:
-                lambda: return id(factory_reset_requested);
-              then:
-                - button.press: factory_reset_button
+      - if:
+          condition:
+            switch.is_off: lock_buttons
+          then:
+            - script.execute: control_leds
+            # If a factory reset is requested, factory reset on release
+            - if:
+                condition:
+                  lambda: return id(factory_reset_requested);
+                then:
+                  - button.press: factory_reset_button
     on_multi_click:
       # Simple Click:
       #   - Abort "things" in order

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -195,6 +195,15 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
+  # Timer LED remaining time off switch
+  - platform: template
+    id: lock_buttons
+    name: Lock buttons
+    icon: "mdi:button-pointer"
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    disabled_by_default: true
   # Internal switch to track when a timer is ringing on the device.
   - platform: template
     id: timer_ringing
@@ -250,15 +259,23 @@ binary_sensor:
       number: GPIO0
       inverted: true
     on_press:
-      - script.execute: control_leds
+    - if:
+        condition:
+          switch.is_off: lock_buttons
+        then:
+          - script.execute: control_leds
     on_release:
-      - script.execute: control_leds
-      # If a factory reset is requested, factory reset on release
-      - if:
-          condition:
-            lambda: return id(factory_reset_requested);
-          then:
-            - button.press: factory_reset_button
+    - if:
+        condition:
+          switch.is_off: lock_buttons
+        then:
+          - script.execute: control_leds
+          # If a factory reset is requested, factory reset on release
+          - if:
+              condition:
+                lambda: return id(factory_reset_requested);
+              then:
+                - button.press: factory_reset_button
     on_multi_click:
       # Simple Click:
       #   - Abort "things" in order
@@ -273,7 +290,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed);
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(lock_buttons).state;
               then:
                 - if:
                     condition:
@@ -323,7 +340,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed);
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(lock_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -344,7 +361,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed);
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(lock_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -360,7 +377,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed);
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(lock_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -418,7 +435,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(dial_touched);
+                lambda: return !id(dial_touched) && !id(lock_buttons).state;
               then:
                 - light.turn_on:
                     brightness: 100%
@@ -447,7 +464,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(dial_touched);
+                lambda: return !id(dial_touched) && !id(lock_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -939,7 +956,9 @@ sensor:
       - lambda: id(dial_touched) = true;
       - if:
           condition:
-            binary_sensor.is_off: center_button
+            and:
+              - binary_sensor.is_off: center_button
+              - switch.is_off: lock_buttons
           then:
             - script.execute:
                 id: control_volume
@@ -952,7 +971,9 @@ sensor:
       - lambda: id(dial_touched) = true;
       - if:
           condition:
-            binary_sensor.is_off: center_button
+            and:
+              - binary_sensor.is_off: center_button
+              - switch.is_off: lock_buttons
           then:
             - script.execute:
                 id: control_volume

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -227,10 +227,10 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
-  # Timer LED remaining time off switch
+  # Disable physical controls switch
   - platform: template
-    id: lock_buttons
-    name: Lock buttons
+    id: disable_buttons
+    name: Disable physical controls
     icon: "mdi:button-pointer"
     entity_category: config
     optimistic: true
@@ -295,13 +295,13 @@ binary_sensor:
     on_press:
       - if:
           condition:
-            switch.is_off: lock_buttons
+            switch.is_off: disable_buttons
           then:
             - script.execute: control_leds
     on_release:
       - if:
           condition:
-            switch.is_off: lock_buttons
+            switch.is_off: disable_buttons
           then:
             - script.execute: control_leds
       # If a factory reset is requested, factory reset on release
@@ -324,7 +324,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(lock_buttons).state;
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(disable_buttons).state;
               then:
                 - if:
                     condition:
@@ -377,7 +377,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(lock_buttons).state;
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(disable_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -398,7 +398,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(lock_buttons).state;
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(disable_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -414,7 +414,7 @@ binary_sensor:
         then:
           - if:
               condition:
-                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(lock_buttons).state;
+                lambda: return !id(init_in_progress) && !id(color_changed) && !id(group_volume_changed) && !id(disable_buttons).state;
               then:
                 - script.execute:
                     id: play_sound
@@ -999,7 +999,7 @@ sensor:
           condition:
             and:
               - binary_sensor.is_off: center_button
-              - switch.is_off: lock_buttons
+              - switch.is_off: disable_buttons
           then:
             - script.execute:
                 id: control_volume
@@ -1023,7 +1023,7 @@ sensor:
           condition:
             and:
               - binary_sensor.is_off: center_button
-              - switch.is_off: lock_buttons
+              - switch.is_off: disable_buttons
           then:
             - script.execute:
                 id: control_volume


### PR DESCRIPTION
As described in #383 (closes #383), there are use cases where you don't want the center button and the wheel to be inoperable.
The pull request offers a new switch that locks both things (the easter egg can still be triggered).