### PR TITLE
Update ESPHome version and allow HA to use API dynamic encryption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.8.1
+    uses: esphome/workflows/.github/workflows/build.yml@2025.9.0
     with:
       files: |
         home-assistant-voice.factory.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.9.0
+    uses: esphome/workflows/.github/workflows/build.yml@2025.8.1
     with:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.7.2
+      esphome-version: 2025.9.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -97,6 +97,7 @@ api:
     - script.execute: control_leds
   on_client_disconnected:
     - script.execute: control_leds
+  encryption:   # Uses key set by Home Assistant
 
 ota:
   - platform: esphome

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.7.2
+  min_version: 2025.9.0
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
Now builds the firmware with ESPHome 2025.9.0. Adds ``encryption`` to the API component. HA will generate a new encryption key after connecting.