### PR TITLE
Fix out-of-bounds read in VoiceKit::dfu_reboot_()

### DIFF
--- a/esphome/components/voice_kit/voice_kit.cpp
+++ b/esphome/components/voice_kit/voice_kit.cpp
@@ -328,9 +328,9 @@ bool VoiceKit::dfu_get_version_() {
 }
 
 bool VoiceKit::dfu_reboot_() {
-  const uint8_t reboot_req[] = {DFU_CONTROLLER_SERVICER_RESID, DFU_CONTROLLER_SERVICER_RESID_DFU_REBOOT, 1};
+  const uint8_t reboot_req[] = {DFU_CONTROLLER_SERVICER_RESID, DFU_CONTROLLER_SERVICER_RESID_DFU_REBOOT, 1, 0};
 
-  auto error_code = this->write(reboot_req, 4);
+  auto error_code = this->write(reboot_req, sizeof(reboot_req));
   if (error_code != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Reboot request failed");
     return false;


### PR DESCRIPTION
The reboot_req array had 3 elements but write() was called with a hardcoded length of 4, reading one byte past the array from the stack. Add the missing payload byte required by the XMOS DFU protocol and use sizeof(reboot_req) instead of a hardcoded length to prevent mismatch.

Note that this worked previously because the XMOS device doesn't actually care what's in the command byte, so any value we send is fine. This cleanup is to help save the next person who wonders why we declare are array of 3 bytes and send 4 bytes some worry, it changes no functionality.