### PR TITLE
Fix building with ESPHome 2025.12.5

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1696,7 +1696,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: aef3a4afd9c7186751fc9d097742325b3390572f
+      ref: 71c8c6bdfc8006902eb0ea7b15bc86c575cef9be
     components: [mdns, sendspin]
   - source:
       # https://github.com/esphome/esphome/pull/12429


### PR DESCRIPTION
Bumps the sendspin commit id to one that includes a fix for failing to build with ESPHOme 2025.12.5.

2025.12.5 included a change to core/socket component that made it it not possible to request a thread safe wake looping socket from a validator like I previously did. Now it requests it in the ``to_code`` portion allowing it to build with 2025.12.5.

Should fix #519 