### PR TITLE
Remove the second microphone channel from being sent to HA

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1790,8 +1790,6 @@ voice_assistant:
   microphone:
     - microphone: i2s_mics
       channels: 0
-    - microphone: i2s_mics
-      channels: 1
   media_player: external_media_player
   micro_wake_word: mww
   use_wake_word: false


### PR DESCRIPTION
Workaround for a bug where the `voice_assistant` component in 2026.5.0 can send an audio packet with zero length, which makes HA assume mic audio is done. This could potentially truncate commands. 

The proper fix is https://github.com/esphome/esphome/pull/16634