### PR TITLE
ESPHome 2025.1 compatability update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.12.6
+      esphome-version: 2026.1.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -62,7 +62,7 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 5.5.1
+    version: 5.5.2
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -62,7 +62,7 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 5.5.2
+    version: recommended
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -38,7 +38,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2025.1.0
   on_boot:
     priority: 375
     then:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1672,19 +1672,19 @@ external_components:
       # https://github.com/esphome/esphome/pull/12253
       type: git
       url: https://github.com/esphome/esphome
-      ref: 0fe230114c80b6d3378f04c777baadee178e40ad
+      ref: 7f34908569650e5a8b8c83e6bf89fea561218880
     components: [mixer]
   - source:
       # https://github.com/esphome/esphome/pull/12254
       type: git
       url: https://github.com/esphome/esphome
-      ref: 1ab4b990092ae063a16cb1511a188c536fdb336e
+      ref: 6006b896a691ad38d8045ac67564c168973d1a1d
     components: [resampler]
   - source:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome
-      ref: 047ba60f01af84513f8d5aabaa2a53074facee8f
+      ref: 9148832ea4e54907bad71a24d4ced1ce6c862433
     components: [audio]
   - source:
       # https://github.com/esphome/esphome/pull/12258
@@ -1696,13 +1696,13 @@ external_components:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: 71c8c6bdfc8006902eb0ea7b15bc86c575cef9be
+      ref: a6c0a861a014e64c67d46115eba8e5370777b80a
     components: [mdns, sendspin]
   - source:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: f5c1a8111df78e32d07d7a7bb800018808cdc0e7
+      ref: 928204066ce0082404573ea1c6a0b58aeebbd7c6
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 


### PR DESCRIPTION
Updates for the Sendspin related external components various commit references to their latest versions. 
Uses the recommended IDF version for building.
Updates the min ESPHome version to 2026.1.0 and builds with it (closes #525 since it is redundant)

Fixes #529.