### PR TITLE
Adds http_request component to the main YAML to fix package imports

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1552,6 +1552,8 @@ sendspin:
   task_stack_in_psram: true
   kalman_process_error: 0.01
 
+http_request:
+
 media_source:
   - platform: sendspin
     id: sendspin_source


### PR DESCRIPTION
Adds ``http_request`` component to the main YAML file. #493 changed the media player to use the ``http_request`` media source. The automated builds worked fine, because that component is defined in the ``home-assistant-voice.factory.yaml`` file, but it caused build failures for uses who have taken control and import the ``home-assistant-voice.yaml`` YAML directly.

Fixes #495.