### PR TITLE
Bump min ESPHome version to 2026.6.0

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -38,7 +38,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2026.5.0
+  min_version: 2026.6.0
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
This fixes a bug with the two microphone channels on the VA where commands could potentially get truncated.

Closes #600