### PR TITLE
Fix conflict with web_server component

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1691,7 +1691,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: a064ee8fbdda9ef7f5c6a402b19bdb2d6160464f
+      ref: aef3a4afd9c7186751fc9d097742325b3390572f
     components: [mdns, sendspin]
   - source:
       # https://github.com/esphome/esphome/pull/12429


### PR DESCRIPTION
Updates the Sendspin PR commit reference so that it uses updated code with a different ctrl port in the http server to avoid conflict with the ``web_server`` component. Fixes #502.

This bug only applied to users who took control of the VPE and added the ``web_server`` component. It doesn't appear to affect any other situations.