### PR TITLE
Add optional Child lock switch for the center button

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -227,6 +227,17 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
+  # Child lock. When on, a simple press of the center button will not start a
+  # voice assistant session (it still silences a ringing timer and stops/pauses
+  # the assistant, announcements and media). The wake word is unaffected. Useful
+  # to prevent accidental or child button presses from starting the assistant.
+  - platform: template
+    id: child_lock
+    name: Child lock
+    icon: "mdi:account-lock"
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
   # Internal switch to track when a timer is ringing on the device.
   - platform: template
     id: timer_ringing
@@ -342,6 +353,7 @@ binary_sensor:
                                             condition:
                                               and:
                                                 - switch.is_off: master_mute_switch
+                                                - switch.is_off: child_lock
                                                 - not: voice_assistant.is_running
                                             then:
                                               - script.execute:


### PR DESCRIPTION
## What

Adds an optional **Child lock** config switch (`switch`, template, default off, state restored). When enabled, a **simple press of the center button no longer starts a voice assistant session** — everything else the button does still works, and the wake word is unaffected.

## Why

The center button is easy to press by accident, and in households with young children a press opens the microphone and starts a session. This gives users a way to disable that one behavior without muting the device or losing wake-word control.

## Behavior

The simple-click already walks an "abort in order, else start" chain: silence a ringing timer → stop a running assistant → stop an announcement → pause media → **otherwise start the assistant**. Child lock gates only that final start step:

| Child lock off (default) | Child lock on |
|---|---|
| Unchanged — full chain, starts the assistant when idle | Same abort steps, but the assistant is **not** started (no press sound, no session) |

The wake word path, double/triple/long-press events, and factory-reset gestures are all untouched.

## Changes

Two small additions to `home-assistant-voice.yaml`:

1. A `child_lock` template switch alongside the existing `Mute` / `Wake sound` config switches.
2. One condition — `switch.is_off: child_lock` — added to the `and:` that guards the center button's start branch (next to the existing `master_mute_switch` and `voice_assistant.is_running` checks).

Default is off, so existing devices behave exactly as before unless a user opts in.

## Testing

`esphome config` passes; validated on ESPHome 2026.6.x with the switch exposed and a single `center_button` definition. Verified on hardware that with the switch on, a button press silences timers / stops playback but does not start a session, while the wake word still triggers normally.