### PR TITLE
Fix http_request media sources

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1702,7 +1702,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: 9b3625da70532c752eca8be9f86b911a7f2cebc8
+      ref: f5c1a8111df78e32d07d7a7bb800018808cdc0e7
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1702,7 +1702,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: 627572d9aa0c372f4ca8adcbdaf68c1c2e65b84c
+      ref: eb30780aacab37cea68f13ba867ff902d039d9ca
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1702,7 +1702,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: eb30780aacab37cea68f13ba867ff902d039d9ca
+      ref: 9b3625da70532c752eca8be9f86b911a7f2cebc8
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 


### PR DESCRIPTION
Fixes two bugs:
- If the reader task failed because the url couldn't open, the http_request media_source would get in a stuck state because the decode task couldn't end. This required rebooting the VPE before it could ever play an announcement again. This PR allows the decode task to end gracefully in this situation so that the media source is ready to receive a new URL.
- The http_request component only tried once to fetch the headers. This caused it fail when a TTS response took a long time to generate (either due to length or due to the speed of the TTS model). This PR now retries up to 6 times to fetch the headers (matching the behavior of the speaker media player we previously used)

Fixes #511 #507 and #500. It probably also fixes #508 