### PR TITLE
Fix "stop" wake word not enabling for long TTS responses

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1464,6 +1464,11 @@ script:
   #   This allows us to prevent having the deactivation of the stop word before its own activation.
   - id: activate_stop_word_once
     then:
+      - wait_until:
+          condition:
+            media_player.is_announcing:
+              id: external_media_player
+          timeout: 5s
       - delay: 1s
       # Enable stop wake word
       - if:


### PR DESCRIPTION
The new speaker source media player isn't as optimistic about changing it's state to ANNOUNCING unless the URL has fully opened. This caused the stop wake word activation script to immediately disable the "stop" wake word right after starting it. This PR adds a ``wait_until`` the speaker is announcing action to ensure it doesn't. It fails-safe with a 5 second timeout.

Fixes #506 (at least the stop wake word part, the response freezing is a different problem that is also being tracked in other raised issues).