### PR TITLE
Add second mic to voice assistant with audio not passed through AGC

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1788,8 +1788,10 @@ select:
 voice_assistant:
   id: va
   microphone:
-    microphone: i2s_mics
-    channels: 0
+    - microphone: i2s_mics
+      channels: 0
+    - microphone: i2s_mics
+      channels: 1
   media_player: external_media_player
   micro_wake_word: mww
   use_wake_word: false


### PR DESCRIPTION
This will allow future HA releases to choose the microphone stream that works best with a particular STT engine.