### PR TITLE
Potential stuttering fix: disable lwip locking to a core

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -57,6 +57,8 @@ esp32:
   framework:
     type: esp-idf
     version: recommended
+    advanced:
+      enable_lwip_tcpip_core_locking: False
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"


### PR DESCRIPTION
This a beta fix for #455 

It allows the LWIP task to swap cores as needed, potentially fixing a situation where the http reader task has to wait on a lock to be freed.