### PR TITLE
Add id to wake word sensitivity select

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1767,6 +1767,7 @@ micro_wake_word:
 select:
   - platform: template
     name: "Wake word sensitivity"
+    id: wake_word_sensitivity
     optimistic: true
     initial_option: Slightly sensitive
     restore_value: true


### PR DESCRIPTION
 `mww` already has an id, which can be used to extend the available wake words. This, however, will not have a settable sensitivity. Adding an `id` to the select will allow users to `!extend` the select, when including this file as a package. Thus allowing to define different sensitivities also for custom wake words.