### PR TITLE
Build with ESPHome 2025.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.9.3
+      esphome-version: 2025.11.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.9.3
+  min_version: 2025.11.0
   on_boot:
     priority: 375
     then:
@@ -112,6 +112,7 @@ i2c:
 psram:
   mode: octal
   speed: 80MHz
+  ignore_not_found: false  # The VPE has PSRAM, so this is safe. Allows configuring WiFi driver to use more resources (done automatically by the speaker media player)
 
 globals:
   # Global index for our LEDs. So that switching between different animation does not lead to unwanted effects.


### PR DESCRIPTION
Updates to ESPHome 2025.11.0. This includes several improvements:

- Should fix #455, as we now guarantee PSRAM is available, so the WiFi and networking driver configurations configure with higher settings.
- Reduces the latency of wake word detection by up to 15 ms, as the ``micro_wake_word`` component now immediately runs the loop function to notify the detection instead of waiting until the next usually timed loop.

Closes #469, as that didn't properly fix the stuttering issue.