### PR TITLE
Fix update-latest workflow skip and add manual dispatch

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -3,13 +3,26 @@ name: Update latest build
 on:
   release:
     types: [edited]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish as latest (e.g. 26.6.0)"
+        required: true
+        type: string
 
 jobs:
   update-latest:
     name: Update latest build version
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ !contains(github.event.release.tag_name, 'beta') && github.event.changes.make_latest && github.event.changes.make_latest.to == 'true' }}
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+          || (!contains(github.event.release.tag_name, 'beta')
+              && github.event.changes.make_latest
+              && (github.event.changes.make_latest.to == true
+                  || github.event.changes.make_latest.to == 'true')) }}
+    env:
+      VERSION: ${{ github.event.release.tag_name || inputs.version }}
     strategy:
       matrix:
         device:
@@ -17,12 +30,11 @@ jobs:
           - ha-voice-8mb
     steps:
       - name: Download version manifest from R2
-        run: curl -o manifest.json https://firmware.esphome.io/home-assistant-voice-pe/${{ matrix.device }}/${{ github.event.release.tag_name }}/manifest.json
+        run: curl -o manifest.json "https://firmware.esphome.io/home-assistant-voice-pe/${{ matrix.device }}/${VERSION}/manifest.json"
       - name: Update paths
         run: |
           mkdir output
-          version="${{ github.event.release.tag_name }}"
-          jq --arg version "$version" \
+          jq --arg version "$VERSION" \
               '.builds[].ota.path |= $version + "/" + . | (.builds[].parts // [])[].path |= $version + "/" + .' \
               manifest.json > output/manifest.json
       - name: Upload updated manifest to R2


### PR DESCRIPTION
The `Update latest build` workflow has silently skipped its job since the 26.5.0 release (last successful run was 26.4.0). The job's guard compares `github.event.changes.make_latest.to` against the string `'true'`, but GitHub Actions expression evaluation coerces a boolean operand to a number (`true` → `1`) and an unparseable string to `NaN`, so `true == 'true'` is always false. The job runs only while GitHub delivers that field as the literal string `"true"`; once the value is delivered as a boolean (or otherwise stops matching), the job skips even though the release was correctly toggled to latest.

This accepts both the boolean and string forms of `make_latest.to`, adds a `workflow_dispatch` trigger with a required `version` input so the manifest can be republished on demand (e.g. to recover 26.6.0), and routes the version through a job-level `VERSION` env. The steps now reference the `$VERSION` shell variable instead of inlining `github.event.release.tag_name`, which also removes a latent script-injection vector in the `run` lines.