### PR TITLE
Use DMA for the LED ring so it stops flickering during playback

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -589,6 +589,10 @@ light:
     num_leds: 12
     rgb_order: GRB
     rmt_symbols: 192
+    # Without DMA the RMT peripheral is refilled from an interrupt, and WS2812 is
+    # a bit-timing protocol: under audio load a late refill corrupts the stream
+    # from that point down the chain, so the ring flickers during playback.
+    use_dma: true
     default_transition_length: 0ms
     power_supply: led_power
 


### PR DESCRIPTION
Fixes #628.

`esp32_rmt_led_strip` without `use_dma` refills the RMT peripheral from an interrupt. WS2812 is a bit-**timing** protocol, so when the S3 is simultaneously running I2S, its DMA and the mixer, a late refill violates the timing and the strip latches corrupted data from that point down the chain.

The visible result is the LED ring flickering while audio plays. It is most obvious at the bottom of the dial, where a single lit pixel is the only corruption that *can* be seen — the unlit ones flicker black.

`rmt_symbols` is already 192, which is this component's ESP32-S3 default, and raising it further does not resolve it. `use_dma` is accepted only on the ESP32-S3 and P4, and this board is an S3, so the option is safe here.

### How it was found

Worth recording, because the obvious instrument is the wrong one. `control_leds` only runs on an event, and it was the only thing being logged. The effects re-render every 16–50 ms and read their inputs directly, so a steady-state flicker is invisible to that instrument. A probe logging all seven inputs the effects read — volume, `is_muted()`, ring state and brightness, mic mute, the light's own on/brightness, and the active effect name — produced **zero output over 74 seconds** while the ring was visibly flashing. Nothing in software was moving, which is what pointed at the signal rather than the state.

Six software explanations were wrong before that.

### Testing

Running on my own device since 2026-08-31, with no RMT or DMA init errors at boot.

No flicker since, in either situation where it used to appear: during ordinary playback, and while physically turning the dial through the bottom of its range. The dial case had looked like it might be something separate, but it only ever occurred under the same condition — audio playing — and it went away with this change, which is what you would expect if a late RMT refill is the single cause.

One data point in the other direction, and it is the useful one: the device was later reflashed from a branch predating this option, and the flicker came straight back until `use_dma` was restored. The symptom moved both ways with the setting.

---

Generated with [Claude Code](https://claude.com/claude-code)
