### PR TITLE
Made sendspin static delay adjustable

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1590,6 +1590,7 @@ speaker:
 sendspin:
   id: sendspin_hub
   task_stack_in_psram: false
+  static_delay_adjustable: true
 
 audio_file:
   - id: center_button_press_sound

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1590,7 +1590,6 @@ speaker:
 sendspin:
   id: sendspin_hub
   task_stack_in_psram: false
-  static_delay_adjustable: true
 
 audio_file:
   - id: center_button_press_sound
@@ -1638,6 +1637,7 @@ media_source:
   - platform: sendspin
     id: sendspin_media_source
     fixed_delay: 480 microseconds  # The AIC3204 DAC used, as configured, on the VPE delays audio by 480 microseconds
+    static_delay_adjustable: true
 
 media_player:
   - platform: sendspin


### PR DESCRIPTION
In order to allow users to adjust the static delay caused by downstream devices (or for other reasons) from e.g. Music Assistant the setting "static_delay_adjustable" must be enabled.
Does not cause any incompatibilities with existing deployments and should really be true in the case of the voice PE.