### PR TITLE
Fix announcements without presound/build with Esphome 2026.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2026.1.5
+      esphome-version: 2026.2.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1667,18 +1667,6 @@ external_components:
       - voice_kit
     refresh: 0s
   - source:
-      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: c28c97fbaf15c4ce353317e873054fb00a1d7a6d  # ESPHome dev branch commit hash
-    components: [mixer]
-  - source:
-      # https://github.com/esphome/esphome/pull/12254 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: 298efb53400852a09e2f8bdf16feac9a58422059  # ESPHome dev branch commit hash
-    components: [resampler]
-  - source:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -38,7 +38,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2026.1.0
+  min_version: 2026.2.0
   on_boot:
     priority: 375
     then:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1434,11 +1434,11 @@ script:
   - id: fetch_first_active_timer
     then:
       - lambda: |
-          const auto timers = id(va).get_timers();
-          auto output_timer = timers.begin()->second;
-          for (auto &iterable_timer : timers) {
-            if (iterable_timer.second.is_active && iterable_timer.second.seconds_left <= output_timer.seconds_left) {
-              output_timer = iterable_timer.second;
+          const auto &timers = id(va).get_timers();
+          auto output_timer = *timers.begin();
+          for (const auto &timer : timers) {
+            if (timer.is_active && timer.seconds_left <= output_timer.seconds_left) {
+              output_timer = timer;
             }
           }
           id(first_active_timer) = output_timer;
@@ -1447,13 +1447,11 @@ script:
   - id: check_if_timers_active
     then:
       - lambda: |
-          const auto timers = id(va).get_timers();
+          const auto &timers = id(va).get_timers();
           bool output = false;
-          if (timers.size() > 0) {
-            for (auto &iterable_timer : timers) {
-              if(iterable_timer.second.is_active) {
-                output = true;
-              }
+          for (const auto &timer : timers) {
+            if (timer.is_active) {
+              output = true;
             }
           }
           id(is_timer_active) = output;

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1670,25 +1670,31 @@ external_components:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome
-      ref: 9148832ea4e54907bad71a24d4ced1ce6c862433
+      ref: a2d98e1d5e020200db8f3caf27a74a939a661dc4
     components: [audio]
   - source:
       # https://github.com/esphome/esphome/pull/12258
       type: git
       url: https://github.com/esphome/esphome
-      ref: bff22983a390352360796f8e1363127e0cd1f898
+      ref: b4b7c5b25ebe0f2ab988f700219fa3c57b2377b7
     components: [media_player]
   - source:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: 3cc894763b05ac8ffd9fdd15bcb549d47cadf6eb
-    components: [mdns, sendspin]
+      ref: d48058e140c98f5c2d902661d851a6b712d62434
+    components: [sendspin]
+  - source:
+      # https://github.com/esphome/esphome/pull/14013
+      type: git
+      url: https://github.com/esphome/esphome
+      ref: 51dcce3d1f22865ebb458a5447bbc877ac946b5a
+    components: [mdns]
   - source:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: 32708a2ee74f5ea4107448f62755004ad3e879c5
+      ref: b49b09b6ae56502aa3ce51be86f90d732d019b2c
     refresh: 0s
     components: [file, http_request, media_source, speaker_source]
 


### PR DESCRIPTION
Fixes #545, where the ``assist_satellite.announce`` Home Assistant action didn't work if the preannounce sound wasn't enabled (the media player failed to queue the TTS response if there was nothing in its internal playlist)

Updates everything to work with and build with ESPHome 2026.2.0 (closes #547) and updates the build script to build with it 

- Updates to the [``voice_assistant`` component](https://github.com/esphome/esphome/pull/13857) required some changes to how timers are accessed in C++ lambdas
- Removes ``mixer`` and ``resampler``external components as those changes are now in ESPHome 2026.2.0
- Pulls in ``mdns`` via a separate external component (the [PR](https://github.com/esphome/esphome/pull/14013) is approved but not merged)
- Updates the ``media_player`` external component hash (the [PR](https://github.com/esphome/esphome/pull/12258) is approved but not merged)
- Updates the ``media_source`` and ``audio`` external component hashes to now work with 2026.2.0's chnages so unused IDF libraries aren't always built as well as updating to follow ``http_request`` components changes
- Updates the ``sendspin`` external component hash to eliminate a compilation warning about the deprecated set_retry command

~Note this will fail CI as ESPHome 2026.2.0 hasn't been released yet at the time I created this PR. Once it is available, rerunning the CI should work.~ I tested building this with ESPHome 2026.2.0b4 locally with no issues.