### PR TITLE
Update Sendspin and media player PRs with several bugfixes and stability improvements

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1696,7 +1696,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: a6c0a861a014e64c67d46115eba8e5370777b80a
+      ref: fd6c7fcc692662f30fc2a2bc904226132e798768
     components: [mdns, sendspin]
   - source:
       # https://github.com/esphome/esphome/pull/12429

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1684,7 +1684,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome
-      ref: 9148832ea4e54907bad71a24d4ced1ce6c862433
+      ref: a2d98e1d5e020200db8f3caf27a74a939a661dc4
     components: [audio]
   - source:
       # https://github.com/esphome/esphome/pull/12258

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1669,16 +1669,16 @@ external_components:
       - voice_kit
     refresh: 0s
   - source:
-      # https://github.com/esphome/esphome/pull/12253
+      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2025.2.0)
       type: git
       url: https://github.com/esphome/esphome
-      ref: 7f34908569650e5a8b8c83e6bf89fea561218880
+      ref: c28c97fbaf15c4ce353317e873054fb00a1d7a6d  # ESPHome dev branch commit hash
     components: [mixer]
   - source:
-      # https://github.com/esphome/esphome/pull/12254
+      # https://github.com/esphome/esphome/pull/12254 (merged into upstream ESPHome, will be available in ESPHome 2025.2.0)
       type: git
       url: https://github.com/esphome/esphome
-      ref: 6006b896a691ad38d8045ac67564c168973d1a1d
+      ref: 298efb53400852a09e2f8bdf16feac9a58422059  # ESPHome dev branch commit hash
     components: [resampler]
   - source:
       # https://github.com/esphome/esphome/pull/12256

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1702,7 +1702,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: 928204066ce0082404573ea1c6a0b58aeebbd7c6
+      ref: f25630c2d5bef3cce617a6180cec1e4ce05a1b61
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1696,7 +1696,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: fd6c7fcc692662f30fc2a2bc904226132e798768
+      ref: 3cc894763b05ac8ffd9fdd15bcb549d47cadf6eb
     components: [mdns, sendspin]
   - source:
       # https://github.com/esphome/esphome/pull/12429

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1684,7 +1684,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome
-      ref: a2d98e1d5e020200db8f3caf27a74a939a661dc4
+      ref: 9148832ea4e54907bad71a24d4ced1ce6c862433
     components: [audio]
   - source:
       # https://github.com/esphome/esphome/pull/12258

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1702,7 +1702,7 @@ external_components:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: f25630c2d5bef3cce617a6180cec1e4ce05a1b61
+      ref: 32708a2ee74f5ea4107448f62755004ad3e879c5
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1669,13 +1669,13 @@ external_components:
       - voice_kit
     refresh: 0s
   - source:
-      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2025.2.0)
+      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
       type: git
       url: https://github.com/esphome/esphome
       ref: c28c97fbaf15c4ce353317e873054fb00a1d7a6d  # ESPHome dev branch commit hash
     components: [mixer]
   - source:
-      # https://github.com/esphome/esphome/pull/12254 (merged into upstream ESPHome, will be available in ESPHome 2025.2.0)
+      # https://github.com/esphome/esphome/pull/12254 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
       type: git
       url: https://github.com/esphome/esphome
       ref: 298efb53400852a09e2f8bdf16feac9a58422059  # ESPHome dev branch commit hash


### PR DESCRIPTION
Updates the Sendspin and media player PRs for several bug fixes:

- Updates the speaker source media player hash to:
  - Fixes verify_ssl failing to work by using upstream http_request component (closes #536)
  - Increases the timeout for slowly generated TTS response (closes #527 and probably fixes #518)
- Updates the Sendspin media player hash to:
  - Improve stability by reducing heap churn for encoded audio chunks and maintaining sync
  - Improves logic for new streams to reduce latency until first audio and to support the next MA beta where new streams very quickly fill up the buffer
  - Fixes a potential overflow causing audio glitches when inserting or removing a sample to maintain sync
  - Adds initial support for multiple Sendspin servers (experimental, may have bugs, please report!)
- Mixer and resampler now use the commit hashes from the squash commit from merging the PRs. They will be available in ESPHome 2026.2.0