### PR TITLE
Remove pinned mdns external component

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1657,7 +1657,7 @@ voice_kit:
     version: "1.3.1"
     md5: 964635c5bf125529dab14a2472a15401
 
-# Sendspin related components are pinned to specific commits for reproducible builds
+# Components are pinned to specific commits for reproducible builds
 external_components:
   - source:
       type: git
@@ -1684,12 +1684,6 @@ external_components:
       url: https://github.com/esphome/esphome
       ref: d48058e140c98f5c2d902661d851a6b712d62434
     components: [sendspin]
-  - source:
-      # https://github.com/esphome/esphome/pull/14013
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: 51dcce3d1f22865ebb458a5447bbc877ac946b5a
-    components: [mdns]
   - source:
       # https://github.com/esphome/esphome/pull/12429
       type: git


### PR DESCRIPTION
## Summary

Remove the pinned mdns external component (from esphome/esphome#14013). The sendspin mDNS support was merged into ESPHome 2026.3.0, so the pin is no longer needed.

## Problem

The pinned mdns component at commit `51dcce3d` contains old C++ code:

```cpp
const std::string &friendly_name = App.get_friendly_name();
```

Since ESPHome 2026.3.0 (esphome/esphome#14532), `App.get_friendly_name()` returns `const StringRef &` instead of `const std::string &`. When the old code binds this to `const std::string &`, the compiler creates a **temporary** `std::string` (via `StringRef::operator std::string()`). The temporary's lifetime extends only to the end of `compile_records_()`, but the pointer from `.c_str()` is stored in the mDNS TXT record and read later by `register_esp32()` — **after the temporary has been destroyed**.

This dangling pointer causes the `friendly_name` mDNS TXT record to contain garbage data, which makes Home Assistant display garbled device names in discovery (e.g. `R�?���?d�����?���?` instead of the actual friendly name).

## Note

This PR is completely untested as it's close to midnight, I'm I'm too tired to hook up a vocie PE. The analysis is based on code inspection of the lifetime issue.

## Test plan

- [ ] Flash a Voice PE with this change on ESPHome 2026.3.0
- [ ] Verify `friendly_name` TXT record in mDNS is correct (not garbled)
- [ ] Verify device appears correctly in Home Assistant discovery