### PR TITLE
Bump to ESPHome release 2025.7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.6.2
+      esphome-version: 2025.7.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -21,7 +21,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.5.1
+  min_version: 2025.7.2
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
2025.7.2 includes some fixes that make streaming TTS responses more resilient to getting in a stuck state. These changes should reduce the frequency of the [getting stuck responding issue](https://github.com/esphome/home-assistant-voice-pe/issues/382), but I don't think it's fully solved yet.