### PR TITLE
Add Alexa wake word

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1578,6 +1578,8 @@ micro_wake_word:
     gain_factor: 4
   stop_after_detection: false
   models:
+    - model: https://github.com/kahrendt/microWakeWord/releases/download/v2.1_models/alexa.json
+      id: alexa
     - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
       id: okay_nabu
     - model: hey_jarvis

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1646,17 +1646,20 @@ select:
       # Sets specific wake word probabilities computed for each particular model
       # Note probability cutoffs are set as a quantized uint8 value, each comment has the corresponding floating point cutoff
       # False Accepts per Hour values are tested against all units and channels from the Dinner Party Corpus.
-      # These cutoffs apply only to the specific models included in the firmware: okay_nabu@20241226.3, hey_jarvis@v2, hey_mycroft@v2
+      # These cutoffs apply only to the specific models included in the firmware: alexa@v2, okay_nabu@20241226.3, hey_jarvis@v2, hey_mycroft@v2
       lambda: |-
         if (x == "Slightly sensitive") {
+          id(alexa).set_probability_cutoff(230);        // 0.90 -> ????? FAPH on DipCo (Manifest's default)
           id(okay_nabu).set_probability_cutoff(217);    // 0.85 -> 0.000 FAPH on DipCo (Manifest's default)
           id(hey_jarvis).set_probability_cutoff(247);   // 0.97 -> 0.563 FAPH on DipCo (Manifest's default)
           id(hey_mycroft).set_probability_cutoff(253);  // 0.99 -> 0.567 FAPH on DipCo
         } else if (x == "Moderately sensitive") {
+          id(alexa).set_probability_cutoff(217);        // 0.85 -> ????? FAPH on DipCo
           id(okay_nabu).set_probability_cutoff(176);    // 0.69 -> 0.376 FAPH on DipCo
           id(hey_jarvis).set_probability_cutoff(235);   // 0.92 -> 0.939 FAPH on DipCo
           id(hey_mycroft).set_probability_cutoff(242);  // 0.95 -> 1.502 FAPH on DipCo (Manifest's default)
         } else if (x == "Very sensitive") {
+          id(alexa).set_probability_cutoff(191);        // 0.75 -> ????? FAPH on DipCo
           id(okay_nabu).set_probability_cutoff(143);    // 0.56 -> 0.751 FAPH on DipCo
           id(hey_jarvis).set_probability_cutoff(212);   // 0.83 -> 1.502 FAPH on DipCo
           id(hey_mycroft).set_probability_cutoff(237);  // 0.93 -> 1.878 FAPH on DipCo


### PR DESCRIPTION
Hello! I just wanted to see if it's possible to add Alexa wake word to the Voice PE. I have taken control of my Voice PE and referenced my YAML file instead of the official one and my changes seem to work as expected!

**IMPORTANT BEFORE MERGE:**
- The only thing missing is that I don't know how to test False Accepts per Hour values against all units and channels from the Dinner Party Corpus, so we can add real values to the sensitive selectors. Right now I just added some values I feel are good enough, but I'm sure they can be improved. I'll continue to investigate, but if someone can help me with this topic I would be extremely grateful.

Also, I would like to help training the Alexa wake word in Spanish, since we say the "L" differently and that has been an issue for the wake word to be recognized in my home. So again I'll investigate, but if someone can help me with this topic I would be extremely grateful.

I mainly wanted to start a conversation of adding this wake word to the Voice PE, since I've been seeing a lot of people asking for it and the configuration seemed easy to implement.

Let me know if there is something I can help with for this PR to be merged. Thanks!!